### PR TITLE
Update tutorials to work easily with Google colab

### DIFF
--- a/00_getting_started.ipynb
+++ b/00_getting_started.ipynb
@@ -1,448 +1,540 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "1dfd7ec3",
-   "metadata": {},
-   "source": [
-    "# Getting started with Bifrost\n",
-    "\n",
-    "Once Bifrost is installed you can load the Python API with:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "proud-container",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import bifrost"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "rental-equipment",
-   "metadata": {},
-   "source": [
-    "This loads the core parts of Bifrost and several useful functions.  The main way of interacting with Bifrost is through the `bifrost.ndarray`, a sub-class of `numpy.ndarray`.  You can create an empty array with:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "subject-quebec",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) system\n",
-      "[[1.9045215e+31 1.6631021e+22 2.7229835e+20 ... 0.0000000e+00\n",
-      "  0.0000000e+00 0.0000000e+00]\n",
-      " [0.0000000e+00 0.0000000e+00 0.0000000e+00 ... 4.5557614e-41\n",
-      "  1.4012985e-45 0.0000000e+00]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "data = bifrost.ndarray(shape=(2,4096), dtype='f32', space='system')\n",
-    "print(type(data), data.dtype, data.shape, data.bf.space)\n",
-    "print(data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eleven-omaha",
-   "metadata": {},
-   "source": [
-    "Note that bifrost defines datatypes differently to numpy:\n",
-    "```\n",
-    "f32: 32-bit float (equivalent to numpy float32)\n",
-    "cf32: complex 32-bit data (equivalent to numpy complex64)\n",
-    "i[8,16,32]: signed integer datatypes of 8, 16 and 32-bit width\n",
-    "u[8,16,32]: unsigned integer datatypes of 8, 16 and 32-bit width\n",
-    "ci[4,8,16,32]: complex 4-bit per sample, 8-bit, 16-bit and 32-bit datatypes\n",
-    "```\n",
-    "\n",
-    "The `ci4`, `ci8` and `ci16` datatypes do not have an equivalent numpy type, but are commonly encountered in radio astronomy.\n",
-    "\n",
-    "You can also use the `bifrost.ndarray` to wrap existing numpy arrays:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "lightweight-madrid",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'bifrost.ndarray.ndarray'> float64 (2, 4096) system\n",
-      "r: [[ 0.13445404  0.3175441   0.53332765 ...  1.18956152 -1.15990205\n",
-      "  -0.64751085]\n",
-      " [ 0.45399238 -0.42930972  0.47645107 ...  2.00526937  2.27132679\n",
-      "   0.78468687]]\n",
-      "data: [[ 0.13445404  0.3175441   0.53332765 ...  1.18956152 -1.15990205\n",
-      "  -0.64751085]\n",
-      " [ 0.45399238 -0.42930972  0.47645107 ...  2.00526937  2.27132679\n",
-      "   0.78468687]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "import numpy\n",
-    "r = numpy.random.randn(2, 4096)\n",
-    "data = bifrost.ndarray(r)\n",
-    "print(type(data), data.dtype, data.shape, data.bf.space)\n",
-    "print('r:', r)\n",
-    "print('data:', data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "earlier-latino",
-   "metadata": {},
-   "source": [
-    "Since `bifrost.ndarray`s are derived from numpy arrays they can do many (but not all) of the same things:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "regional-darkness",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "data += 2.0: [[2.13445404 2.3175441  2.53332765 ... 3.18956152 0.84009795 1.35248915]\n",
-      " [2.45399238 1.57069028 2.47645107 ... 4.00526937 4.27132679 2.78468687]]\n",
-      "data[0,:] = 55: [[55.         55.         55.         ... 55.         55.\n",
-      "  55.        ]\n",
-      " [ 2.45399238  1.57069028  2.47645107 ...  4.00526937  4.27132679\n",
-      "   2.78468687]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "data += 2.0\n",
-    "print('data += 2.0:', data)\n",
-    "data[0,:] = 55\n",
-    "print('data[0,:] = 55:', data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "artificial-spider",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "data[:,[1,3,5,7]] = 10: [[55.         55.         55.         ... 55.         55.\n",
-      "  55.        ]\n",
-      " [ 2.45399238  1.57069028  2.47645107 ...  4.00526937  4.27132679\n",
-      "   2.78468687]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "data[:,[1,3,5,7]] = 10\n",
-    "print('data[:,[1,3,5,7]] = 10:', data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "thirty-stretch",
-   "metadata": {},
-   "source": [
-    "You can also use `bifrost.ndarray`s with [numba](https://numba.pydata.org/):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "smaller-organizer",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'bifrost.ndarray.ndarray'> [[65.         65.         65.         ... 65.         65.\n",
-      "  65.        ]\n",
-      " [12.45399238 11.57069028 12.47645107 ... 14.00526937 14.27132679\n",
-      "  12.78468687]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "from numba import jit\n",
-    "\n",
-    "@jit(nopython=True)\n",
-    "def compute(x):\n",
-    "    for i in range(len(x)):\n",
-    "        x[i] = x[i] + 10\n",
-    "\n",
-    "compute(data)\n",
-    "print(type(data), data)\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "informative-brush",
-   "metadata": {},
-   "source": [
-    "### Arrays on the CPU and GPU"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "acute-efficiency",
-   "metadata": {},
-   "source": [
-    "Unlike numpy arrays `bifrost.ndarray` are \"space aware\", meaning that they can exist in different memory spaces.  What we have created so far is in system memory.  `bifrost.ndarray`s can also exist in \"cuda_host\" (pinned) memory and \"cuda\" (GPU) memory:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "changing-enhancement",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) cuda_host\n",
-      "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) cuda\n"
-     ]
-    }
-   ],
-   "source": [
-    "data2 = bifrost.ndarray(shape=(2,4096), dtype='f32', space='cuda_host')\n",
-    "data3 = bifrost.ndarray(shape=(2,4096), dtype='f32', space='cuda')\n",
-    "print(type(data2), data2.dtype, data2.shape, data2.bf.space)\n",
-    "print(type(data3), data3.dtype, data3.shape, data3.bf.space)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "million-guess",
-   "metadata": {},
-   "source": [
-    "To move between the different spaces the `bifrost.ndarray` class provides a `copy` method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "talented-lending",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'bifrost.ndarray.ndarray'> float64 (2, 4096) cuda\n"
-     ]
-    }
-   ],
-   "source": [
-    "data4 = data.copy(space='cuda')\n",
-    "print(type(data4), data4.dtype, data4.shape, data4.bf.space)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "stable-instrumentation",
-   "metadata": {},
-   "source": [
-    "Once on the GPU you can take advantage of Bifrost's GPU-based functions, like `bifrost.map`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "prospective-financing",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "data4/data = data*10/data = 10: [[10. 10. 10. ... 10. 10. 10.]\n",
-      " [10. 10. 10. ... 10. 10. 10.]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "bifrost.map(\"a(i,j) *= 10\",\n",
-    "            {'a': data4},\n",
-    "            axis_names=('i', 'j'),\n",
-    "            shape=data4.shape)\n",
-    "data4 = data4.copy(space='system')\n",
-    "print('data4/data = data*10/data = 10:', data4/data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "amateur-bridges",
-   "metadata": {},
-   "source": [
-    "The `bifrost.map` call here compiles and runs a CUDA kernel that does an element-wise multiplication by ten.  In order to view the results of this kernel call we need to copy the memory back to the \"system\" memory space.  In the future we hope to support a \"cuda_managed\" space to make this easier."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "vocational-archives",
-   "metadata": {},
-   "source": [
-    "`bifrost.map` is an example of a function that does not require any additional setup to run. This code is converted into a CUDA kernel at runtime, using [NVRTC](https://docs.nvidia.com/cuda/nvrtc/index.html). \n",
-    "\n",
-    "For some Bifrost functions, like `bifrost.fft.Fft`, some setup is required so that the function knows how to run. To show the use of the Bifrost FFT, let us first make some example data on the GPU, using `bf.map`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "restricted-carrier",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.legend.Legend at 0x7eff6b0ecc50>"
+      "cell_type": "markdown",
+      "id": "1dfd7ec3",
+      "metadata": {
+        "id": "1dfd7ec3"
+      },
+      "source": [
+        "# Getting started with Bifrost\n",
+        "\n",
+        "Once Bifrost is installed you can load the Python API with:"
       ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEGCAYAAABLgMOSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9eXgc1Zno/Tutbqm7tS/d2rxI8oI3sA0OW2zABsKSAFnIQpIZyIUhuZN8M8ncm0lyM5NMcpMvmXsny0eGmYSELJOQDUISSBh2DDa7AWNsbLxIsiVbUrf2pVtSL+f7o7raLamX6u6qrpKnf8+jR3JVddUpd9V53/OuQkpJkSJFihQpki02swdQpEiRIkUWJ0UBUqRIkSJFcqIoQIoUKVKkSE4UBUiRIkWKFMmJogApUqRIkSI5YTd7AIWkoaFBtrW1mT2MIkWKFFlUvPLKK4NSSs/87f+lBEhbWxt79uwxexhFihQpsqgQQhxPtr1owipSpEiRIjlRFCBFihQpUiQnigKkSJEiRYrkRFGAFClSpEiRnCgKkCJFihQpkhOmChAhxI+FED4hxP4U+4UQ4g4hxFEhxD4hxLkJ+24WQhyJ/dxcuFEXKVKkSBEwfwXyU+DqNPuvAVbFfm4H/h1ACFEHfBm4ADgf+LIQotbQkRYpUqRIkTmYmgcipXxGCNGW5pAbgP+QSs35F4QQNUKIZuAy4DEp5TCAEOIxFEH0KyPGece9f8vEpJ+1pRfSV3sRM/YqIy5jGcJylmPBp7FRwgrXpdhEidlDMpxQNMjR4E7KbJW0OS8qyD0LGaF5Yj/eqUOUhSeZKm2gp/o8xpxLDL82wHR0gmPBZ6goaWBZ2fkIIQpyXTMJREboDO6m1rGU1rJNZg/HcGqCJ3CO7eK18Gt89p3fx9vYquv5rZ5I2Ar0JPy7N7Yt1fYFCCFuR1m9sGzZspwG8fLws+x1zrBl4mX+9fBXuD96Gd8J38gIZ6IgieJcejf28mMA7Ox9mumTHwXO4MlFhHAt/z4lzpMAPD76LDP97zPwgpL32Z7hb+33s1T4F+zdHd3AN8M3cUC2GzcEWwB3279hKx0EYHbwMmYH0xkDFj/CPo5r+fewOSYAmBl4F6GRrSaPyhjOEcf4gv2XeMuO8JfNjQSFjat7X+DyRn2fa6sLkLyRUt4F3AWwZcuWnLpn/fzje/j9od/wpRe/xh/WX8pfHHqav6h+A977Q+i4VNfxms09B+/hmy8d4x8v/EcmZif47qvf5V//SvDOjneaPTTD+N5r3+OufSf5zmXfYZ9/Hz858BN+fONtXNx6sf4XCwzD7z8BRx6BlnPhom9C2zZw1cLocTj4IFtf+Hf+FPgS7PgibP07MGBl8NXnv8r9R0b4/pU/5KHOh/gDf+D+Wz7B+vr1ul/LKnzmqc+w+2SIH131C378xo95xvYwD/73T7KksjArvoIQjcKub8FTX0eWN/CxZeciI5P8/tpfsqxGf4XEbB9IJk4CSxP+vSS2LdV2w3j3WR/g/Kbz+aEcJnTbY+CsgV+8D/bfb+RlC0ooGuIn+3/ClsYtvH/1+/nYho+xqnYVP9j3A87UzpWBUIBfHvwl71j+Dq5YfgWf2vwpWspbuOuNu/S/2MQA/ORa6HwKrv0X+Ksn4ewbobIR7KXQsAq2/R186iVY/2544qvw4N8qk4KODAYH+f3R33Pj6hu5sPlCPvu2z1JVVsXdb9yt63WsRNdYF4+feJxbNtzCRs9GvnjhF7Fh4+79Z9A9RyPwx0/CU1+Ds29k74d+yivT/Xzq3L8xRHiA9QXIA8BfxqKxLgTGpJR9wCPAO4QQtTHn+Tti2wxDCMHN629maHqIZ8LDcOujsORt8Lvb4PCjRl66YOzs2clAYICb19+MEAKbsHHL+lvoGuviNd9rZg/PEP7U+ScmQ5P8xbq/AKC0pJSb1tzEKwOvcHTkqH4XCo7Az94Foyfgo/fD+X+VemXhqoX33Q3b/ie8+jN45AugowD/3eHfEY6G+ejajwJQWVrJe1a+hydPPIkv4NPtOlbi14d+TamtlA+d9SEAvG4v7+x4Jw91PkQgFDB5dDogJfzp0/D6L+GyL8B7f8ivuh6g0lHJDStuMOyyZofx/gp4HjhLCNErhLhVCPEJIcQnYoc8BHQCR4EfAn8NEHOe/2/g5djPV1WHupFc3HIxHpeHB489CK4a+Mi90LQB7r0Z+t8w+vKG82j3o9Q569jWui2+7YplV+Cyu3iw80ETR2YcD3c/TEd1Bxs9G+Pb3rXiXQgEjx7XSTGIhODeW2C4Cz7yW2jflvEjCAGX/yNc+El48fvKj0483P0w5zWeR1t1W3zbe1e9l4iM8Pjxx3W7jlWIyiiPH3+cS5ZcQr2rPr79uhXXEQgHeLLnSRNHpxMv/Du8+h+K0nHZ55mOzLCzZyfXtF+D2+E27LKmChAp5U1SymYppUNKuURKebeU8vtSyu/H9ksp5SellCuklGdLKfckfPbHUsqVsZ+fFGK8dpudHct28Nyp55iNzEJZBXz4Xiirgns/BjOThRiGIcxEZnim9xl2LNtBie10BJLb4WZb6zae6XnmjDNjjc2M8erAq1y+7PI5EUgNrgbObTyXx44/ps+Fdn4DOnfCdd+Ftiydtu/4Gpz1Tnj0H+HkK3kPpWe8h6OjR7l82eVztrdXt9NR3XFmTKbz2Offhy/o44rlV8zZfl7jeTS4Gni652mTRqYT3c/Co/8Aa94F278IwIt9LxIMBxd8z3pjdROW5bhkySUEw0H29MdkWWUjvO+HMHQUHv6cuYPLgz39ewiEA+xYumPBvq2tW/EFfRweOWzCyIzjmd5niMgI25duX7Bvx9IdHB09St9kX34XOfEi7P4ObPoobP5o9p+32eDdd0Jlk6KkzE7lNZynep4CSHrP25duZ0//HiZmJ/K6htV4pvcZ7MLOJUsumbPdJmxc3HIxz/c9TyQaMWl0eTIzCX/4BNS2wXu+rzwvKN9zhaOCtzW9zdDLFwVIlpzfdD6ltlKeO/Xc6Y3tl8DWT8Nrv4CuZ8wbXB683P8ydmHnvMbzFux7e+vbAdh9cnehh2UoL/W/RHVZNesbFkYeXdB8QfyYnAkFlZe7eglc/Y3cz+OqhffepURpPfX/5n4elO+5raotaeTRRS0XEZGRM87f9XL/y6xrWEdlaeWCfVtbtzI2M8b+oaTFMKzP41+G0R54979B2en7e6n/Jc5vOh9HicPQyxcFSJY47U42NGxY+JJd+jlFC/jTZyA8Y8rY8mHPwB7WN6xPai/1ur2srFnJnoEzqxnXqwOvstm7GZtY+Bqsql1FTVlNfgLkue/BcCdc/z1w5pkztPxiOPdmeOHf4NTenE4RlVFe9b2aVEkAOMdzDnabnVcG8jeVWYVgOMj+of1sadySdP+FzRcCnLYoLCZ6X4GXfwQX/ndYdmF8sy/go2eih3Mbz03zYX0oCpAcOLfxXN4cepNgOHh6o8MF7/y2Ysp6/k7zBpcDgVCAA4MHUr5kABs9G3nd/zpRqW9IqVn4A35OTJxIec82YWNL45bcJ5bRHtj1bVh3A3RclvM453DlV8BdDw9/PqeorKOjRxmfHU85sbjsLs5uOPuMUhRe979OOBpO+T3XOmtpq2pjrz83oWwaUirReRWNsP1/zdn16sCrAGnfZ70oCpAc2OzdTFiG2T84b9m78nJYfQ3s/q6SMLZIeGPwDcIynFIzBUWATMxO0D3WXbiBGcgrPkXLPtebWkvb5N3EqalTDAYHs7/A4/+k/H7H13IYXQpctUqI5onn4a3/zPrj6soi3fd8XuN5vDn4JtPh6ZyHaSVeHXgVm7Cx2bs55THneM7hdd/riytI5MD90PMi7PiHOaYrUL5nt93NWXVnGT6MogDJATXkM6mt+PIvweyEkg26SDgwdABQXqRUbPIqdYMWnaaWgn3+fZSVlLGmfk3KY9Ss7AODB7I7+cAB2P87xbRQk1v5nJSc+5dQv0qxfUfCWX30Df8beFweWspbUh6zoWEDYRnmrZG38h2pJTgwdICO6g4qSitSHrPJu4mRmRF6JnpSHmMpIiF4/CvQeDZs+siC3fsG93G252zsNuMLjRQFSA5Ul1WztHIph4YPLdzZuA423gQv/RDGTxV+cDnw5tCbtFa0Ul1WnfKYtqo2qkqr2OffV8CRGceh4UOsrl2Nw5baybiufh02YYsLWM3s/CaUVsDF/0+eo0xCiQOu+DIMHoY3fpvVRw8OH2Rt/dq0RRNVofnm0Jt5DdMqHBw6yLr6dWmPOadBUZxe979eiCHlz77fKAEVO/4BbHOLfoaiIY6MHGFdXfp71ouiAMmRNXVrODh0MPnOSz8H0fCi8YUcHDrI2rq1aY8RQrCmbs0ZEcorpeTQ8CHW1KVefYCSA9NR3bHQVJmOvn1w8AFl9eGuy3OkKVjzLmjcoIQHayxzMh2epmusK+M9N7obqXPWnRECxB/w4w/6Mz7bHTUdOGyOxfFsR8KKdaPpHFh91YLdnaOdhKKhjN+zXhQFSI6srVtL72Rv8pj52uVKjaM9P7G8L2RidoITEydYW5/+JQNYXbuaIyNHFm/MfIyTkyeZmJ3Q9JKtq1/HgaED2u3ju7+tJJZe9Nd5jjINQsDWzyirkEN/0vSRIyNHiMiIJkVhbf3aM0KAHBxWFLxMz7bD5mBlzUreGl4EZrsD9yuRfZf+fdJSOOo9pzPN6klRgOSI6qBK+dC9/dMQmoKXDCjKpyOqGS7TxALKqms6Ms3xieNGD8tQsrnntXVrGZ4eZmh6KPOJR47Dm3+ELR9THN5Gsv49UNehaKMahJvWyRRgXd06jo0eYyay+MLRE3lz6E0EQpOicFbdWbw18pa1HelSKpF93nVKdYIkHBo+hMvuYnnl8oIMqShAckSdfJL6QUDxhay+RqlhNGvdYm2qGU7LxKIKzcPDi2Cpn4aDwwcpESWsql2V8diVtSsBJQQ2Iy/dBQg4//Y8R6gBWwm8/W+hby9078p4+KHhQ1SVVqV1oKucVXcWERmha6xLj5GaxsGhgyyvWk65ozzjsWvq1jA8PZxbxF2h6Hoa/AcV35ot+dR9cOggq2tXzylHZCRFAZIjHreHOmdd+miViz6pVGHd/7vCDSxLjo0do85ZR4OrIeOxHdUd2IU9tdBcJBwePkxbVRtOuzPjsStrFAFybPRY+gOnx+GVnykrg+oC9Zc454PKSuelH2Y89K2Rtzir7ixNXQdXVK8ANApNC3Ns7JgmJQEU8yxg7eizF38A7gZY/96ku6WUHBk5UjD/BxQFSF6sqFlB51hn6gPatoJnLbz8Q13LcetJ52gn7dXaegWUlpTSXtO+OJyNaegc62RFzQpNx9Y766kpq+HIyJH0B772cyV8+6JP6jBCjThcSljvoT/DWOp2OFJKuka76Kju0HTa5VXLsQt7ZqFpYWYjs/RM9Gh+tuOra6s+28NdSu7Plo+BI7ni4w/6mQhNaH629aAoQPKgo7qDrtGu1HZTIeD826Dvdei1XnavlJLOsU7NEwvE7nkRmzZmIjP0TvZqnliEEKysWZleG5dSCZhYcj60Gl8+Yg5bbgUZhVdSF6Qemh5iIjSh+Z4dJQ6WVy1f1ALk+PhxojIaX01loqq0igZXg3Wf7Zd/pJgtt/y3lIeoY9f6PetBUYDkQXt1OxOhifQO1nM+CKWVyirEYgxNDzE+O56VAGmvbufU1KlF62A9MX6CqIxmdc8ra1ZybPRYakXh+HMwdATOu1mnUWZB7XI46xp45acpa7B1jiqr5KwUhZqORS1Ajo0pY++oye7ZtqQACQWVFe7a66EqtQ9LtYZk8z3nS1GA5IH6RakvaFLKKmHTTXDg95YL6VVflqxesqp2ojLKifETRg3LUOIvWRb3vKp2FZOhSQYCA8kPePVnSuju+vfoMcTsedutMOVPWd5EvedsNNOVNSvpmehZtCVNuka7EAjaqto0f6a9ShEglovEOvRnmB6D825Je1jXWBfljnI8Lk9hxoX5HQmvFkK8JYQ4KoT4fJL93xFC7I39HBZCjCbsiyTse6CwI1dQX8i0fhCAzX8BkVnLOdNVDTPbFQhgTU1NA11jysSyvEp7mKM6CSW95+CIErp79o1QmjnaxxA6tkNVK+y9J+ludWJpdDdqP2VNBxK5aL/nzrFOWipaNAVKqLRXtzM+O87IzIiBI8uB136ulMRpS9/JUjVHawmU0AvTBIgQogS4E7gGWAfcJISYk38vpfyMlHKTlHIT8D3g/oTdQXWflPL6gg08gUZ3I+WO8swCpPkcpW5NihfcLDrHOrOeWNSJd7FPLC67S/Nn1HtOuurady+Ep5VS62ZhK4GNH4Kjj8P4wgZYnWOdtFe1ZzWxtFcpisLx8cWZ83Ns7FjWzmS1xa+lnu3RE9D5tFLzKkXorkrXWFdB/R9g7grkfOColLJTSjkL/BpI1/39JuBXBRmZRoQQtFe1ZxYgAJs+DKdeA1+K8icmkMvE4na4aS5vpmvcQi9ZFnSNdc3pBa4Fr9uLy+5KnkD52n9A80Zo2aTPAHNl44cVZ/q+Xy/Y1TmmPdJOZWnlUgBOTCw+U2UkGuH42PGsfQGWXF3vjU15mz6c9rDJ2Ul8Ad9/KQHSCiSWv+yNbVuAEGI50A4kNmx2CiH2CCFeEEK8O9VFhBC3x47b4/f79Rj3HNqr27WVOD/7/WCzw95f6j6GXDk+fjzryRQs7GzMQFRG6R7rznpiEUKwtHLpwhWI7xD0v6FM3mbTsBKWXgiv3TMnZHwqNJXTxOJ2uPG6vIvS19U31cdsdDYr/wdAc3kzZSVl1nm2o1HY+wul42mGqs7d491AYSOwYPE40T8E3CelTCzCtFxKuQX4MPBdIUTS9aqU8i4p5RYp5RaPR3/n0tKqpfgCvsxRSRUeWHWVUkkzyzLcRjAbmWVgaiCuaWZDW1Ub3WPd1nM2ZsAX8DEdmc6pzMPyquULzTlv/BaEDTYkT+wqOJs/okSDJYSM9070AmTl81FZWrV0Ua5A1LLs2T7bNmFjedXy+GRsOieeV0xYmz+a+dCYoM9WaOaLmQLkJJD4DS+JbUvGh5hnvpJSnoz97gR2Aqk7xhjI0sqlSCQnJ1IncsXZdBNMDiglCUymd7IXicxJgCyrWkYgHGB42lpRZZlQJ9Oc7rlyGb0TvYSjMeEvJbxxr9JtsMKr3yDzYd27oaQM9t8X36ROpsl6oGdiWeWyRbkC6Z3M73u2TF+Q/b8DhxvWJK97lYg65paKzKVq9MRMAfIysEoI0S6EKEUREguiqYQQa4Ba4PmEbbVCiLLY3w3A2wFTyoeqD6mmh27llUq454H7Mx9rMPlMpksqlMlIfVEXC/lMLMurlhOWYfomY07qnpcU7fDsD+g5xPxwVsGqK+HAHyBWMVn9nnMSIFXLGJoeYio0peswjaZnogeHzYHXnb1gX1K5hJMTJ81v3RwJw5t/gNVXa4ru653sxePyZBUcogemCRApZRj4FPAIcBD4rZTygBDiq0KIxKiqDwG/lnPtJWuBPUKI14GngG9KKa0vQBxOOOtaOPgghGcNHll68tFM1c+ok9NioWeiB5uw0VTRlPVnVRNQ3JH+xr1gd2rSDgvKhvfCZL+S3Ihyz9Vl1VSVVmV9qmWVit19sa1Ceid6aa1ozamg4NLKpcxGZ/EFfAaMLAu6nobAEGx4n6bDeyZ6clKM8sVUH4iU8iEp5Wop5Qop5ddj274kpXwg4Zh/klJ+ft7nnpNSni2l3Bj7fXehx65SW1ZLuaNc+7J3w3uVpKDOp4wdWAZ6J3px2V3UO+uz/mxrRWv8HIuJ3olemsub03YhTMWyKmUyPT5+XGkpeuB+JQPcmf3EbCirr1bMHrFVbu9kb3zFmC3qPS82P0jPRE9OihEkrK7Nfrb3369YK1Zeoenw3onenO85HxaLE92yqBE6mgVIx3Zw1igPiImoL1kuSUdOuxOvy2sdW7FG8plM6531uO1uZWLpeiamHd6o8wh1oLRcESJv/hEiYXonenPWTNUVyGL6nqWUeWnj8dW1mebZ8IxipVjzrpSFExOZiczgC/hyfrbzoShAdCArAWIvhbXvUsoThMwrE9Ez0cPSityXvEsqlyw+H0geWpoQgpaKFk5OnlRebke5Zu2w4Gx4HwSGCHc+yanJUznfs9vhpsHVsKiSCUdmRpgKTeUsQJormrEJm7lC8+gTMDOm2Xx1cvIkEllcgSxWllQu4eTkSe2tXte/Vyn9ffRxYweWgqiM5qWZQkyAmL3Mz4Kp0BTD08N5vWStFa2cmjypCP/V79CkHZrCyiugrIqBN35DWIbz0kyXVCjP9mIh1xBeFYfNQXN5s7nP9oHfK31eOi7VdHg+ATH5UhQgOrC0cimhaEi74639UnDVKWYGE/AFfMxGZ/MWIJryXyxCPtFIKi0VLZwa74EpH6y9Tq+h6Y/DCauvoue4Ei6ez/fcXNHMqclTeo3McPIVIKAITdNW15EQHH5EaVlbos1Xl09ATL4UBYgOZBWJBVBiVxywRx5RHpgCo4fGsqRiiZL/ski003xCeFVaK1qZiAQZs5fBqnfoNTRjWPNOeqNKK+V8V10DUwPaV9cmoz7baqBHLpi6uu7erZivsojuyycgJl+KAkQHWsuVh/XUVBaa2lnXKtFYx581aFSpUSfTfCYWdSJeLGas+AokD3NOa6yf+Kn2C5Uy/VZm5RX0OMqwI7IqljmflooWwjKMP6h/GSAj6J3oxevyZlWFdz5LKpcwPD1sTv7LoT8rUXQrtmv+iBq2XMgqvCpFAaIDjeXKCxpPMtPCih1gd8GhhwwaVWr6JvsQCJrKs8+HUFlsuSA9Ez1UllZSXVad8zlapicBONVqcuFELZRV0lvTTGtEUiJyf81bYkJzsaw0+6b68s7GNu3ZllIRICt2KO2KNdI7aU4ILxQFiC6UlpTicXnom8pCgJS6lQfl0J8L3i+9b6qPBlcDpSWlOZ+j3llPqa00u3s2kVOTp/IOc2zteQWA3ppmPYZkOH3OclpmgzBwIOdzqJPxYvGD9E310Vye3/ejWhQK/myfeg0mTinhuxqRUjEj52Oyy4eiANGJ5vLm7ExYAGuuhfFepWd6AdHjJRNC0FzRvGgESN9UX14rLoCqtx6hAsGpmdHMB1uAPjlLcziiKCk5oj4ni0GARGWU/qn+nCoNJNJcodxzwZ/tQ38GUQKrr9L8kfHZcYLhYN7vc64UBYhONFc0Z2fCAiXhS9jgrcKasfqn+uMvST40lTctGgHSP9Wf30s23IkYPExLWd2imExnI7MMTg/T5G6GQ3/K+TxOu5N6Z332ypEJDE8PE4qG8p5M65x1OGwOcwTI8ovBXaf5I+oYiwJkkdNS3kL/VH92RdjKG2DZRXlpiNkipdRlBQLKQ9s/2a/DqIxlYnaCydBkfvd8+FEAWmtWLooEyoEppX97c/O50L9PKfyYIy0VLYtCaKoKXL7Ptk3YaCpvKuyzPXQM/Aezrq3WP6WMsShAFjlN5U3MRmezL3F+1rUwsB9Gug0Z13yGp4eZiczkbc4B5aH1B/2ETAhFzgb1Jcvrno88AvWraK1bxanJU5bvhdIfiE0s7TuUDYcfyflci0WAqKskvZSjgq5A3vpP5fdZ12b1sfgKRAeLQi4UBYhOqM7GnMxYAEce03lEydFTY2kub0YiGQgM5H0uI1FfspwFyMykEp+/+iqay5sJhAOMzYzpOEL9iU8sLVugtj2v56ulvIW+qT7zS5xnIP5sL0bz7JFHwbMGarNr/NU31YfdZqfOqd3spSdFAaITcWdjtrbi+hVQ21awsibqS6FH4xnTnI1ZkrfQ7HoaIrOw6h1xIWR5oRlTZBrLG5Wkx65nIBTM6VwtFS2EoiEGg4N6DlF3+qb6KHeUU+nIP0cnvrqOFmB1PTOplN9fdWXWH+2f7KfJ3YQtj1DtfCgKEJ2IT6bZrkCEUF7wzqcLUlxRT6ebeg51grYqfVN92IWdBldDbic4/DCUVsKyi+ICZDHcc52zjrKSWNZ8OAjduSWtLpZQ3r5JxbenR0JdS0ULURnFHyhAAmXX0xAN5VTdoG+qzzTzFRQFiG5UlVZR4ajITRtXX/Dju/Uf2Dz6pvpw2V05NRiaj5rhvBhWII3ljTk1GEJKxfyzYjvYSxeNAJkTddb2diVp9cijOZ1LPY/Vv2c9QrVV1PMU5J6PPAalFbD0wqw/2h/IM7owT0wVIEKIq4UQbwkhjgohPp9k/y1CCL8QYm/s57aEfTcLIY7Efm4u7MiT01TelFu4Y9tWpbvdEePNWHpqaU67kzqn9cNa+6b6ci/n0b8PJvrivqp6Zz12Ybe+CSsx0s7hgvZLlECAHJz/cbPdlPXvWc2cz5eCCU1VQem4TGn1kAXhaBhfwKeb0MwF0wSIEKIEuBO4BlgH3CSEWJfk0N9IKTfFfn4U+2wd8GXgAuB84MtCiNoCDT0lLRUt2ZuwQHnB27blrCFmg14hvCrN5c2LQxvPdZkfC99V7dMlthI8bo+l71lKqSTUJU4sq65UIv2GjmV9vgpHBW6729JCMxAKMDozqps5p2ArTd9BJZk4B/+HP+AnKqP/ZVcg5wNHpZSdUspZ4NfADRo/exXwmJRyWEo5AjwGXG3QODWTUza6yqorYfhYTi94NuhtM22paLG0aSMSjTAwNZD7S3bkEWg5Fyq88U1N5U3xMFkrMj47TiAcmHvP6gSVg5IihKCxvNHSAkT9PvTSxl12F7VltbkphNlwNBYdtzJ7AZJ3dKEOmClAWoHE+ue9sW3zeZ8QYp8Q4j4hhFqLW+tnEULcLoTYI4TY4/cb6xBrKm9iYnaCQCiQ/YfV7nYGRmNNh6cZnh7WVWNRwx2tmhcxGBwkLMO53XNwBE6+sqDzYJO7ydIrkKThrLVt0HBWzqvcRnejpU1YatKfEc+2oRx5DLzroTr7WlZmZ6GD9Z3oDwJtUspzUFYZP8v2BFLKu6SUW6SUWzwej+4DTES1s2tuLJVI/QqoX2moGUvVIPU2YQXDQcZnx3U7p57kpZl2PQMyCisvn7O5sVyZTK0qNFNOLKuuVNoHzExmfc5Gd6OlV11GTKaGJxNOj0pdz3kAACAASURBVMOJ53MyX4FOCbJ5YqYAOQkkdvdZEtsWR0o5JKVUW979CDhP62fNQBUgOS/1V16pJKzlGK+fCSOWvFaPSsrrno89qYTvtp43Z7NadWBkZkSPIepOynteeYWSz5JDD5rG8kZlNRcN6zFE3emb6sMmbHjc+imJTeUGrzQ7d0I0nLMA6Zvqo6q0inJHub7jygIzBcjLwCohRLsQohT4EPBA4gFCiER14nrgYOzvR4B3CCFqY87zd8S2mYrXrdjJc1qBgKLphqcVrcQAVBNEk1s/AaLes1Xt4zmbNqRUBEj7JQtai6r/f1YWmg6bY2F28rKLlGi/Y09lfc6m8iaiMmrZZMKBwAANzgYcNm1tYLXgdXuZDE3mZpLWwrEnFAVl6QU5fTzvAqE6YJoAkVKGgU+hTPwHgd9KKQ8IIb4qhLg+dtjfCCEOCCFeB/4GuCX22WHgf6MIoZeBr8a2mUrek+nyi8HmyOkF14LaVU5PLS3vVZfBxLOTS7PMTh7uVAoQJukMpzYQs6pPoH+qn0Z348LsZIdTESKd2T9f6vdsVaHpD/h1fa6hAMrRsaegfZvm3ufz0TPvJVdM9YFIKR+SUq6WUq6QUn49tu1LUsoHYn9/QUq5Xkq5UUq5XUp5KOGzP5ZSroz9/MSse0jE7XBTWVqZ+8RSWq5oIzm84FrwBXxUllbm1e5zPvWuegQi91WXwfiD/txyQI49qfxesWPBrrjZzqI+AX/AH5/8FrBiO/gPwXh20YJWVxT8Qf0FSF4+zUwMd8HocSX/I0fSfs8FwupO9EVHozvPcMcVl0H/GzClv6nAH/Djden7wDlsDupd9ZYVIL6AL7eJ5dhTULMM6joW7Kpz1mG32a2rjQfTTCwdsRVV586szmn1ZEIjnm11pWnIs63+/3do732eSCgSYmRmRHehmS1FAaIzje7G/B64jpjGm+ULrgVfMMfJNANet9e6mmnAj8eV5T1HQtC9S1l9JMnYtwmbEpVkUQGSVmg2bgB3Q9Zm0qrSKpwlTkt+z7ORWUMmU0NNWJ1PQWULNKzK6eOqL0pvoZktRQGiM3knXLVsAme1IWaswcCgIUvevIWmQUgpczNtnHwFZsaTmq9U8l5pGsRUaIpgOJh6YrHZFLNJ586sypoIIWgqb7LkPccnU52fbZfdRWVppf7PdjSihIiv2J5UQdGCL6iMqbgCOcPwur0MBYdyLwNtK1Eif47tzKluUSqklMoKJFttXANet9eSAmRsZoxQNJS9lnbsSaXVcPslKQ8xPMQzR9TvIe3EsmI7TPlg4EBW57ZqMmH8ng14tg1Rjvr3KUmqHZflfAq1SnDRB3KG0ehuRCIZDOThw+jYrtTH0bGsyejMKOFo2BCNpdHdyNjMGNNh48vRZ0POWtqxJ5XcD1fq8mrqxGK1ZEJNE0vcD5LdKrex3JrJhGp0oRGTqdft1V9oqubD9ktzPoWRQjMbigJEZ3Sxm3ZcpvzW0YylPnBGvWSJ17AKOWlpwVHFhJXBuel1ewlFQ5brTBgXmukmlupWaFidtR+k0d2IP+AnEo3kM0TdUZ+7nPu9pMGQ1XXnTqV8SWWOFaJRhKZd2Kl1mltDtihAdEaXcMe6DiUCSMd8kHgOiEEmLLBeiGdOWppaviSN/wNOr2rUCdsqqEIz46qrY7vSBS+LJmaN7kYiMsLQ9FA+Q9Qdf8C4ydTr9jI4rWMGfigIJ17Iy3wFyrNd76o3rROhSlGA6IwuseNCKC949y6I6PPgap5YcsDQePk8yClxsnsXOMphyZa0h6lCsyAd67LAF/Dhtrszl7dYsV1pYtbzouZzq2GtVvP9+IN+GtwNhkymje5GojLKUFAnoXnieYjM5C1ABoPGBMRkS1GA6Ex1WTVlJWX5201XbFcigU69qsu4jLSZWtWE5Qv4qCqtUtq6aqV7Nyy7MGN2sPr/aLV7TpsDkkjbVrDZswoXjwvNoLWEphE5ICq6P9udO5VqE8svzus0voAxATHZUhQgOiOE0Mdu2n4pIHTLB/EH/dSU1VBakl3XMy1UlCoNh6w2mWatpU0Ngu9NZXLNQNyEZbF71lzSo6xS6XPSvUvzua266jIiC13FEAGy9Hwoq8jrNEbeczYUBYgB6JIj4K6Dpg2KTV4Hcs7I1ogVkwmzTiJUq9RqECBlJWXUlNVYTxsPZnHP7dvg5KswM6Hp8NqyWkpEieWEppHauK7+vakh6NuXc/a5ykxkhrGZsaIJ60xFt8m07RLoeSkrR2cqjFzmg2Ift9zEkm3mffducLihZbOmwz1uj6XuWUqZXX2ktm0gI3BcW/XnElsJ9a56SwnN6fA047Pjhk2matkaXb7n7mcACR25h+9Cgj+zaMI6M1En07xzBNq3KQ633pfzHpPRS16rZaNHZTT7zHuN/g8Vr8trKXPORGiC6ci09nDWpRdASWlsYtOGx+Wx1D0bUWE6EZuw4XXpFMrbvVsJ0NCooKTC6HvOhqIAMYBGdyOhaCj/hkPLL1YyorOwUydD7eNgpMbidSuTaVRGDbtGNoxMjxCWYe2T6dSQZv+HisftsVQYb9Z5L6VuWPI26NL+fHncHkutQOL3bODqWjeLQvezWSkoqSiuQM5w1Ekrb03NWQ3NG7N6wZMxPD1MREYMtZl63V7CMszwtOltWYAcspPj/o9tmq/hcXkYCg5ZJrEup0i7tm3Q97pSWkMDVlt1qQK8wa1/EqGKLkExk37wH8xKQUmFkZn32WKqABFCXC2EeEsIcVQI8fkk+/9OCPGmEGKfEOIJIcTyhH0RIcTe2M8D8z9rJuoXq0v3trZtiglrNveuaEbmgKhYLZkway0tS/8HKPcckZHFKzRBMZMilaRCDXjcHkZmRpiNzOYwQv0p5AokL5N0FgEamfAFfNhtdmrKavI+V76YJkCEECXAncA1wDrgJiHEunmHvQZskVKeA9wH/J+EfUEp5abYz/VYCHUFoovdtP0SiIaySviaj5FZ6CrxZMIpa5h0sp5Ms/R/JJ7bKmYsdTLNqqTHkrcpbW41rnJ1VY50wB/w47A5qC6rNuwaje5GguEgk6HJ3E9y/NmsFZRUqAExIsdKvnpi5grkfOColLJTSjkL/Bq4IfEAKeVTUkpV9X4BWFLgMeaEOlHr8pItuxBESV5+ECPrYKmo92wV+3hW9ZGmhsB3IGvt0Gp5Ef6gn0pHJW6HW/uH7GWKM13j82W1BEo1cdLIyVRduef1bOegoKTCF/QZarLLBjMFSCvQk/Dv3ti2VNwK/GfCv51CiD1CiBeEEO9O9SEhxO2x4/b4/YV50Z12p359BMoqofXcvPwg6gRX76rPfzwpUFvbWkWA+AN+astqtSVO5uD/AOtNpjnn+rRvg4H9iiDNgC6TqY7k1DAsS+LKUa6KghqgsfztuozH6JD8bLCbPQAtCCE+CmwBEgOol0spTwohOoAnhRBvSCkX1D+XUt4F3AWwZcuWgtXe9rq8+i3z27bBc3fAzGROGay+oI86Zx0OW/7aTyrsNqWYnVW08ay0tBT+j1AoRG9vL9PTyfNwpJR8d913qZyu5ODBg/kOOW/eU/UeRJXIOBan08mSJUtwOGLPQ1us70n3LlifUhcDdJhMdcYX9LGyZqWh11Cfo5yFZo4KSir8QT8XNF+gy7nyxUwBchJYmvDvJbFtcxBCXAF8EbhUSjmjbpdSnoz97hRC7AQ2A/o10MiTBneDfrbx9m2w+9tKFc9VV2T98aySy/LA69ZRaObJYGBQu5aWwrzQ29tLZWUlbW1tKU0kJcMlVJRW0FqRbvFcGA6PHMZtd7OkMrWlV0rJ0NAQvb29tLe3Kxtbz1XyEzQIkFpnLXZht9QK5OKW/OpKZUJ9jnLu8ZNDgEYqguEgE7MTlojAAnNNWC8Dq4QQ7UKIUuBDwJxoKiHEZuAHwPVSSl/C9lohRFns7wbg7cCbBRu5Brwub35NpRJZeqFSgC2LhK9EClV4rcHVYB1zjtYs9DT+j+npaerr69Pa1+02u36lvvNASkk4GsZuS68TCiGor6+fu6oqcSgCVIOZ1CZsinJkge85EAowGZo0/Nkud5TjsrtyVwi7dyt+Jnv+dejUOcUKOSBgogCRUoaBTwGPAAeB30opDwghviqEUKOq/i9QAdw7L1x3LbBHCPE68BTwTSmlpQRIg7sBf9CvT8e6UrdSXjxHP0ihSj97XB5LrEAi0QhDwSFtL1kG80Im56zD5rCEAInICFJKTWbKpPfUfgkMvgUTmcOwrZILUqh8CCGE8mznohDGFRR9/B9W6YWuYqoPREr5EPDQvG1fSvg7qb1GSvkccLaxo8sPr+t0x7oapw7x2m3bYNe/wPSYkmCokXA0zND0UEEeOI/bw9C0klhXYisx/HqpGJkZ0Z44mad5wW6zEwjnnqOjF6oQy7QCSUl7TIB274Kzb0x7qMft4fj48dyuoyNGdiKcT4OrITez3YlYfo1e/o8C5L1kQzET3SDydrzNp32b0ilPY+E7leHpYaIyWpAlr8flISqjpifWxTOytQhN1byQY3il3WYnEo0YVsKlpKSETZs2sWHDBq677jpGR0eTHqcKkGgoygc/+EFWrlzJBRdcQHd3t7YLNW2EsipN1Z89LmsUkcypZXGO5FzCpXs32F1K6XwdyOrZLgBFAWIQqoag21J/yflQUpZ1efdC1s2xSoin5nvOMf8jEdVkZJQZy+VysXfvXvbv309dXR133nln0uNC0RAAP//pz6mtreXo0aN85jOf4XOf+5y2C5XYldprGvJBPG4P47PjTIfzrxKdD4UsKphzEcnu3Ur/Dx38H6CYo0ttpVSVVulyvnwpChCD0D2xzuFUHsQsHemFSCJU0TWBMg8028Z1CK9UTUaF8INcdNFFnDypBCoeO3aMq6++mvPOO49t27bFQ3f/9OCfuPnmmwG48cYbeeKJJ7T74dq2wXAnjJ9Ke5hlvueAH2eJk0pHpeHX8rg9BMIBpkJT2j8UGIaBA7qZr+B0cIgVstBhkeSBLEZ0N2GBoinv/KZS+M5Vq+kjhdbSwPzEOs2Jk1n4P77y4AHePDW+YHtURpkOBymzj1AisvP7rGup4svXrdd0bCQS4YknnuDWW28F4Pbbb+f73/8+q1at4sUXX+R/fPp/8KP7f8Spk6dYulSJjrfb7VRXVzM0NERDgwY/gboS694N53wg5WGJrW3ThQwbTSEn08T8l/LqDP3mVY4/B0hd6l+pFCokXyvFFYhBuOwuKh2V+kartKmF77T7QXwBHzZho85Zp984UhCvQmyyCUtz4uTxZ/MOr1QnL2mQDyQYDLJp0yaampoYGBjgyiuvZHJykueee473v//9bNq0iY9//OP09/djL8lTH2w6WwnQyGDGsko730JkoavkZJ7t3q3UGWvVx/8B1umFrlJcgRiIGsqrG63nKQ9k925Yc62mj/iDfuqd9blH52SBo8RBbVmtfvkvOaJJSwsMK+U7dvyjpnOmWilIKTk4fJB6Zz2N5Y3ZDjUjqg8kEAhw1VVXceedd3LLLbdQU1PD3r1748d1jnZiEzZaW1vp6elhyZIlhMNhxsbGqK/XWMLGVqKU2+jenfYw3f17OeIP+llbt7Yg18opA/+46v8o020c/qCfra36rWjypbgCMRDd4+UdTqV6ahZ+EKN7oc9H1wz8HNGkpelUXkIIgV0Yn0zodru54447+Na3voXb7aa9vZ17770XUITY/n37cdgcXH/99fzsZz8D4L777mPHjh3ZmXjatip+kLEFRSHiVJdV47A5TP2epZQFfbazXl0HhqF/v67+j0BI8cEUImxZK0UBYiC6r0BAeSD79ysPqAYKXXhN1wz8HNHUvlfH8hJ2mz0eBWUkmzdv5pxzzuFXv/oV99xzD3fffTcbN25k/fr1PPrQo9htdm699VaGhoZYuXIl3/72t/nmN7+Z3UUS/SApUBPrzFyBTIWmCIaDBXu2q0qrKCsp0x44cOJ5dPd/WKiRlIpmu4YQwp1QWr2IBtQViJRSP0df21ZAKg/omndmPNwf9HOO5xx9rq2BBlcDR0aPFOx68wlHla6IGVcgOpaXsNvszEaNabA0OTm3B8WDDz4Y//vhhx8GlHt+a/gt7DY7TqczvjLJicYNp/0gGz+Y8jCzW9sWOiNbCJFdqZ64/+M83cZgtRwQ0LACEUJcLIR4EzgU+/dGIcS/GT6yM4AGVwOz0VnGZxdG7+TMki2n/SAZCEVDymRawAfO4/YwHBw2rTe6mjiZVktT/R86aYcOm4NwxLxyJqr5TJdqy7YSWL41oyPd6za3nIkZfcGzKhbavTvWrEtH/4fFstBBmwnrO8BVwBCAlPJ14BIjB3WmYEjDIXtZLB8kc8LXUFDp71DIl8zj8hCWYUamtfXY1htNE4vO5bXtNjsRaVw2eiZU85lugRJtW2GkG0Z7Uh5idjZ6IcPTVTSXMwmOQP8buvo/wJx7zoQmH4iUcv6TFDFgLGcchoW1avSDFDKJUMXsbHRN96yj/wMKm0yYjLzrYM1HXZmpgjYJHreHydAkgZA5Vu1CljFR0ez3Oa76P/QpoKjiC/hw2V1UOLLvCWQUWgRIjxDiYkAKIRxCiP+JUj23SAYSE650RfWDHH8u7WFmLPPNbjikSUvTubyEajoqhCM9GbqvQBo3gLMmbfVns3uj+wI+3HY35Q6NSX06oArNYDiY/sDjzyplh1q36Hp9f8BPg6vBMlnooE2AfAL4JEq72ZPApti/i2QgvgLRezJNzAdJgxmln9VrmTmxCETqxEmd/R9gjRVIia0Em9ApqNJmU/5/0phJzU4aVXuhF5J4CZdMUYbduxQFxeHU9fr+YOESJ7WS8YmTUg5KKT8ipWyUUnqllB+VUmZunlwEt0PRkHR/yeJ+kPQCxB/wUyJKCpKFrqJOLGbZxweDg9S70iRO6uz/AGsIEN0TRdu2wuhxGD2RdLfZyYT+gIZQbZ2Jl+pJl/8SHIW+fbr1P0/EDKGZCS1RWD8RQvx4/k8hBncmYFi8fNs2RZNO4wfxBXw0uBr000w1UFZSRnVZtak+kLRams7ltQFKRAlCCENMWFrKuYej4bgZ7dvf/jbr1q3jnHPO4fLLL+f48Rz7dqgCtju5H8TsciZmlPTQ5N878QJ6539A4RMntaJlZvkT8OfYzxNAFTCZ9hMaEUJcLYR4SwhxVAjx+ST7y4QQv4ntf1EI0Zaw7wux7W8JIa7SYzxGYFi8fLwuVmo/iFkai5mdCTPec/duWKZP/oeKEMKw1rZayrmHoqH4CmTz5s3s2bOHffv2ceONN/L3f//3uV3Yu04p2JnCjKUm1pmhKEgpTTVhpVUIu3cp/o8lb9P12oVOnNSKFhPW7xJ+7gE+AOTtHRJClAB3AtcA64CbhBDr5h12KzAipVyJEk78z7HPrkPpob4euBr4t9j5LIdhK5DWcxVNOo0ZyyybaYOrwTTTRlotzQD/h0oheqOnKuf+4Ws/TNfhLgC2b9+O2+0G4MILL6S3tze3i9lssbpYyQWImlhnhgAZnx1nJjJT8GdbLeGS9p67dyu5Wjr7P6zWylYlF8PpKkAPMXg+cFRK2QkghPg1cAOQ2Nv8BuCfYn/fB/yrUEIQbgB+LaWcAbqEEEdj58uuXV8B8Lg88d7oukZPaPCD+AN+zvXqZ6rRitft5eX+lwt+XTVxMqWWlo//4z8/r8T2p6AlMq3kgdjd2s/ZdDZco63USKpy7m0r2rjvsfv4wt99gV075072d999N9dcc4328cynbRsc+hOMHIfa5Qt2m5VMGI8uLPBkmrE3+vQY9O+DSz6r+7XNiKjUQkYBIoSYACQgYr/7AY1tztLSCiTml/QCF6Q6RkoZFkKMAfWx7S/M+2xrivHfDtwOsGzZMh2GnR0et4eZyAwToQn9u4i1bYOnvqZo1u65jvLZyCyjM6PmrUCMEJoZUBMn1V4sC+h+Vnf/h4oQQnvjpixQy7mfPHmStWvXLijnHpVRZiOzyPDca//iF79gz549PP3007lfPN4nfXdSAeJxeTg8cjj38+dIPFTbjGc7XbHQEy8obacNWOFaMYkQNAgQKaXx7b4MREp5F3AXwJYtW/R/wzOQaDfVX4AkJHytvW7OLjMLr3lcHsLRMKMzo9Q6tTW+0oOMpR7y8X9kWCmMB/z4Aj7W1K2hxKafNTVTOfeJ2QlOjJ+gvbo9/pnHH3+cr3/96zz99NOUleVRSsOzFlx1yv/b5o8s2O11e3n2VOpkQ6Mw+9nuHutOvrN7F5SU6u7/AHMSJ7WQ0gcihDg33Y8O1z4JLE3495LYtqTHCCHsQDVKSRUtn7UEhmZmt56X0g9i1jI/8ZqFto+ntRMb6P+AhN7o0hg/SKpy7qFoCCklb76hWH5fe+01Pv7xj/PAAw/g9eY52dhsSjZ1CjNpg6uBqdBUwbPR1cgvM8qaqybppHTvVpIHHS7dr2tG4qQW0jnRv5Xm5190uPbLwCohRLsQohTFKf7AvGMeAG6O/X0j8KRU7AQPAB+KRWm1o/hlXtJhTLpjaGa2vVTRqJO84PHKnSYs883KRk+rpcXbi+pbn0ilELkgycq5b3vbNm7YegN/fvDPAHz2s59lcnIy3q3w+uuvz++ibZfA2AmlNtY8DKu0kAF/wE+loxK3Iwt/k0543B7GZ8eZDk/P3TE9Dn2vG6agWDEHBNKYsKSU2428cMyn8SngEaAE+LGU8oAQ4qvAHinlA8DdwM9jTvJhFCFD7Ljfojjcw8AnpZSWrM9l+EvWthWeXOgHMXuZnziGQuEL+CgRJdSWJTGbGZD/kYhRAiRTOfdTk6cYnx1nTd0aQDFf6Upif5Datjm7EnNBllct9JEYhaZ+LwYRz0YPDs7tB2+g/wPMSZzUgqYoLCHEBpRQ23hsmpTyP/K9uJTyIeChedu+lPD3NPD+FJ/9OvD1fMdgNPFsdKO0cVWjnucH8QV82G12aspqjLluGlQndqFzQfxBP/Wu+uQ+CAPyPxIxqx5WYhKhIXjWgLs+5gf56JxdZmWjm5lQl1iqZ44A6d4FNoch/g9Q7vlsz9mGnDsftGSifxn4XuxnO/B/gDzXxf+1MLT0dUssH2Re4Tu1E6EZhddcdheVjsqCZyn7AynyXlT/x3LjeknbhA0hRMHLmSQmERpCvC7WbpgXZaYqCmaYsMxKqIuXM5n/bB9/Vsn/KNXfrCalZDA4aLkkQtCWiX4jcDnQL6X8GLARxZldRCNet9e4lyyFH8QXNLfsgcdd+Gz0lKaNuP/DOAFiZDZ6OgxfgYCyyh3rWeAHqXRU4ixxFnQFIqU09dlOGiAyMwGn9hpS/wpgIjTBdGTakiYsLQJkWkoZBcJCiCrAx9wIqCIZ8LgNbr7Ttg18B2DqdI3LwcCgqU43M3pmp9RMVf9Hq7FJlQ6bo6ACREppTCHF+aToky6EUJ7tdMUFdWZ0ZpRwNGxaQl1NWQ12YZ+rHJ14AWTkdN6Mzlg1hBfSh/HeKYTYCrwkhKgBfgi8AryKBTO+rUxib3RDSPSDxPAFfaaEOao0uAtb5mI2MsvIzEhyLS3e/0O/9qLJsNvsBfWB6N5IKhWeNeBuSBrtV2hFweyEOpuwUe+qn6sQxv0f5xtyTTMjKjORbgVyGPi/wLuA/wW8CFwJ3BwzZRXRiCG90RNp2ax02Iu94MFwkInZCVM1FsOF5jxUjXDBPcfzP4zRDhMptAkrLkCEwQJEiNP9QeZ9n4U2VVpBG1/QG12tf2WA/wPMjajMREoBIqX8/6SUF6H0Px8Cfgw8DLxHCLGqQOM7IzCkN3oi9lJYetoPotbqMVNjMVxoziOlllYA/4eKw+YgKqNEovpFlKcr566udhJ9ID/96U/xeDxs2rSJTZs28aMf/UifgbRthfGTMNI1Z3Ohe6NbQRtvcDWcvufpcUP9H2Bu4mQmtFTjPS6l/Gcp5WbgJuDdwCHDR3YGEY+XN9JW3LY15gcZtETlzrizsUDmjZSmjQL5P8CYXJB05dzVrPf5JqwPfvCD7N27l71793LbbbfpM5C2hLpYCXjdXgLhAFOhKX2ukwGzTVgwr11Bz4uK/8NABWUwOEiFo8KUxMlMaAnjtQshrhNC3AP8J/AW8F7DR3YGUZB4+fZLlN/Hn81cE6oAaOrepiMpq5V274albzPc/wGnTUlGmbHml3O/8bob+cDlH2DHZTs4dMhgnc5zFpR7FoSLF1pR8AV8VJdVU1Zi/PeZCo/bw+jMKLOR2dP+j6XG+D/A3LyXTKQ0ngohrkRZcVyLUibk18DtUsrCqBpnEAWJl0/wg/iWKwlHZj50qtmuUPZxf9CPXdjnFm8MDMPAG7D9H/I+/z+/9M8cGk4/SUdllGA4SFlJmSbH9pq6NXzufG2FrZOVc//Kt76Cd5mX0SOj/PVf/zVPPvkkAL/73e945plnWL16Nd/5zndYulSHoMm4HySWDxLLL0qsOtBW3Zb/dTKQMtengCRWl2jtflapSVdqXI0qK9xzKtKtQL4APAeslVJeL6X8ZVF45IbL7qKy1ODEuhIHLLsQunfjD/opKynTv/pvFhS6N7ov4KPBPa99rxqVZlB45XzUpE2JfoEDajn3pqYmBgYG5pRz//hffpz3XPoePv7xj9PX1wfAddddR3d3N/v27ePKK6/k5ptvznCFLGjbChOnYLgzvqnQrW2tUBMqLjTHjsOp1wz3r1nhnlORrhbWjkIO5ExHjUoylLat8MRX8Y330OBqMCULXcXtcBc0G90X8C002XXtUlZlOtS/0rJSkFJyaPgQtc5amsqb8r4mpC/n/uAzD+KwOVhWdbrPTX19ffzv2267LfeWtsloi5lJu3dD/Qqg8OVMfAHfnNL1ZqBO5r4Tzxnu/7BqL3QVLYmERXSgIAlXMUenf7STRnejsdfSQCE71vkDSbS07t1KdJpB9a/mo2ajG5ELkqyc+4O/fxC7zY6UktdfqhLGOAAAIABJREFUfx0gvhIBeOCBB1i7dq1+g2hYBeXeOW1uyx3luOyuguT8RGWUweCg6c923ITV/5rh/o/RmVFC0ZAly5hAUYAUjIJMpi2bwVGOPzBgCY2lkFnKC8pbTA0qUWkFCN9NxMhckMRy7j//xc+57+f3ceVFV7J+/Xr++Mc/AnDHHXewfv16Nm7cyB133MFPf/pT/QYw3w/C6TavhVAUhqeHiciI6c92TVkNdpsd38hRw/0f6gp+0ZmwiuiL2ogmKqNz7fR6UuJALr2AgfBRtlrA6eZ1e3mp3/g2LUkTJ+P+j0sMv34iDpuDYDio2/lSlXOfjczyg9/+gJaKljmBA9/4xjf4xje+odv1F9C2FQ7cr/hBYmasQikK8cnUZG1cCIHX2YBvvBPWvMvQa1k5iRCKK5CC4XGfbvNqJFPLLyAooNFufucyr9vLYGCQqIwaep2kiZNdu8BRrqzKCoi6AjE6A79gZUzmowrkrmfimwri38MaWegq3hIn/hKb8Q50EzuLaqEoQAqE4dnoMXyN6wDwTA5lONJ4PC4PYRlmZHrE0OsMBAaU6yW+ZN27lKi0EoMr1c7DbrMTlVHDhaYqQAyvxDuf+pVQ0TgnodDjVlbXRgtNKyTIqnhCIXx2u6H+D7BG5n06TBEgQog6IcRjQogjsd8LWsgJITYJIZ4XQhwQQuwTQnwwYd9PhRBdQoi9sZ9Nhb2D7ClUlz5fhdKV0Dt03NDraCEerWJwJFZ8ma+aNib94D+kS/hutpNivDe6wTWxVEd9LiuQvCb6JH4Qj8tDMBw0PBvdF/AhENS76jMfbDDeqWF8doeh/g9Q7rmmrIbSksIEgmSLWSuQzwNPSClXAU/E/j2fAPCXUsr1wNXAd2NVgVU+K6XcFPvZa/yQ86NQGbv+GUXb9/btN/Q6WihUz+y4bbw8JkDUKKE8Cyg6nU6GhoaymnDVCd3oqrzhaBghBCUiSffFNEgpGRoawul0Zj44FW3bYLIfho4CBSrVg/Lu1LvqC7/qms/MBN6xfqaENF5oBn2WMNmlwiwn+g3AZbG/fwbsBOYE2kspDyf8fUoI4QM8gLFOBINI2clMZ+JLXv9hRROvMD8b3fAVSMCPs8RJpaNS2dC9G0oroDm/hemSJUvo7e3F79cuAMPRML6Aj+myaUNrF41OjzITnUH4ss/1cTqdLFmyJPOBqYjXxdoFDavmmGc7qjtyP28GfAGfNUw5J17EE1YUBH/AT3m1wVnoFjDZpcIsAdIopVQD1vuBtIHdQojzgVLgWMLmrwshvkRsBSOlnEnx2duB2wGWLVuW7JCCUFpSSk1ZTUG08YoSF24p4fhuWP8eQ6+XjnpXPQJhvNCMhfDGEye7d8Gyi6Akv8fb4XDQ3p5d0logFODDv/wwnz7309y69ta8rp+O2x69jWA4yD3X3mPYNVJSvwIqmhRBveW/Fc48G/DplqCZF8d3440tSn0Bn6ElXPwBP6trVxt2/nwxzIQlhHhcCLE/yc8NicdJxT6Q0kYghGgGfg58LNYZEZQyK2uAtwF1zFu9zDv/XVLKLVLKLR6PuZLc8M6ExMoeVDQpGniSBkCFxGFzUOesK8iqK66ZTgzA4OGClS+Zj9vhptxRbngNMH/Ab15CnRDK/2/MD1Iw82yqlsWFpns33nolQdNIs10kGmFwetAa95wCwwSIlPIKKeWGJD9/BAZigkEVEEm/hVgL3T8DX5RSvpBw7j6pMAP8BDA2FEInChHuqJQ98MbrYpmNof3gY8zJQo/7PwqbQJhIIXpkmF5gr20rTA7A4BHKHeW47W5D7zkUCTE8PWy+P2BmEk6+ineZ0v/DyHsemh4iKqOm572kwywn+gOAWuXtZuCP8w8QQpQCvwf+Q0p537x9qvARKP1JzPcYa6AQCVfxmlBtW5VIpMnC9iWfj9GrLinl3GJz3bugrAqaNhp2zUwYLTQDoQAToQlzNdNEPwjG33O846TZk+lxpf5VeccO3Ha3oQqh1XNAwDwB8k3gSiHEEeCK2L8RQmwRQqgt1D6A0g3xliThuvcIId4A3gAagK8Vdvi54XF5GAoO6dqxLpGojJ5e5sf7pJu7CvG6vYYKkMnQJMFwMEGA7NbF/5EPRgvNlO17C0ldB1Q2x1e5Hrex5UyS5vqYQedOKCmDZRca/myr5za79lc6THnLpJRDwOVJtu8Bbov9/QvgFyk+vygrBXvdXiIywsjMiCHtKUdnRglHw8rE0rxJ8YN07TLVke51eRmeHiYUCeEwIKlvTiOp8T4ltPS8W3S/TjYk9oM3oiKyJZLLhFCUlM6dih/E5eGNwTcMu5y6ujF9Mu16GpZdAA6X4QLECt0XM1HMRC8gRvdOmFPqocSuaOIm+0HUezbKqTxHM7WA/wOM7wdvmQJ7bVthygeDh+MFFY3KRo8LTTMn00k/DOyH9ksB4812voAPm7BR56wz7Br5UhQgBcTo3gnxyVTVTNu2wuBbMFmYirjJiOeCGOT7mVNsrnMnuGpN9X/Ex4KBioJVCuypgrp7Fx63h+nINBOhCUMu5Qv4sNvs1JTVZD7YKLpj9b86LgNOmyqNFJr1zvrC1zvLgqIAKSBGZ+yqgim+zI87Os1bhRg9mcY1U2eDIkDaLwWbuY91PKzVIO3UF/DhsruocFQYcn7N1HVAVSt07TrdwjhgzEpTjTozrJK1FjqfVgI0YgmqXpeXUDRkWIHUBS0KLEhRgBQQtYaPUSsQVTDF/SvNG6G00lQBYnQGvj/gp9JRiXv8FIyfjGuHZmL0SlOdTM3sOAnMqYvlUVsYG6QcWaKkR9fTyv3GAjQMX2kma5JmMYoCpICoiXVGaqZ1zrrTzuoSOyw31w9S66zFbrMbN5mqUWedO5UNHZcZcp1saHArk6lh37OVNNO2rRAYxBNU+pYYphwFTBYgI93KT8z/AcbXevMH/OaHLWegKEAKjJGdCZNqLKofZGLAkGtmwiZshibWDajdFzt3Qs1yqDO3XzaAy+6istS4fvBJ+7+bRcwP4hl4EzBWGzc16qzzaeV3x2XxTUYGxcxGZhmZGbGOopCCogApMEZOpkmLzamOThPzQYxMoPQH/HidDUq4csdlhlwjF4xq8yqltFaBvdp2qFqC+8SLVDgqDIm2C4QCTIYmzV2BdD2t1P/ynBXfZKR51jKBEhkoCpACY2ToX9JlfpP5fpBGd6Mhk6maOOmNSpgZs5YAMUhoToQmmI5MW2diSfSDGJRAafpkKqXSgbH9EuV+Y5SWlFJbVmvMPSfmN1mYogApMB63ko2ud7+IUFSpFbRAM1X9IF27dL1eNhi16hqZHiEcDeOZiAmnBPu02XhdXkMiknxTFskBSaRtKwSG8JS4DVGOTM8B8b0JU37oWPh8GZWBr4bkW+p7TkJRgBQYr9uLROo+uQwFh5DI5A9c+yUwdATGenW9plY8bg+ToUkCoYCu5+0P9APQNNQNTedAufmd6lTUFYjeOQLxe7ZCWXOVWOVjTzhsiKJg+mSq+j+SKChet9eQlWb/lAW/5yQUBUiBaXIrD4Q6EehF/IFzJ3ngVsSqxhx7UtdrakXNS9FbOx2YUiaWpoGDljJfgTKxhKNh3XME0n7PZlGzHKqX0jg1zEBgQPd+8Kbfc+dOJeelZumCXUaVMxkIDOCyu6gqrdL93HpSFCAFRtUo1JdCL9TzNZYnqRXkXQuVLXD0CV2vqRWjolXi9zwzbTkBYpSDdSAwgEDEQ4UtgRDQcRlNQycIR8MMTw/revr+qX4qSysN7fCYkvCMUiJnRfLye2qB1HA0rOtl+6f6aXQ3mp/rk4GiACkwRguQpEteIZQXoHMnGFQJOB3qCkT3ew7048BGnYjV/bIQRmWj90/143F5zO8LPp+VV9A0o+SC6P09D0wNmGfKOfEChAKw8oqkuxvLGxWTtM7RZ6becxYUBUiBqSytpNxRbshk6ra7T/cFn8/KHTA9Cidf1fW6WjBKaA5MDeCNSmxLL4BSE7TTNBi1Aumf6rfmxNJxGU0Rxd9jxLNtmvnq6ONgc5wuCzQPdVx9U31J9+dKf6Df/MrDGigKEBNocjcZsgJpKm9KveTt2A4IOFZ4M5bL7qKmrEb/ex4/QdNMMKV2aCaN7kYEQn+hGRhIbqY0G1cNTd6zAWNW16YJzWNPKt09y5LXHWsubwb0vedwNMxgcNCaisI8TBEgQog6IcRjQogjsd+1KY6LJDSTeiBhe7sQ4kUhxFEhxG9i3QsXDU3lTbo70TMued110HquaX6Q5vJm3bW0gfEemiIRWHWlrufVA0eJgwZXg64Ti5Qybhu3IjUrrqQsGqV/tEu3cwbDQUZnRs2ZTMf7lPLtKxe0LoqjjkvPZ9sf8BOV0aIAScPngSeklKuAJ2L/TkZQSrkp9nN9wvZ/Br4jpVwJjAC3GjtcfWkqN2AFEtCgpa28Ak7ugeCIrtfWQmN5o65CMyqjDITGabK5wLtOt/Pqid5Cc3x2nGA4aNmJRay6guZwhH6/fh2m45F2ZtyzGrWYZoVbUVpBpaNS1/dZDVu2qqKQiFkC5AbgZ7G/f4bS11wTsT7oOwC1T3pWn7cCjeWNDE8PMxuZ1eV8oUiIoeBQZjvxistBRk/HtReQ5vJm+if1e8mGp3yEkTTWr56THWwl9FYU1InFqgKE5s00Sht94yd0O2U878UMH8jRx6GiERo3pD2sqaJJV0VhseSAgHkCpFFKqf6P9wOpRK1TCLFHCPGCEEIVEvXAqJRSjZvrBVpTXUgIcXvsHHv8fuO6h2WD+jKo2lW+DAQGkMjMD1zreVBWbYofpKm8iYnQBJOzk7qcr7/rKeW8rRfocj4jUFcgeiUTxsOWraqZ2mw0lTfSH5qAqD65IKZNptEIdD6lKF0ZFJQmd5Nu7zIUBQgAQojHhRD7k/zckHicVN6uVG/YcinlFuDDwHeFECuyHYeU8i4p5RYp5RaPxxp1ZeJRSTqZdNLmgCRSYlfKMRx9UqnvU0D0djb2H48JkPbk8flWoLmimZnIjG7JhIthYmmqP4tBG4RPvabL+dSJueCBA6deU0y9afwfKnqbKvsD/ZQ7yqksTRFRaSEMEyBSyiv+//bOPDqu4kz0v68ltSxLsqxd1mJLxpbkFbywLwEDYR0gwUlgJsRhyMtL5mROZpKZQN5M5uRNXk4gJ8m88OBNkgkJTMIEyAYOsQ3GrI/FC+BFsi1LtrW7JWtXa5e63h91W5asxa3ue3sx9TunT9+uW7e6qu699VV99dVXSqnV03xeAFpEZBGA9T2traNSqsn6PgG8DqwD2oGFIuLf57EQaHKqHE5gt1nrnNxbLLseehrhdJUt/x0odgvNFs9+AHIzltmSnhPYbeLZ0t9CnMRFtYO9vPxL8IlwuvpFW9Lz9HtIT0wnMS7RlvQCpuYVQCzrxdnJS86ja6iLgdEBW/66pa8lekeZZxEpFdZWYIt1vAV44ewIIpIuIonWcRZwJXDYGrG8Bmye7fpoxnYBMhdXD/4JweqXbfnvQPGPQGxpTHtb8PS1kChxpCdOa8AXFeSl2CtAPH0espKyiHPF2ZKeE+RllgLg8e8fHiIRM+Gt2aWtFgPwr+bE+xzNo8yJREqAPAzcKCLVwA3Wb0Rko4j83IqzAtgnIgfQAuNhpdRh69yDwNdEpAY9J/JEWHMfIknxSaQlptn6wAXs6iGtEHLXwLEdtvx3oGQlZeESlz1lPr4LT3wcuUlZUe3qwW61XSysTh739dZ+FAZCV915+jzhV195T0PjXlgWmHm4rZ0jArSojBLizx3FfpRS7cAU5aJSah/wBev4HWDNDNefAC5xMo9OkzffvrUgLf1zbFjKboa3fgT9HXp9SBiId8WTMz/Hnsa0eieexCTyFiwOPS0H8ateTnntU2GVZZSdO2IEGe+Nx1mLVlffHVJ6LX0tbMzdaEfWAqf6ZUBB2S0BRfeX2Y6JdL9FpVFhGWbFThPPlr6WuZk5lt4CaszS84YPW1bgj41AzS5a3EnkRpNH2mkQEW2+bENHIdoXEfpJcaeQkpCCZ14KVG0PKa2+kT56R3rD3xs/tl07H110YUDR/V4H7BiBtA60BmZRGSUYARIh8pLtsx2fs840fx0k54T8gs8VW6xV6t5mdKibVjUSEy9ZbnKuLfe5Y7CDwbFB8lPybciVs+Ql53FqQZ7uyY8Fv3FaRKzORofg+GtQelPA64vs9DrQ7G0GzqjFoh0jQCJEXnIevcO9IW+y1D/ST+dQ59waFpcLSj+uJwpDeMHnSl6KtpcPab+Io9vwJM5nDB+FqYX2Zc4h7FpA6W9YClJmXPIUNeQl5+FxJ8Jgt/ZmGyRNXm1cGdYy174Fw96A1Vd+7DLljUiZQ8AIkAhhlw+doB+40lv0PuL174b0/3Mhb34ew77h4PeLUAqqttNcpHXisfCSLUpexOmB04yEKKib+vR9joURyKLkRXjG+iHOHdIo1/9sh7XMVdshYb7exXMO5Cbn2jYCEcSMQAyzU5iie8/+lyRYgu6ZXnAdxCVCVfissUK2SmqpgO56mvLKgdhpTBVq3A1JsDT1xk7PND8ln86hLvqLr4aqbUEvWm32NuN2uclKCtPmWUrp92HpdZCQNKdLFyUvwtPnCdnrQJO3iZz5OSTERdl+LzNgBEiE8KtfGntD26e80auvn3Nj6k7Wvaxj28O2Kn1RihYgfqE3Z6q2A0JTqjYJjoU5ELvWCDR7m1mYuJDkhGQ7suUo48928aXQeRLajgWVTpO3ifyUfFwSpmaqpUIvsi27ec6XLkpexODYIJ1DoTkqbfY2x0QnwY8RIBEic14m8+LmjQuAYGn2NpMUn0TmvHMveJpC6U3QcSLoF3yu+F+MoEddR/8MhRfTPNxN7vzc6NuVbxr8gj3UkWZTX1NMjLjgzOi6MdvyPFS1Lah0mrxN4W1Mq3YAAqVzFyB+oekfKQZL2MscIkaARAgRIT8l35YHLj85P7gFdeW36e8jW2ePZxOp7lQWJi4MbtTV3QSn9kPZLeM901ggPzkfQWzpKMRKwzLeUfANaFPYozEiQI5shcKLISVnzpeOC80Q7vOIb4SW/paYebbBCJCIUpBSEHrPNJTGdEE+FF0GleHzBFOYUhjcS+bvxZbdGlO9tIS4BPKS80JSVSqlYkqA+FVtTd4mKL8dGvdAz9zUlt5hL91D3eFrTDtOgOcgrLzz3HGnoSBV35tQ7rPfQjFW7jMYARJRClMLafI2hTTxFnJjuvJOaDkE7ceDT2MOFKYWBveSHX4BssoYziihtb81pl6yotQiGnobgr6+fbCdobGhmOmZiojuHPU2wUprF4bDcxvljlsXpobpPvvzt/KO2ePNQFJ8EllJWSGNQGLNhBeMAIkoBSkFeEd0TysYeoZ76B3uDW09xIq/0N+HwzMKKUwtpNnbzJhvLPCLelug9v/Bqk/gsfY+iZXGFEIQmhax2LAUpBToxjS7FHJWweHn53S9v8x+1ZDjHH4B8tfDwuDd4xSmhHaf/cYlsfRsGwESQUI15fXPn4T0wC0sgoKN4RMgKYWMqtG5mbUe2QooWHXXeA8vlhrTotQi2gfbg140GkuLCP341bNK6ftG/btzUmOFtTHtqofmD4JWX/mxo6PgElf4nUeGgBEgEWRcbxrksNe2hmXlnXqCurM2tHQCICjz5crnIbscclbEZGMa6gSrv4MRK4vLQN/ngdEBvWg0CDVWk7eJpPik8LjrD1F95acwtRBPvyfoRaNN3iby5ufFhHWhHyNAIkioZq229cb9L04YRiHjAiTQxrTXA3Vvw6pP6Ot6G4kX7dk3VihKLQKCn2Bt6G0gY15GYO76o4RJQjMINVajt5GClILwuOs//ALkrYWMpSElU5hSiE/5aO4Lbp1TY29j+OZ8bMIIkAiS6k4lLTEtpIYl1Z3KAveC0DKSXqwdLFb+MbR0AiB3fi7xEh94mY/8CVDjvdj63noKUwuJd0VkJ4Kg8AvNYCfS63rqKF5QbGOOnGe8c+Q3U191l/aLFaAaq7G3MTy+zrrqtZVYiOorCH1xcH1vPYtTo3uLgrMxAiTCFKQUBP3A+RsWW3ppqzfrfaDbqkNPaxbiXfEsSlkUeJkr/mCpr7T7ktqeWhZH+T4gZ5OWmEaqOzX4hqWnPubKPEU9u/IuQAU0yh3zjVHfUx8eoXnwOf29ZvPs8QJgfNQVxH3uGe6hY7CDJQuWhJyPcBIRASIiGSKyU0Sqre8pik4RuU5E9k/4DIrIXda5J0Xk5IRzF4W/FPawJHUJ9b31QV1b11Nn3wO3ZjOICw48Y096sxDwWpDOWqh/B9Z8CgCf8tHQ0xBzLxnoMjd45z4C6R/p5/TA6Zgrc1J8EtlJ2dT11OmA7FK9qDCA58vT72HYN+x8mZWCg8/C4sv1KDxEsudn43a5g5rrqu/RbUCs3edIjUAeAnYppZYDu6zfk1BKvaaUukgpdRGwCegHJm7k/Y/+80qp/WHJtQMUpxXT7G1mcHRwTtcNjg7i6fPY1zNNzdNO5A4+B74Q3K0HQGFqYWBC88CzgMDazwDQ2t/K4NggS1Jj6yUDa81PEF4H/A1wrKk2AErSSqjtqT0TcOG92lij9cis1/nL7Hhjemq/duNjPV+h4hIXBakFQakqw1Zmm4mUALkTeMo6fgq46xzxNwPblVKhbZ4RhRQvKEah5vzQNfQ2oFD2DvMvvAe66x138V68oJjuoW46B2dxPKcUHPgNlFytTY0500uLNXUOaAHQ6G1k1Dc6p+vqemOzYQF9n2u7a88slF29GVzx+r7OQtga04PPaZfzq87V/ASOv8xzpb6nHkFiYo+biURKgOQqpfwbYXiAcxk+3wOc/dR9V0QOisi/iUjiTBeKyBdFZJ+I7Dt9+nQIWXaG4rRigMk9tQBw5CUrvw0SkuGgs2qskrQSAE52n5w5UsNu7cn1wnvHg/x1FIuNaUlaCaO+0Tnrx/1C02/JFUsUpxXTM9xzxkNtSjYsu9Ea5c68kLSup25cBeYYY6Nw6HfaoWiSfabCJWkl1PXWzbmjUNtTy6LkRSTGzdiURSWOCRAReUVEKqb5TDJ3ULp7MqMvDxFZBKwBXpoQ/E2gHLgYyAAenOl6pdTPlFIblVIbs7MdfCCDxD+CmGuvxZHG1J2sTXorX4CRuanU5oJfgJzoPjFzpAO/0Rv7+FfKoxtTt8sdE27czyagMk9DXU8dOUk5MWXC62faZ/uie6H3FJx4bcbr/HN7jprwHn8V+lptU1/5WZq2lFHf6JxN82PRUAIcFCBKqRuUUqun+bwAtFiCwS8gWmdJ6tPAH5VS46tzlFKnlGYI+CVwiVPlcJr5CfPJmZ8z5xFIfU89WUlZ9u8PceG9eqdCBz305qfkkxiXOPMIZLgfKv4IK+6AxNTx4LreOhYvWBy+/SFsJKBR1zTU99SzJC32Rlwww+i69GaYtxD2z6zGstU4ZCbefxKSs2H5TbYmO95R6Aq8o6CUoq43DGV2gEi9iVuBLdbxFmA22757OUt9NUH4CHr+pMKBPIaNkgUlcx6BOPaSFV8NGRfAvl/Yn7aFS1wULyieuTGt/IMWYus+Oym4trs2JieTQa/5yUnKmdMIRClFbU9tTDYsoF3Zu13uyc92fCKs/bTuoPS1TblmZGyEJm+Ts/e5pxmO7dDPV7zb1qTHOwo9gXcUOgY76B3ujcn7HCkB8jBwo4hUAzdYvxGRjSLyc38kESkGioA3zrr+aRE5BBwCsoD/FYY8O0ZxWjEne04G7JVXKcWJ7hPO2Mm7XLDxfj2R3nLY/vQtStJKZhYge5+ArDIovmo8aGhsiIbeBpalL3MsT05Tkja3jkL7YDtdQ10sWxibZY5zxbF4weKpjenGB2BsGD781ZRr6nrq8CnfeEPsCB/8CtQYrP+c7UmnulPJTsqe0wjkeJf2hB2L9zkiAkQp1a6Uul4ptdxSdXVY4fuUUl+YEK9WKVWglPKddf0mpdQaSyX2WaWUN9xlsJPiBcX0Dvdqv0EB0DbQRtdQF8vTlzuToQv/Uu+X7uAopCSthCZv01Tz5eYPtWO7jX8NE3Tgtd21jKkxli90qMxhoCSthBPdJwLuKFR36kWdsdiw+JnWKimnHJZcpZ+vsybTq7t0mUvTS53JkG8MPvhPbbIeouuSmShJK5nTCMRf5li8z7GnTD4PWbpQP8j+nsi58D9wjjWmyZnatPHAMzDkjGwuSStBoc4sNPOz9wk9eX7hPZOCY/kl81OSVoJ3xEvbwFTVzXT4n4cLFl7gZLYcpSSthIbeBobGhiafuPgB7Uak5pVJwdWd1cRJnHMjkOqX9b7nG+93Jn3OjK4D7SjUdNWQlphGVlKWY3lyCiNAooCy9DIAjnYcDSj+eM/USXXOxgdguNcxk96laVpoTpoT6O+Ait/D6rshaeGk+Me7jhPvio9JPbGf8Y5Cd2AdhZquGtIT04Pb7z5KKMsoY0yNTe0cld8OKbmw9+eTgmu6aliyYAnuOHvnJsZ593FYUABltzqTPlqA9A73BtxRqOmsYdnCZeFxHGkzRoBEAZlJmWQlZVHVWRVQ/JquGjLnZZIxL8O5TBVdAgUb4J3HZrXZD5aStBLiJX6y0Nz7BIz0w2VfnhK/prOG4gXFJMTFjqvrs/GPGKs6ArvP1V3VLEuPzYbFj79zNKXM8W7YcL8eEZw+c666s9o51Wzzfqh9Cy79Ejj4HPnVb4F0CJVS1HTVxOzI2giQKKEsvYxjnccCiuvoS+ZHBK78ql7Md+RPtifvjnNzwcILzrxkIwOw+yd6oVnuqinxq7uqY/Yl85OZlEnO/JyAG5bjXce5IC121VegF0AmxSdN3zm65L9BfBK8/WNA+/1q9DY6d5/ffQzcqbBhy7njhkB5hnb8Gch9bulvwTvijdln2wiQKKE0o5TjXcfPuRnNmG+ME90nwvPAld+uJxrf/rF2LWJ38hnlHO04qnVLWb4YAAAQ6ElEQVTF+/8L+tvgqr+bEs877KXJ2xSzL9lEVmSsCKhhafQ20jfS53xHwWHiXHEsT18+/agrOUtbQh18Frobx9VcjpS5q0F7dt6wBeal2Z/+BFLdqRSmFHKkY3afX8B4pzFW77MRIFFCWXoZI76Rc64TqO2pZWB0YLyX4yiuOLjib7VV1MmzLalDZ0XmCjoGO2j1NsM7j2qV2ZIrp8Q73K7NiVdlTR2ZxBrlGeWc6D7BwOjArPEq2yuB86PMZellVHVWTT+pfMVX9Pc7j43fZ0ee7bd+qL1NX/ol+9OehhWZgXUUKtoqEIQVGSvCkCv7MQIkSvDris+lxjrUdgiANdlrHM8ToE16U/Nh13dsH4X4G4qqfT/Rrtuv+cdJprt+Ktr1OtFVmbHfmK7IWIFP+cYNIWaisq2SBFcCpQsdMmcNI2XpZfQO93Kq79TUkwsXw5pPw/tPcujUbjLmZZCfbPM+6J21es3Jhi3jjjmdpjyjnIbeBnqHe2eNV9FWwdK0pTHpqgaMAIkaitOKSYpP4uDpg7PGq2irICUhJXw71CXMg2sfhKZ9ULXN1qT9QvPwkd9D4SXazcU0VLRVUJBSQPq8MOyP7TDlmYHpxyvbKynPKI9powE/KzNXAmc6P1O49kHwjVLR+Dars1bbbzTwxve1F+Cr/8HedGchkHkQpRSV7ZUxPco0AiRKiHfFszZrLQdOH5g13qG2Q6zKXBVef1AXfRYyl8Guf7XVIivFncIF7nT2yzBc/y/Tjj5A98ZXZ6227X8jSX5yPhnzMma9zz7l43D74fGGN9YpzyxnXtw89rfOsG1PejHeDVs4MdbH6qRF9v55y2HtmHPjA7DA5rRnYU2W1hDMdp9P9Z2iY7Ajpp9tI0CiiItyLqKqs4q+kb5pzw+ODnKs41j4H7i4eNj0z3D6KLz/S/vS7fWwvtPDgfnJjC25YtoobQNtNPc1j7+QsY6IsCF3A++3vD9jnONdx+kb6TtvypzgSmBV1qqZBQhQufImlAhrjr9jn6pUKdj+DT1pfk34Rh8A6fPSWZq2lA9aPpgxjl/bEMv32QiQKGJdzjp8yjejGmv/6f2MqlHW5awLc87Qe1qXfAxe+VfobbEnzZf/mfUDA3jxzTj3s+fUHgA25m605z+jgPU562nyNuHp80x7fo9Hl/nivIvDmS1HWZezjqMdR2c0HtjXXY0LYe3Jd+zzBF35R73uY9O3YL6Da6ZmYH3uej5s/ZCxGUbtezx7SE5IDo9BjEMYARJFrM1ei0tcM/ZOd5/aTZzEsSF3Q5hzhlYv3fYjGB2Al74Zeno1r8Ch37JhzX0AfNA6fU9tj2cPqQmpMf2SnY3//s10n/d69lKQUkB+is2TyRFkXc46RtXojCqd3ad2szJzJQty1sC2b8Bgd2h/2NcG2x/U+7Bv+HxoaQXJ+pz1eEe84254zmavZy/rc9YT74oPc87swwiQKCLVncrarLW81fTWtOd3n9rN6qzVpLhTwpwzi6xlcM03tLuRA88Gn05fOzz/N5BdzqLrvkVhSiHvNL8zbdQ9nj1syNtAnCsu+P+LMkrTS0l1p/Ju89Stg8d8Y+xr2XdejT5AjyATXAm81Tj12e4f6efQ6UNcuugyuONRvdHTi18LXpWlFPzpqzDYBXf9uzZHjwD+ezjdfW7tb6W2p5ZL8mJ2KyPACJCo42NFH+Nw+2FO90/efrdtoI3K9kouz788QjmzuOrvYfEV8OLfQ9vspqjT4huD578MA51w988hIYlri67lveb36B+ZvOX98a7jNPQ2cGX+1LUhsUycK46rC67mzcY3p6g3Pmj9gO6hbq4quGqGq2OT+QnzuSTvEt5sfHPKuXea32FUjepnO38dXPc/oOJ3etOnYNjzH3D0Ra26msarQbjIS86jPKOc1xqm7r74esPrAFxZENvPthEgUcbVBVcD8Hrj65PCd9Xtwqd8fHzJxyOQqwnExeuGPz4Rnv4UeOe4z/zL34Lql+Dm70Genjy8rug6hn3DU3pqO+t2IgjXL77ertxHDZsWb6JzqJMPWz+cFL6rfheJcYnjz8H5xDWF11DbUztlsezLtS+Tnph+RjV71dfhguv1BPiJ1+f2J8dfhR0PQektcPlX7Ml4CGwq2sT+1v20D7RPCt9Zt5PiBcUx713BCJAoozS9lKVpS3m++vlJ4dtObqMkrSQ6Hri0AvjL56DXA0/fHZgQUQpe/S689zhc8t/h4vFtX1iXu47MeZk8X3OmzD7l488n/sy6nHVkz4++vexD5aqCq0iKT2Lr8TMTxiNjI+w4uYMr86+M2YVls3HjkhuJk7hJz7Z32Mvrja9z/ZLrz8wFuFyw+QltOv7MX0H9e4H9wck3dfzscrj7P3Q6EebGJTeiUPzp+Bl/cp4+D3s9e7lhyQ0x7SgTIiRARORTIlIpIj4RmdG8RkRuFpEqEakRkYcmhJeIyG4r/FkRccj3c/gRETaXbuZg20Eq2vQK7Mq2Sj5o/YC7l98dPQ9c0cXwmV/B6WPwxI3gmWVX4eF+2PoVePP7sO4+PfqYQIIrgbtL7+aNxjdo6GkAtFqjtqeWzaWbnSxFxEhOSOb2pbez7eS28Y3EdtTuoH2wnU+VfSrCuXOG7PnZXFt0Lc/XPD+urvx99e8ZGB3g7uV3T46clA73/VG7fH/qDr2H+kxzIkrpTaJ+vRkWLoHPPQ+JqQ6XJjCWpS9jfc56nql6hlHfKADPHH0Gn/JNLXMMEikRXQF8EpiqELUQkTjgceAWYCVwr4j4V1Y9AvybUmoZ0Ak84Gx2w8tdy+4iPTGdh/c8TP9IP4/sfYS0xLToe+CW3whb/gTDffCzj8GOb0L7hH0fhrzaSeK/Xw4fPq1dlfzFo9NOan6m7DPMi5/H9/Z8j76RPn6474fkJ+dzU/FNYSxQePnsys8y5hvjB3t/QNdgF49++Chl6WVckT/9mpjzgc+v+jydQ508vv9xWvpa+NnBn3Fp3qXTr21KzYMvvAKFG+H5L8HTm6H27TOLWX0+Per41V2w9W9hyeXw+T9DSk54C3UO7l99P03eJp6sfJKT3Sf59ZFfc1PxTRSmFkY6ayEjge6a5cifi7wO/INSat805y4Hvq2Uusn67bcdfRg4DeQppUbPjjcbGzduVPv2TfmrqGTbiW08+NaDuF1uhn3DfO/q73H70tsjna3p6WuHnd/SOxiqMUjOhoQk6G7Sv3NX61FHyTWzJvP0kad5eM/DuF1uRtUoj216jKsLz7+5gIk89uFj/PTgT3G73CgUv7z5l1yYfWGks+Uo33n3Ozx37DncLjfxrnh+c9tvxjfbmpaxUdjzU3jjEW3e607Rnny9rXr/mKR0+NhD2j18FFrrKaX4+htfZ2fdTtwuNynuFJ69/VnykvMinbWAEZH3lVJTtEXRLEA2Azf790gXkfuAS4FvA+9Zow9EpAjYrpSadnm2iHwR+CLA4sWLN9TV1U0XLSrZVb+LV+tf5bqi67hhyQ2Rzs656WqAqu3gOQhjw5BWBMuuh6LLAtZHv3jiRd5rfo9bS27lioLztyfuRynFb4/9lkNth/jk8k9GZpFomBn1jfL0kac52X2Se8rvCXyNz3Cffr4a9mgrvuQsPTopvQXc0T1nNDw2zJOVT+Lp83Dfyvuc27LXIcIuQETkFWA6EftPSqkXrDiv47AAmUgsjUAMBoMhWphJgDi2BFIpFWqXuQmY6Hu50AprBxaKSLxSanRCuMFgMBjCSOTt3GZmL7DcsrhyA/cAW5UeMr0G+M1ztgAvRCiPBoPB8JElUma8nxCRRuBy4M8i8pIVni8i2wCs0cVXgJeAI8BzSqlKK4kHga+JSA2QCTwR7jIYDAbDR52ITqKHGzMHYjAYDHNnpjmQaFZhGQwGgyGKMQLEYDAYDEFhBIjBYDAYgsIIEIPBYDAExUdqEl1ETgPBLkXPAtpszM75iqmnwDF1FRimngLDyXpaopSa4hb7IyVAQkFE9k1nhWCYjKmnwDF1FRimngIjEvVkVFgGg8FgCAojQAwGg8EQFEaABM7PIp2BGMHUU+CYugoMU0+BEfZ6MnMgBoPBYAgKMwIxGAwGQ1AYAWIwGAyGoDACJABE5GYRqRKRGhF5KNL5CTci8gsRaRWRiglhGSKyU0Sqre90K1xE5FGrrg6KyPoJ12yx4leLyJZIlMVJRKRIRF4TkcMiUikiX7XCTV1NQETmicgeETlg1dP/tMJLRGS3VR/PWts4ICKJ1u8a63zxhLS+aYVXicg5t7WORUQkTkQ+FJEXrd/RU09KKfOZ5QPEAceBpYAbOACsjHS+wlwH1wDrgYoJYd8HHrKOHwIesY5vBbYDAlwG7LbCM4AT1ne6dZwe6bLZXE+LgPXWcSpwDFhp6mpKPQmQYh0nALut8j8H3GOF/wT4snX8N8BPrON7gGet45XW+5gIlFjvaVyky+dAfX0N+C/gRet31NSTGYGcm0uAGqXUCaXUMPAMcGeE8xRWlFJvAh1nBd8JPGUdPwXcNSH8P5XmPfTukYuAm4CdSqkOpVQnsBO42fnchw+l1Cml1AfWcS96H5sCTF1Nwiqv1/qZYH0UsAn4nRV+dj356+93wPUiIlb4M0qpIaXUSaAG/b6eN4hIIXAb8HPrtxBF9WQEyLkpABom/G60wj7q5CqlTlnHHiDXOp6pvj5S9WipD9ahe9emrs7CUsvsB1rRAvI40KX0RnIwuczj9WGd70ZvJHfe1xPwv4FvAD7rdyZRVE9GgBhCRulxsrEHtxCRFOD3wN8ppXomnjN1pVFKjSmlLgIK0b3h8ghnKeoQkduBVqXU+5HOy0wYAXJumoCiCb8LrbCPOi2WugXru9UKn6m+PhL1KCIJaOHxtFLqD1awqasZUEp1Aa+ht7deKCLx1qmJZR6vD+t8GtDO+V9PVwJ3iEgtWnW+CfgxUVRPRoCcm73AcsvywY2enNoa4TxFA1sBv3XQFuCFCeGfsyyMLgO6LfXNS8DHRSTdskL6uBV23mDpm58AjiilfjThlKmrCYhItogstI6TgBvR80WvAZutaGfXk7/+NgOvWiO5rcA9lvVRCbAc2BOeUjiPUuqbSqlCpVQxut15VSn1V0RTPUXawiAWPmhrmWNoPe0/RTo/ESj/b4BTwAhaf/oAWre6C6gGXgEyrLgCPG7V1SFg44R0/ho9gVcD3B/pcjlQT1eh1VMHgf3W51ZTV1PqaS3woVVPFcC/WOFLrYatBvgtkGiFz7N+11jnl05I65+s+qsCbol02Ryss2s5Y4UVNfVkXJkYDAaDISiMCstgMBgMQWEEiMFgMBiCwggQg8FgMASFESAGg8FgCAojQAwGg8EQFEaAGAwOICKZIrLf+nhEpMk69orI/410/gwGOzBmvAaDw4jItwGvUuoHkc6LwWAnZgRiMIQREbl2wr4O3xaRp0TkLRGpE5FPisj3ReSQiOyw3KIgIhtE5A0ReV9EXvK7RTEYIo0RIAZDZLkA7ePoDuDXwGtKqTXAAHCbJUT+D7BZKbUB+AXw3Uhl1mCYSPy5oxgMBgfZrpQaEZFD6M3Ldljhh4BioAxYDezUrraIQ7uVMRgijhEgBkNkGQJQSvlEZESdmZT0od9PASqVUpdHKoMGw0wYFZbBEN1UAdkicjlod/EisirCeTIYACNADIaoRultlDcDj4jIAbSH3ysimyuDQWPMeA0Gg8EQFGYEYjAYDIagMALEYDAYDEFhBIjBYDAYgsIIEIPBYDAEhREgBoPBYAgKI0AMBoPBEBRGgBgMBoMhKP4/Rn2H5wyDs1gAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "proud-container",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 306
+        },
+        "id": "proud-container",
+        "outputId": "5633f081-04ce-43c4-d3d4-dcb8941fade1"
+      },
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "ModuleNotFoundError",
+          "evalue": "ignored",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-1-ffe2c8b74e15>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mbifrost\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bifrost'",
+            "",
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0;32m\nNOTE: If your import is failing due to a missing package, you can\nmanually install dependencies using either !pip or !apt.\n\nTo view examples of installing some common dependencies, click the\n\"Open Examples\" button below.\n\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n"
+          ],
+          "errorDetails": {
+            "actions": [
+              {
+                "action": "open_url",
+                "actionText": "Open Examples",
+                "url": "/notebooks/snippets/importing_libraries.ipynb"
+              }
+            ]
+          }
+        }
+      ],
+      "source": [
+        "import bifrost"
       ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "data = bifrost.ndarray(shape=(16, 4096), dtype='cf32', space='cuda')\n",
-    "bifrost.map(\"a(i,j) = exp(Complex<float>(0.0, 2*3.14*i*j/4096))\",\n",
-    "            {'a': data},\n",
-    "            axis_names=('i', 'j'),\n",
-    "            shape=data.shape)\n",
-    "data2 = data.copy(space='system')\n",
-    "\n",
-    "import pylab\n",
-    "pylab.plot(data2[0,:].real, label='Re0')\n",
-    "#pylab.plot(data2[0,:].imag, label='Im0')\n",
-    "pylab.plot(data2[2,:].real, label='Re2')\n",
-    "#pylab.plot(data2[2,:].imag, label='Im2')\n",
-    "pylab.plot(data2[5,:].real, label='Re5')\n",
-    "#pylab.plot(data2[5,:].imag, label='Im5')\n",
-    "pylab.xlabel('Time')\n",
-    "pylab.ylabel('Value')\n",
-    "pylab.legend(loc=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "soviet-conference",
-   "metadata": {},
-   "source": [
-    "Now run the FFT and plot the results. The FFT is initialised using its `.init` method, and then executed using its `.execute` method.  An output data array also needs to be pre-allocated :"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "moral-worship",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.legend.Legend at 0x7eff6b1b8b38>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZUAAAEGCAYAAACtqQjWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3de3xdZZno8d+T+/1+a5O2aWlJs1sQSy0DIsJwK4hcPQOoHDzwsaLi0WF0ZERndJwz4O0oCsrxwqB8HJBRVHAKLaiAXHsDhKZNk7aBJrRJm3vS3POeP961k500adJk7bX25fl+PvuTvVfWXuvJzt77We/7vOtdYoxBKaWUckOC3wEopZSKHZpUlFJKuUaTilJKKddoUlFKKeUaTSpKKaVck+R3AOFQVFRkKisr/Q5DKaWiyvbt248YY4rns42YTCqVlZVs27bN7zCUUiqqiMhb892Gdn8ppZRyjSYVpZRSrtGkopRSyjUxWVNRSik/DA0N0djYSH9/v9+hHFdaWhoVFRUkJye7vm1NKkop5ZLGxkays7OprKxERPwOZ0rGGFpbW2lsbGTp0qWub1+7v5RSyiX9/f0UFhZGbEIBEBEKCwvD1prSpKKUUi6K5IQSFM4YNako5ZH23kE2vnHQ7zCg9glon/fpCL574/AbvH74db/DUJNoUlHKIxse3ManfrmDlm4fi7hDffDwR+D57/oXg0v+9eV/5asvftXvMCLSk08+SVVVFcuXL+euu+7ydN+aVJTySGN7HwDDIz5eGO/IHjAj0FLjXwwuGBgZoL69nn2d+zg6dNTvcCLKyMgIn/70p3niiSeoqanhoYceoqbGu/+3JhWl4knLrvGfUXzV1z1texg2w4yaUfa07/E7nIiyZcsWli9fzrJly0hJSeG6667j97//vWf71yHFSsWTYAtloAu6miC3wt945qimdfzIe2frTk4rOc3HaKb2tcd3UvNOl6vbDCzM4V8+uOq46zQ1NbFo0aKxxxUVFbzyyiuuxnE82lJRKp4010BC0vj9KFXTVkNuai6FaYUTEozyn7ZUlIonLbtg2XlQ/5RttZx8kd8RzUlNaw2BggBJCUkRm1RmalGES3l5OQcOHBh73NjYSHl5uWf715aKUvGivxO6GmHJWZC9YLy+EmWCRfpAYYBAYYB9nfvoG+7zO6yI8Z73vIe6ujr279/P4OAgDz/8MJdffrln+9eWilLxomW3/Vm6CkoCUTsCrK69jmEzTKDQtlRGzSi1bbURWVfxQ1JSEvfccw8XX3wxIyMj3HTTTaxa5V2rSZOKUvGiZaf9WVJtb1ueh5FhSIyur4Fgd1cwqQSXaVIZd+mll3LppZf6sm/t/lIqXrTsgpQsyF1kWyojA9C+3++oTlhNaw05KTmUZ5VTmlFKQVpBxNZV4pEmFaXiRcsu20IRsT8hKrvAalprCBQGEBFEhEBhgJq26Ps7YpUmFaXigTHQvNO2UACKVwISdcX6wZFB6jrqCBQGxpYFCgPs69hH/3BkX8MkXmhSUSoe9LRAX9t4UknJgIKlUddSqWuvY3h0+JikMmJGqG2v9TEyFaRJRal4EEwewW4vsAkmyk6A3NlqBxuEJpVVhXZkk9ZVIoMmFaXiQbCbq2T8y5iSamjbC0PR020ULNJXZI1PL6PF+siiSUWpeNBSA5nFkFU8vqwkAGbUzlwcJWpaa6gurJ5wkSkRobqwWpOK48CBA5x33nkEAgFWrVrF3Xff7en+NakoFQ9aaiZ2fcF4qyVKivVTFemDAgUB9nbs1WI99uTH73znO9TU1PDyyy9z77336tT3oUQkQUT+j4j8QERu9DsepaLO6Kg9m75k0pdx4UmQkDx+UmSEq+s4tkgftKpwFSNmRKfBBxYsWMCaNWsAyM7Oprq6mqamJs/278uptCJyP3AZ0GKMWR2yfD1wN5AI/NQYcxdwBVABtAKNPoSrVHTrfBuGeo9tqSQmQ9HJUdNSCXZvrSo4dsqRYKKpaa3h1OJTPY1rWk/cDofecHebZafAJbO/kmNDQwOvvvoqZ5xxhrtxHIdfLZUHgPWhC0QkEbgXuAQIANeLSACoAl40xtwGfNLjOJWKfmNF+inmfyoNRFVSyU7JpiL72GvAlGWWkZ+ar3WVED09PVxzzTV873vfIycnx7P9+tJSMcY8JyKVkxavA+qNMfsARORhbCvlADDorDMy3TZFZAOwAWDx4sUuR6xUFGt2ureKq479XUk1vPFf0N8Fad598czFziM7CRQEJhTpg8bOrI+kpHICLQq3DQ0Ncc011/CRj3yEq6++2tN9R1JNpRybQIIanWWPAheLyA+A56Z7sjHmx8aYtcaYtcXFxdOtplT8adkFuYunThpRUqw/XpE+KFBoi/UDIwMeRhZ5jDHcfPPNVFdXc9ttt3m+/0hKKlMyxhw1xtxsjPmMMeZev+NRar48vzJ8cM6vqUTJHGBjRfqi4yeVYTPMnrb4Lta/8MILPPjgg/zpT3/itNNO47TTTmPjxo2e7T+S5rxuAhaFPK5wliml5mpkyJ6HMt0VHnMX25mLI7ylcrwifVBosf6U4lM8iSsSnX322Rjj+aHLmEhqqWwFVojIUhFJAa4DHvM5JqVcd2xFIIxa62F06NjhxEEJCXZyyQhvqRyvSB+0IHMBeal5OmOxz3xJKiLyEPASUCUijSJyszFmGLgV2ATsAh4xxkTHAHqlItVUc35NVlJt1/Px6HYmwWvST1WkD4rIYn0c8iWpGGOuN8YsMMYkG2MqjDE/c5ZvNMacbIw5yRjzf/yITalw8/Sru2UXSKI9H2U6JQE42gq9h72L6wQMjQxR1378In1QoDBAfXt93Bfr/RRJ3V9KKbe17ILC5ZCUOv06pcERYJF5hF/XUcfQ6NCsk8qwGaauvc6DyNRUNKko5TFPayrNO4/f9QURP6w49Jr0Mwkt1it/aFJRKlYN9kJ7w/RF+qDMYsgoHD9JMsLUtNaQnZzNouxFM667MHMhuam5mlR8FElDipWKC57VVA7X2r3N1FIRsYknglsqk6e7n46IECjQYn1lZSXZ2dkkJiaSlJTEtm3bPNu3tlSUilXBGknp9Od2jCkJwOHddkbjCDI0MsSe9j2z6voKChQGqOuoY3BkcOaVY9if//xnXnvtNU8TCmhSUcpzntVUWnZBUhrkV868bkk1DPZA54GZ1/VQfUf9rIv0QYHCAMOjWqz3i3Z/KRWrWmrsJJIJiTOvWxIyAix/SXjjOgEnUqQPCq67s3Unq4pm0UoLk29s+Qa723a7us2VBSv54rovzrieiHDRRRchInziE59gw4YNrsZxPJpUlIpVLbtg2XmzW7dkpfOcGqi6JHwxnaCa1hqykrNmVaQPKs8qJyclJ67rKs8//zzl5eW0tLRw4YUXsnLlSs455xxP9q1JRalYdLQNug/OXKQPSsuF3EURV6wPFukTZPY99ZFyZv1sWhThUl5eDkBJSQlXXXUVW7Zs8SypaE1FqVg0dmGu2Xcb2elaIiepDI06RfqCE/gbHPFcrO/t7aW7u3vs/ubNm1m9evUMz3KPtlSUikWzmfNrspJq2PtnO7NxYnJ44joBezv2Mjg6eEL1lKCxYn1HHasK/aur+KG5uZmrrroKgOHhYT784Q+zfv36GZ7lHk0qSsWill22Sytn4eyfUxKwMxq37h2vsfhoLkX6oNAz6+MtqSxbtozXX3/dt/1r95dSsailxiaJWZwwOKYksuYAq2mtITM5k8U5J3558Iqsirgv1vtFk4pSscYYJ6mcQNcX2JmMJSFi6io1rTVUF5xYkT5IRKgurNak4gNNKkp5LOzTtHQfhP7OEyvSAySnQcFJEdFSGRodoratdl5dV4HCAHXtdQyNDLkY2cz8vOribIUzRk0qSsWasSL9idcixi7Y5bP5FOmDAoUBhkaHqOvw7sz6tLQ0WltbIzqxGGNobW0lLS0tLNvXQr1SHgv7NC3Ncxj5FVS6CnY9DoNHISXD3bhOwHyK9EHB69nXtNbMazsnoqKigsbGRg4fjswLngWlpaVRUTH9pZnnQ5OKUrGmZRdklUFGwYk/t6QaMHCkFha+2/XQZms+RfqgiuwKslOyPa2rJCcns3TpUs/2F4m0+0spj4W9Y2QuRfqgYJdZs79dYPMp0gfpNPj+0KSiVCwZHbHXUZnNdPdTyV8Kiam+1lWCRXo3uqwChQH2tO/xvFgfzzSpKOWxsNZU2htguG/uLZXEJDuzsY/Divd17Jt3kT4oWKyv76h3ITI1G5pUlIolc5meZTKfrwLpRpE+SK9Z772oSCoikiki20TkMr9jUWq+wlpTadkFCBTPY5qVkmrofgf62l0L60TsbN1JZnImS3Lmf12XRdmLyE72tlgf73xJKiJyv4i0iMibk5avF5FaEakXkdtDfvVF4BFvo1QqCrXU2Cs9pmTOfRtj07X401rZ1bqLlQUr51WkD9Iz673nV0vlAWDCtJkikgjcC1wCBIDrRSQgIhcCNUCL10EqFQ5hrak018ztpMdQpf7NATY8OkxtuztF+qCxYv2oFuu94EtSMcY8B7RNWrwOqDfG7DPGDAIPA1cA5wJ/A3wY+LjI1IcvIrLB6SLbFuknHikVFsMD0Fo/v3oKQE45pOb40lLZ27GXgZEB15PK4Oggezv2urZNNb1IqqmUAwdCHjcC5caYO4wxnwP+E/iJMWZ0qicbY35sjFlrjFlbXFzsQbhKzU3YaipH6sCMzD+piPh2wS43i/RBWqz3ViQlleMyxjxgjPmD33EoFbGCSWCu56iEKqmG5p12xmMP1bTWkJGUQWVOpWvbXJS9iKzkLE0qHomkpNIELAp5XOEsUyqmhK2m0rITEpLtTMPzVbIK+jug+9D8t3UCatpqXCvSByVIghbrPRRJSWUrsEJElopICnAd8JjPMSnlurAd+7fsgqIVkJQy/20Fu9A8LNYPjw6zp21PWCZ/DBQEqG2r1WK9B/waUvwQ8BJQJSKNInKzMWYYuBXYBOwCHjHG7PQjPqWi0nzm/JpsLKl4V1fZ17mP/pH+8CQVp1i/r2Of69tWE/kyS7Ex5vpplm8ENnocjlLRb6AbOt6GNTe6s73MIsgs8bSlEuyeCsc15UOL9VUFVa5vX42LpO4vpdRctey2P+d7jkqo0oDnSSU9Kd2VM+knW5yzmMzkTHa2audHuGlSUcpjYbkqoBtzfk1WErDJanTKUfyuC053n5iQ6Pq2EySB6oJqdrX6N6dZvNCkolQsaNkFyZmQ5+JRfkm1nfG4o8G9bU5jeHTYtenupxMoDFDbXsvw6HDY9qE0qSgVG1pqoGQlJLj4kfbwgl3hLNIHBQoDDIwM6Jn1YaZJRalY4ObIr6DgTMcejAALZ5E+SM+s94YmFaU85npJpecw9B52t0gPkJplu9M8KNaHs0gftCRnCZnJmZpUwkyTilLR7rDTknC7pQKeXbArnEX6oARJYGXBSmraNKmEkyYVpaJd8Eu/JAxdRyXV0FoHw4Pub9vhRZE+KFAYYE/bHi3Wh5EmFaWiXfNOSC+ArBL3t126CkaHbWIJk/2d+8NepA8KFAboH+lnX6eeWR8umlSUinYtu2w3lYRhqkoPpmsJx3T309FiffhpUlEqmhnjJJUw1FMACldAQlJYi/XBIr2b091PpzKnkoykDE0qYaRJRalo1tkIg93jlwB2W1IKFC4P67kqNa12uvtwFumDxor1mlTCRpOKUtFsbHqWMHYdlYRvDrCR0RHXr0k/k0ChnQZfi/XhoUlFKY+5ep5K8Ms+eKJiOJQEoOMtGOhxfdP7O/fTN9zneVLpH+lnf+d+z/YZTzSpKBXNWnZBTgWk54VvH8F6zeFa1zcdPGckUOBdUgmeta9dYOGhSUWpaNYchulZJhsbAeb+tPHBIv3S3KWub3s6S3KWkJ6UrkklTDSpKOUx49YFhUeG4Uht+JNK/lJISg/LsOKa1hqq8qs8KdIHJSYkUl2g16wPF00qSnnE9bNI2vbByGB4i/RgZz4uWel6sX5kdITdbbs9racEBafBHxkd8XzfsU6TilIecf3SXMEv+XANJw4VhjnAGroaPC/SBwUKA/QN92mxPgw0qSgVrVpqQBKg6OTw76skAD3N0Nvq2ia9PJN+srEz63VySddpUlHKY64NKW6pgYJlkJzu0gaPY6xY796XsB9F+qDKnEot1oeJJhWlPOJ6TSWc07NMFqzbuNgFFizSJyUkubbN2UpMSNQz68Mk4pOKiFwpIj8RkV+JyEV+x6PUXLlaUxnqs4X6cEx3P5XsMkjLc62lMjI6wq62Xb50fQUFCgPsbtutxXqX+ZJUROR+EWkRkTcnLV8vIrUiUi8itwMYY35njPk4cAtwrR/xKhVxDteCGfWupSJip8F3Kan4WaQPChbrG7oafIshFvnVUnkAWB+6QEQSgXuBS4AAcL2IhL7jvuz8Xqmo5kqLZezCXB5+KZdU2/26UBR6+eDLgD9F+qDgWfzbm7f7FkMs8iWpGGOeA9omLV4H1Btj9hljBoGHgSvE+gbwhDFmh9exKhWRWmogMdUW6r1SUg0DXdDVNOdNHOw5yOef/Tx3bbmL5XnLfSnSBy3NXcri7MX828v/xtde+hpt/ZO/ktRcRFJNpRw4EPK40Vn2GeAC4EMicst0TxaRDSKyTUS2HT58OLyRKuW3ll1QfDIkeljknkexvn+4nx+99iMu/93lPHPgGT71rk/xnx/4T1+K9EGJCYk8dNlD3BC4gd/V/Y7LHr2MB2seZGh0yLeYYkEkJZUpGWO+b4w53RhzizHmvuOs92NjzFpjzNri4mIvQ1TKey013nZ9wZyGFRtj2Nywmct/dzk/fP2HvH/R+3n8ysf55GmfJD3Jg6HQM8hJyeEL7/kCv7niN5xacirf3PpNrnnsGl5oesHv0KLWjElFRBJFZLcHsTQBi0IeVzjLlIopZr41ib4O2wXlVZE+KD0fshfO+oJde9r3cPPmm/mHZ/+B7JRs7r/4fr79/m+zIGtBmAM9cctyl/Gj83/Eveffy6gZ5Zanb+Ezf/wMb3W95XdoUWfGtqcxZsQZkbXYGPN2GGPZCqwQkaXYZHId8OEw7k+p6HTYOcbzuqUCTrH++Emlc6CTe169h0f2PEJ2SjZfPuPLXHPyNb52dc2GiHBOxTmcueBMfrnrl9z31/u48vdXckPgBjacsoGslCy/Q4wKs/0v5wM7RWQL0BtcaIy5fC47FZGHgHOBIhFpBP7FGPMzEbkV2AQkAvcbY9yfa1upaOfF1R6nU1INW56H0RGYNLPw8Ogwv97za+557R56Bnu4tupaPn3ap8lNzfU+znlITkzmY6s/xmUnXcbdO+7mP978Dx7f+zifXfNZLj/pchIk4qsGvpptUvmKmzs1xlw/zfKNwEY396VUpJn3gNzmGkjJhtwKN8I5MaWrYGQA2vZD0fKxxVsPbeXOLXdS117HGWVn8MV1X2RF/grv43NRUXoRX3/v17m26lru2nIXX3nhK/xq96+4/YzbeVfxu/wOL2LNKuUaY54FGoBk5/5WQIf3KnUCXJumJTg9i7g+8cvMJl2w652ed7jtmdu4adNNHB06ynfP/S4/uegnUZ9QQq0uWs2DlzzIv5/977QcbeGjGz/Kl/7yJVqOtvgdWkSaVUtFRD4ObAAKgJOwQ33vA84PX2hKxRZXTno0xnZ/VX/Qja2duKIqQOg79Ab/MdjE/W/ejyB8+rRP87FVHyMtKc2fuMJMRPjgSR/k/MXn89M3fsoDOx/g6befZsOpG7ghcAOpial+hxgxZtv99WnsyYmvABhj6kSkJGxRKaWm1tMCfW22G8oH9b3v8OSCxfyu8VGaDwxxSeUl3Lb2Nsoyy3yJx2sZyRn87zX/m6tWXMW3t36bu3fcza/3/JqrV1zN+sr1LM5Z7HeIvpttUhkwxgyK09wWkSTCcM0hpeLBvEYUB68T7+Fw4obOBp5seJJNDZuo76gnIQ3eMzTCNy57gNNLT/csjkiyKHsRd//t3bz0zkvc9/p9/ODVH/CDV39AdUE165eu5+LKiynPKvc7TF/MNqk8KyJfAtJF5ELgU8Dj4QtLqdjjSgXEozm/Grsb2dSwiScbnmR3mx3CvKZkDV8640tceKCGohfvhQJ/WkuR5MyFZ3LmwjM51HuITQ2b2NSwie9u/y7f3f5dTi06lYsrL+aiyovipiUHs08qtwM3A28An8CO0PppuIJSKhbNu2k/1A/7noHMYsgsciGiiUK/GN848gYApxadyhfWfmHiF+Pwo2BGbCxV66ffYBwpyyzjxlU3cuOqG8cS8qaGTXxr27f41rZvsaZkzViCKUp3/38XSWQ2Z/eKyPnAi8aYvvCHNH9r164127Zt8zsMpSY4884/crCzn6dvez/LS07gRDpjYPcfYNMd0PEWvPezcOG/uhLTkb4jbG7YzJMNT/Jqy6sAM3fh9ByG//c+6D4I7/owXPAv9nor6hgNnQ1jLb76jnoSJIG1pWu5uPJiLlhyAQVpBX6HOIGIbDfGrJ3XNmaZVH4OnImdWfgvwHPA88aY9vnsPFw0qahINJ5UzmF5SfbsntSyG578om0VFFfDJXfBsnPnFUdbfxtPv/U0mxo2sa15G6NmlOV5y1lfuZ71S9ezJGfJzBsZ6IbnvgUv/RCSUuGcL8DffNLeV1Oqb68fq001dDWQKImsK1vH+qXrOX/x+RFxkqhnSSVkhwuBDwGfBxYaYyJy3gVNKioSnXXnH3lntkmlrx2euQu2/ARSs+C8O2DtzXOalbi5t5kdLTvY3ryd7c3bqe+oB+x12tcvXc/6yvWclHfSXP4kaN1rW1B7nrDT8F/873Dyen/OoYkSxhhq22t5cv+TPNnwJE09TQhCVUEVp5eezpqSNawpXeNLN5mXLZWPAu8DTgGOAM8DfzHGvDSfnYeLJhUViWbVUhkdgR0/hz9+Hfo74PSPwXlfhszCWe3DGENjdyPbmrexvXk7O1p2cKDbXlEiIymDd5e8mzWlazin4hyq8qsQt77865+GJ/8JjuyBk86H9XfZqfnVcRlj2Nm6k+can2NH8w5eP/w6/SP9gE36p5eePnZbmLUw7PG4kVRme9jzPWAv9oTHPxtjGuazU6XUFBpesF1dh96AJe+1X8wLTj3uU0bNKHs79rKjebwl0tJnz/TOTc3l9JLTubbqWtaWrqWqoCp8kzouvwA++X7bsnrmLvjRmbDuE/D+f4T0vPDsMwaICKuLVrO6aDUAQyND7GzdOday3Nywmd/U/QaABZkLJiSZypxK9w4KXDTr7i8RWQWcA5wNrABqjTE3hDG2OdOWiopEwZbKU39/DitKQ1oqHQfgqa/Azt9CTgVc9HVYddWUXUjDo8PUttVOaIl0DnQCUJJeMuFLZ1neMn8mP+w5DH/6Ouz4BWQUwvlfgXffcMwElGpmI6Mj1HXUjR0wbG/ePnaFyoK0ggn/7xV5K0ic52vsWUtFRHKAxcASoBLIBUbns2Ol4s0xKWKoD174Pjz/XcDA+2+3I7tSMgDoGexhT/sedrftpra9lt1tu6lvr2dwdBCwJ+Cdt+i8sS+ViqyKyDhyzSqGy78Pa2+CJ74Ij38Wtv4MLvkmLDnT7+iiSmJCIisLVrKyYCUfqf4IxhgauhomtEyfeuspANIS0zg5/2SqCqpYWbCSqoIqVuStICM5w9OYZ1tT+Su2jvI88JwxpjHcgc2HtlRUJBprqXzufaxo/RNs/gp0vo2pvoLmcz5H7XD3hAQSrIUA5KXmjX25BAoDnF56OiUZUTBTkjHw5m/gqX+2FxZb/SE7HDo3Ps82D4eDPQfZ1ryNmtaasfdO92A3AIKwJGfJWJKpyrcJpyi9aMoDED9Gf2UBGGN65rPTcNOkoiLRmXf+kZyuXXx72W9p6KihNn8hu4uXUtvXTMdAx9h6i7MXjx1trixYSVV+FSUZJZHRCpmrwV54/nvwwt22G+zs2+CsWyHZ/0sKxxpjDAd7D9oDlLbasQOVpp7xC+kWpBWMJZqV+fbnkpwlJCcmezb6azXwIHaWYgEOAzcaY96cz87DRZOK8lv3YDcNnQ00dDWwv62WhqZXqDlcx+GkYQYTbHJISUhhRf6K8Q93wUpOzj+ZzORMn6MPo/a3YPOXYddjkL0AVl8Dq6+GhWt0GHKYdQ12sadtz1hrpratlrqOOoZHhwFITUxl+w3bPUsqLwJ3GGP+7Dw+F/h3Y8xZ89l5uGhSUV4YGR3hnZ532N+1n/2d+2noahhLJEf6joytl2gMFcPDlA0l0D9Qxnln3cj7V7yXytzKiL/Ebtjsfw5evAf2/glGhyC/0g5OWHU1lJ2iCcYjQyND7OvcR217LbVttfzjun/0LKm8box510zLIoUmFeWWkdERDvcdprG7kcaeRt7qessmkM4G3u5+m6HRobF181JzqUzOpbKvl8q2t1naf5TK5FwWVV1O8in/g7Me7OSdrkE2//05nFw6yzPqY11fO+z6A+x8FPY9a+cUK1xhWy+rroaSlX5HGFe8PE9ln4h8BdsFBvBRYN98dqxUJDDG0DHQQVNPE409jTR1N9HUY2+N3Y280/vOWPcAQJIksShnEZU5lZyz6ByWZlVQ2d1KZcMr5O95CgZ7IKMIAlfaL8bFZ44NpTXyR2efvvypkSk9H9bcYG+9R2y32JuPwrPfhGe/YWdjXnW1fS0L53jWv/LUbJPKTcDXgEexk63+xVmmVEQzxtA91M2h3kO80/POWLIITSJHh49OeE5+aj7lWeVUF1ZzwZILKM8qpyKrgvLschZmLSTZYI+qdz4Ku74HA52Qlme7b1ZfA5Xvm3I6Fe3QmUFmkR2GvPYm6G6Gmt/b1/jP/2ZvZaeOt2DyZzE/mfLFcZOKiKQBtwDLsdPe/4MxZuh4z1HKSz2DPRzqPUTz0WYO9R7i0NFD9nFv89j9vuGJk2unJ6WPJYp1Zesozyofu1VkV0xdKB/qhwMvw7P/F2oes1dfTM2BlR+wX3LLzoWklOPGqg2UE5BdCmdssLfORtj5O5tgnv6qvZWfbl/3lR+w9RitwUSMmVoqPweGsC2TS4Bq4HPhDkqpYLdUy9EWjvQdoeVoy8Tk4dzvGZo4ujRpAXcAABabSURBVF0QitKLKMssY3nect678L2UZZZRmlnKwsyFlGeVU5BWMPPw3IFuOPAKvPWivTVth5FBSM601xBZdbWdmiQ5Nq/JHlFyK+zw47NuhfYGO/PAm4/C5jvsLafcdjMuOctOb1NcpUnGRzMllYAx5hQAEfkZsCX8IalYNmpGaetv40jfEQ4fPczhvsMTfh7pO0JLn00kobWMoMK0Qsoyy6jMreSMBWdQlllmk0ZGKWWZZRRnFJOckHzigfW2wtsv2dtbL8DB18GMgiTCwtNg3Qb7hbXs3LEz3ufKaJtl7vIr4ey/t7fWvXb02NsvQcPz8Oav7ToZhSFJ5iwoPWVOszuruZnplR7r6jLGDPtx8pWIZAI/BAaBZ4wxv/Q8CHVco2aUroEu2vrbaO1vtbc+ewsuCyaOtr42hs2xySI3NZfi9GKK04tZl7uOovQiSjJKKEovsssziinNKCUl8fhdTLPW9c54K+StF+Gwc5nexFSoWAvv+wf7hVSxzk497wI9dnZZ4Un2tu7jdvRD+/6J/9Pdf7DrpWTD4jPs/3PxWVC+Rq/7EkYzJZV3iUiXc1+w16jvcu4bY0zOXHYqIvcDlwEtxpjVIcvXA3cDicBPjTF3AVcDvzbGPC4ivwI0qXhgYGSA9v522vvbxxJDW1/bWMIIXdbWP3WiSJAE8lPzKUwvpDi9mBX5KyhOL56YMDLs49TEMH7IR0ehbZ+tibz1om2JtDfY36VkwaIz4JQP2ZZIGL9wtH0SRiL2ei4Fy+DdH7XLQg8c3n4J/uhcLTMxFSre47RkzrQnXupMyq45blIxxoRrWtEHgHuAXwQXiEgicC9wIdAIbBWRx4AK7CABgJEwxRPTRs0o3YPdNkkMtI8li+D9joEO2vrb6OjvGFs2eURUUEpCCoXphRSmFVKaUUp1QfXY44K0gvH76QXkpeZ5P0vu4FFo2QWH/mqnkD/0BjTvhKFe+/v0Avtlsm6D7SIpO1W7RmJVzkJ7sHDKh+zjo21O96ZzYPGX78BzzldK3mL7Xig7ZfyWu0hrM3Pgy6fJGPOciFROWrwOqDfG7AMQkYeBK7AJpgJ4DZj2G0pENgAbABYvXux+0BFicGSQjoEOOgY66BzopHOg85j7oY/bB9rpHOhkxEydj9OT0slLzSM/LZ/81HwqcyvJS82jIK2AvLS8sZZGMGlkJmdGzhxUPYcnJo9Db0Brna2FgO32KDvFHrmWrbZHp0VVkODDdPAh9DwVn2QU2NFiKz9gHw90Q+NWWz8Lvn92/zdjbcq0XJtoSlePJ5rilTOO8ot3kXSIVg4cCHncCJwBfB+4R0Q+ADw+3ZONMT8Gfgz2jPowxjlvxhh6h3rpGuyic6CTrsEuexvoonOwk66BrrHfdQ5OTByTh8eGSklIIS81j9y0XPJS81iau5R3p72b/NR88tPyJySLglT7Mz0pCib0Gx2Btv3HJpCeQ+Pr5C6yH/pVV45/CeQt8T2BhIqQVKyCUrPhpL+1t6DB3mNbujt+DkNOyz0h2SaW0BZN2Wp7EqcCIiupTMkY0wv8L7/jmGxoZIjuoW66B+2ta7CLnsGeCY+DiSJ4P5hAuge7p205gD1rOyc1h5yUHPJS8yjNKOXk/JPJS82zSSM1l9zU3LH7wZ9piWmR04qYi74OaK2HI3W2xXHEubXtg5EBu05Ckv1Qn3Te+Ie6dLU9Co1wEX2ko6yUTDtQoyJkppKpDmr2/gle/8/xdTJLoGgFFC53fq6wP/OWxF33aiT9tU3AopDHFc4y142aUY4OHaVnyCaBsZ+DPfQM9Yw9nipZdA920z3UfdwWA0CiJJKdkk1uai45KTZBVGRVjCWL0OWTl6UnpUd3cjiekWHoeGti4mitt9c27z08vp4kQsFS++FcccH40WHxSh25o7yVkAhFy+1t9dXjy3tanJrdm+MHQLv/AEdbQ56bbAcPTJVwouBAaC4iKalsBVaIyFJsMrkO+PBcNtR8tJmvv/R1uofGE0UwefQM9tA71DvjuQLBpBB6K84otveTJy7PSck55nFMJ4aZjAxB5wE7zXnHW/YoL9gCadtnZ6UNyii0H7KTLx7/sBWdbM9HSJzD+SZRQGsqMSKrBJafb2+hjraNHyiNHTTVwZ5NE9/76QXjSabwJPuez18CeZU24UTp94cvSUVEHgLOBYpEpBH4F2PMz0TkVmATdkjx/caYnXPZfmtfK0+//TRZyVlkpWSRnZzN4uzF9n5KNlnJ9mdmcubY74M/M5MzyU7Jju+kMJPRUehptgkjmDjaG8bvdzWNF8th4tFa1SXjiaNwecwerU1F301xIqMAMtbBonUTl0/XSq/bDK+1TFw3Jct2neUvcX5WhtxfYrvpIpRfo7+un2b5RmDjfLcfKAzw7LXPzncz8SuYNLqa7LxLHW/bpDGWRN4er3EEZS+wb/glZ036MCyx02gkhGt0evTQBkqcS0waP2GT9RN/1981xefMaeXve2Z8oEBQRtHEz1h+pR2sklthh1Kn+ndphUjq/lJeMMZOMd7VCJ1N44mjq8meLNbZBN3vwOQpUtLy7Ju3pNrOfRU8espbYsf46xxYs6bTtKhjpOXYUWRlq4/9XfAzG+wRCE0677xqLxcw+fOamgu55TbB5JSPJ5vQ+2Fq7WhSiSXDA7aF0d1sh9t2H7KJoqvJSSCN9vHI4MTnJaY4b7gKe4ZxTrnzhnTefHmL9YxjF2j3l5oTEcgqtreKKa6fNTriHBAecH42hnzmm+x5OKGDYILS8pwE4ySf3HJXwtWkEg0Gj44nie5DTuII+dl9yP6+r/3Y5yYkQbbzhilfC9ULx99IwcSRWRS1RUGl4l5CIuQtsrfpDPVD98FjDzCD95u2TRy1Ng+aVPwy2GuHJPYegd4WeyTRc3ji/Z5mexvoOvb5CcmQVWqvO1F4kq1lZJc5y8qc+2U2YWg9IyJop5fyTXKaHaJfsHT6dYb64Gvzm4EbNKm4Z2TIDiU82gpHjzjJwkkYockjeD84F9Vkqbm2mZtZDKUBe7ZvdqlNEKHJIj0/os4WV7OnQ4pVREp2Z3YNTSpTMcZea7z3iJMojthk0XtkPGkcbZv4uL9z6m1Jgj0XI7PEthoWrRu/n1Uy8X5GkRa8Y5h2MKp4EPtJZXjQXvr1aJutOUx7v33i8snF7KCEZJsEMgrtbcG7Jj7OKBx/nFlix6xr95NSKk7EZlI5XAvfXW2TxHTdTGBHPaUX2C/+9HxbmwjezyialCQK7LLUbC1qqznRXi8VD2IzqSQmQ+XZTsLIt0kiNHkE7ydnaIJQSikXxWZSKVgGV93ndxRKTaCHLyoe6PAhpTyi3V8qHmhSUUop5RpNKkp5TM9TUbFMk4pSHtGaiooHmlSU8og2UFQ80KSilFLKNZpUlPKYXk9FxTJNKkp5RGsqKh5oUlHKI9o+UfFAk4pSHtMhxSqWaVJRyiPa/aXigSYVpZRSromKCSVF5ErgA0AO8DNjzGafQ1LqhGmvl4oHYW+piMj9ItIiIm9OWr5eRGpFpF5Ebj/eNowxvzPGfBy4Bbg2nPEqFW6aXFQs86Kl8gBwD/CL4AIRSQTuBS4EGoGtIvIYkAjcOen5NxljWpz7X3aep1TU0ZqKigdhTyrGmOdEpHLS4nVAvTFmH4CIPAxcYYy5E7hs8jZERIC7gCeMMTum2o+IbAA2ACxevNi1+JVSSs2eX4X6cuBAyONGZ9l0PgNcAHxIRG6ZagVjzI+NMWuNMWuLi4vdi1Qpl2i3l4oHUVGoN8Z8H/i+33Eo5QajJ6qoGOZXS6UJWBTyuMJZplTM0pqKigd+JZWtwAoRWSoiKcB1wGM+xaKUUsolXgwpfgh4CagSkUYRudkYMwzcCmwCdgGPGGN2hjsWpfyknV4qHngx+uv6aZZvBDaGe/9KRRpNLiqW6TQtSnlEayoqHmhSUcoj2kJR8UCTilIe0xHFKpZpUlHKI9r9peKBJhWllFKu0aSilEe010vFA00qSnlO04uKXZpUlPKI1lRUPNCkopRSyjWaVJTyiHZ6qXigSUUpj+l5KiqWaVJRyiNaU1HxQJOKUkop12hSUcoj2uul4oEmFaU8pslFxTJNKkp5RGsqKh5oUlFKKeUaTSpKeUS7vVQ80KSilMf0PBUVyzSpKOURramoeKBJRSmllGs0qSjlMaP9XyqGaVJRSinlmqhIKiKSKSLbROQyv2NRSik1vbAmFRG5X0RaROTNScvXi0itiNSLyO2z2NQXgUfCE6VSSim3JIV5+w8A9wC/CC4QkUTgXuBCoBHYKiKPAYnAnZOefxPwLqAGSAtzrEp5QisqKpaFNakYY54TkcpJi9cB9caYfQAi8jBwhTHmTuCY7i0RORfIBAJAn4hsNMaMTrHeBmADwOLFi138K5RSSs1WuFsqUykHDoQ8bgTOmG5lY8wdACLyMeDIVAnFWe/HwI8B1q5dqweDSinlAz+SypwYYx7wOwal5kOPdFQ88GP0VxOwKORxhbNMqbigp6moWOZHUtkKrBCRpSKSAlwHPOZDHEp5SqdpUfEg3EOKHwJeAqpEpFFEbjbGDAO3ApuAXcAjxpid4YxDKaWUN8I9+uv6aZZvBDaGc99KRRrt9VLxICrOqFcqlhhNLyqGaVJRyiNaU1HxQJOKUkop12hSUcpr2vulYpgmFaWUUq7RpKKUUso1mlSUUkq5RpOKUh7TkoqKZZpUlFJKuUaTilJKKddoUlFKKeUaTSpKeUynvlexTJOKUkop12hSUUop5RpNKkoppVyjSUUpj+nU9yqWaVJRSinlGk0qSimlXKNJRSmP6ZBiFcvExOA7XES6gVq/45iFIuCI30HMQjTEGQ0xgsbpNo3TXVXGmOz5bCDJrUgiTK0xZq3fQcxERLZpnO6IhhhB43SbxukuEdk2321o95dSSinXaFJRSinlmlhNKj/2O4BZ0jjdEw0xgsbpNo3TXfOOMyYL9UoppfwRqy0VpZRSPtCkopRSyjVRm1RE5H+IyE4RGRWRtZN+908iUi8itSJy8TTPXyoirzjr/UpEUjyI+Vci8ppzaxCR16ZZr0FE3nDWm/cQvznE+VURaQqJ9dJp1lvvvMb1InK7xzF+S0R2i8hfReS3IpI3zXq+vJYzvTYikuq8H+qd92GlV7GFxLBIRP4sIjXOZ+mzU6xzroh0hrwX/tnrOJ04jvt/FOv7zuv5VxFZ40OMVSGv02si0iUin5u0ji+vp4jcLyItIvJmyLICEXlKROqcn/nTPPdGZ506Eblxxp0ZY6LyBlQDVcAzwNqQ5QHgdSAVWArsBRKneP4jwHXO/fuAT3oc/3eAf57mdw1AkY+v7VeBz8+wTqLz2i4DUpzXPOBhjBcBSc79bwDfiJTXcjavDfAp4D7n/nXAr3z4Py8A1jj3s4E9U8R5LvAHr2M70f8jcCnwBCDA3wCv+BxvInAIWBIJrydwDrAGeDNk2TeB2537t0/1GQIKgH3Oz3znfv7x9hW1LRVjzC5jzFRnzV8BPGyMGTDG7AfqgXWhK4iIAH8L/NpZ9HPgynDGO8X+/w54yKt9hsE6oN4Ys88YMwg8jH3tPWGM2WyMGXYevgxUeLXvWZjNa3MF9n0H9n14vvO+8Iwx5qAxZodzvxvYBZR7GYOLrgB+YayXgTwRWeBjPOcDe40xb/kYwxhjzHNA26TFoe/B6b4DLwaeMsa0GWPagaeA9cfbV9QmleMoBw6EPG7k2A9KIdAR8qU01Trh9D6g2RhTN83vDbBZRLaLyAYP4wp1q9ONcP80zeLZvM5euQl7lDoVP17L2bw2Y+s478NO7PvSF07327uBV6b49Zki8rqIPCEiqzwNbNxM/8dIej+CbX1Od9AYCa8nQKkx5qBz/xBQOsU6J/y6RvQ0LSLyNFA2xa/uMMb83ut4ZmOWMV/P8VspZxtjmkSkBHhKRHY7RxqexAn8CPg69oP8dWxX3U1u7n82ZvNaisgdwDDwy2k2E/bXMtqJSBbwG+BzxpiuSb/ege3C6XFqa78DVngdI1H0f3Tqs5cD/zTFryPl9ZzAGGNExJXzSyI6qRhjLpjD05qARSGPK5xloVqxzeMk5yhxqnXmZKaYRSQJuBo4/TjbaHJ+tojIb7HdKa5+gGb72orIT4A/TPGr2bzO8zKL1/JjwGXA+cbpAJ5iG2F/Lacwm9cmuE6j857Ixb4vPSUiydiE8ktjzKOTfx+aZIwxG0XkhyJSZIzxdHLEWfwfw/5+PAGXADuMMc2TfxEpr6ejWUQWGGMOOl2FLVOs04StAwVVYOvY04rF7q/HgOuc0TVLsUcBW0JXcL6A/gx8yFl0I+BVy+cCYLcxpnGqX4pIpohkB+9jC9JvTrVuuEzqi75qmv1vBVaIHUWXgm3uP+ZFfGBHVwH/CFxujDk6zTp+vZazeW0ew77vwL4P/zRdYgwXp4bzM2CXMeb/TrNOWbDWIyLrsN8Znia/Wf4fHwP+pzMK7G+AzpCuHa9N2xMRCa9niND34HTfgZuAi0Qk3+kGv8hZNj2vRyG4dcN+2TUCA0AzsCnkd3dgR9/UApeELN8ILHTuL8Mmm3rgv4BUj+J+ALhl0rKFwMaQuF53bjuxXT1ev7YPAm8Af3XeeAsmx+k8vhQ7Ymiv13E6/7cDwGvO7b7JMfr5Wk712gD/ik2CAGnO+67eeR8u8+H/fDa2i/OvIa/jpcAtwfcocKvz2r2OHRBxlg9xTvl/nBSnAPc6r/cbhIwI9TjWTGySyA1Z5vvriU1yB4Eh53vzZmwN749AHfA0UOCsuxb4achzb3Lep/XA/5ppXzpNi1JKKdfEYveXUkopn2hSUUop5RpNKkoppVyjSUUppZRrNKkopZRyTUSf/KiUl0RkBDscNehKY0yDT+EoFZV0SLFSDhHpMcZkTfM7wX5eRj0OS6moot1fSk1DRCrFXhPlF9gzuBeJyBdEZKsz2ebXQta9Q0T2iMjzIvKQiHzeWf6MONf7EZEiEWlw7ieKvSZMcFufcJaf6zzn12KvF/PLkDOw3yMiLzqTEW4RkWwReU5ETguJ43kReZdnL5JSk2j3l1Lj0mX8wmn7gb/HTvNzozHmZRG5yHm8DnsG92Micg7Qi52K5TTsZ2oHsH2Gfd2MnUrkPSKSCrwgIpud370bWAW8A7wAvFdEtgC/Aq41xmwVkRygDzvNyseAz4nIyUCaMeb1+b4QSs2VJhWlxvUZY0KP+iuBt4y9PgfYeY8uAl51Hmdhk0w28FvjzEEmIrOZA+0i4FQRCc4/l+tsaxDYYpy54ZwkV4mdGv+gMWYrjE9MKCL/BXxFRL6AnU7jgRP9o5VykyYVpY6vN+S+AHcaY/5f6Aoy6ZKxkwwz3s2cNmlbnzHGTJicT0TOxc5nFzTCcT6nxpijIvIU9oJLf8dxZr9WygtaU1Fq9jYBNznXH0FEyp3rezwHXCki6c5suh8MeU4D41/0H5q0rU86U88jIic7M/BOpxZYICLvcdbPdqbMB/gp8H1gq7FX51PKN9pSUWqWjDGbRaQaeMmpnfcAHzXG7BCRX2Fnnm3BTn0f9G3gEbFXK/zvkOU/xXZr7XAK8Yc5ziWtjTGDInIt8AMRScfWUy4Aeowx20WkC/gPl/5UpeZMhxQr5TIR+Sr2y/7bHu1vIfbCSSt1yLPym3Z/KRXFROR/Yq8rf4cmFBUJtKWilFLKNdpSUUop5RpNKkoppVyjSUUppZRrNKkopZRyjSYVpZRSrvn/+UurlXGAKb8AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+      "cell_type": "markdown",
+      "id": "rental-equipment",
+      "metadata": {
+        "id": "rental-equipment"
+      },
+      "source": [
+        "This loads the core parts of Bifrost and several useful functions.  The main way of interacting with Bifrost is through the `bifrost.ndarray`, a sub-class of `numpy.ndarray`.  You can create an empty array with:"
       ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "subject-quebec",
+      "metadata": {
+        "id": "subject-quebec",
+        "outputId": "7d9ff2dd-dfea-4cc1-9a68-efe5aa914dde"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) system\n",
+            "[[1.9045215e+31 1.6631021e+22 2.7229835e+20 ... 0.0000000e+00\n",
+            "  0.0000000e+00 0.0000000e+00]\n",
+            " [0.0000000e+00 0.0000000e+00 0.0000000e+00 ... 4.5557614e-41\n",
+            "  1.4012985e-45 0.0000000e+00]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "data = bifrost.ndarray(shape=(2,4096), dtype='f32', space='system')\n",
+        "print(type(data), data.dtype, data.shape, data.bf.space)\n",
+        "print(data)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "eleven-omaha",
+      "metadata": {
+        "id": "eleven-omaha"
+      },
+      "source": [
+        "Note that bifrost defines datatypes differently to numpy:\n",
+        "```\n",
+        "f32: 32-bit float (equivalent to numpy float32)\n",
+        "cf32: complex 32-bit data (equivalent to numpy complex64)\n",
+        "i[8,16,32]: signed integer datatypes of 8, 16 and 32-bit width\n",
+        "u[8,16,32]: unsigned integer datatypes of 8, 16 and 32-bit width\n",
+        "ci[4,8,16,32]: complex 4-bit per sample, 8-bit, 16-bit and 32-bit datatypes\n",
+        "```\n",
+        "\n",
+        "The `ci4`, `ci8` and `ci16` datatypes do not have an equivalent numpy type, but are commonly encountered in radio astronomy.\n",
+        "\n",
+        "You can also use the `bifrost.ndarray` to wrap existing numpy arrays:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "lightweight-madrid",
+      "metadata": {
+        "id": "lightweight-madrid",
+        "outputId": "192b8c53-93a9-4fbe-f0c4-6d35813e1c49"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "<class 'bifrost.ndarray.ndarray'> float64 (2, 4096) system\n",
+            "r: [[ 0.13445404  0.3175441   0.53332765 ...  1.18956152 -1.15990205\n",
+            "  -0.64751085]\n",
+            " [ 0.45399238 -0.42930972  0.47645107 ...  2.00526937  2.27132679\n",
+            "   0.78468687]]\n",
+            "data: [[ 0.13445404  0.3175441   0.53332765 ...  1.18956152 -1.15990205\n",
+            "  -0.64751085]\n",
+            " [ 0.45399238 -0.42930972  0.47645107 ...  2.00526937  2.27132679\n",
+            "   0.78468687]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "import numpy\n",
+        "r = numpy.random.randn(2, 4096)\n",
+        "data = bifrost.ndarray(r)\n",
+        "print(type(data), data.dtype, data.shape, data.bf.space)\n",
+        "print('r:', r)\n",
+        "print('data:', data)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "earlier-latino",
+      "metadata": {
+        "id": "earlier-latino"
+      },
+      "source": [
+        "Since `bifrost.ndarray`s are derived from numpy arrays they can do many (but not all) of the same things:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "regional-darkness",
+      "metadata": {
+        "id": "regional-darkness",
+        "outputId": "b0014540-15ea-4a4d-9aa1-c9af6c8f9193"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "data += 2.0: [[2.13445404 2.3175441  2.53332765 ... 3.18956152 0.84009795 1.35248915]\n",
+            " [2.45399238 1.57069028 2.47645107 ... 4.00526937 4.27132679 2.78468687]]\n",
+            "data[0,:] = 55: [[55.         55.         55.         ... 55.         55.\n",
+            "  55.        ]\n",
+            " [ 2.45399238  1.57069028  2.47645107 ...  4.00526937  4.27132679\n",
+            "   2.78468687]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "data += 2.0\n",
+        "print('data += 2.0:', data)\n",
+        "data[0,:] = 55\n",
+        "print('data[0,:] = 55:', data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "artificial-spider",
+      "metadata": {
+        "id": "artificial-spider",
+        "outputId": "4f1ae3cd-105b-4730-e1fc-b7bbb9916324"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "data[:,[1,3,5,7]] = 10: [[55.         55.         55.         ... 55.         55.\n",
+            "  55.        ]\n",
+            " [ 2.45399238  1.57069028  2.47645107 ...  4.00526937  4.27132679\n",
+            "   2.78468687]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "data[:,[1,3,5,7]] = 10\n",
+        "print('data[:,[1,3,5,7]] = 10:', data)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "thirty-stretch",
+      "metadata": {
+        "id": "thirty-stretch"
+      },
+      "source": [
+        "You can also use `bifrost.ndarray`s with [numba](https://numba.pydata.org/):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "smaller-organizer",
+      "metadata": {
+        "id": "smaller-organizer",
+        "outputId": "b33a3ea8-8aaf-4518-b351-39433408d557"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "<class 'bifrost.ndarray.ndarray'> [[65.         65.         65.         ... 65.         65.\n",
+            "  65.        ]\n",
+            " [12.45399238 11.57069028 12.47645107 ... 14.00526937 14.27132679\n",
+            "  12.78468687]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "from numba import jit\n",
+        "\n",
+        "@jit(nopython=True)\n",
+        "def compute(x):\n",
+        "    for i in range(len(x)):\n",
+        "        x[i] = x[i] + 10\n",
+        "\n",
+        "compute(data)\n",
+        "print(type(data), data)\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "informative-brush",
+      "metadata": {
+        "id": "informative-brush"
+      },
+      "source": [
+        "### Arrays on the CPU and GPU"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "acute-efficiency",
+      "metadata": {
+        "id": "acute-efficiency"
+      },
+      "source": [
+        "Unlike numpy arrays `bifrost.ndarray` are \"space aware\", meaning that they can exist in different memory spaces.  What we have created so far is in system memory.  `bifrost.ndarray`s can also exist in \"cuda_host\" (pinned) memory and \"cuda\" (GPU) memory:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "changing-enhancement",
+      "metadata": {
+        "id": "changing-enhancement",
+        "outputId": "84f7c97b-9de7-418b-b748-7ede65a98640"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) cuda_host\n",
+            "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) cuda\n"
+          ]
+        }
+      ],
+      "source": [
+        "data2 = bifrost.ndarray(shape=(2,4096), dtype='f32', space='cuda_host')\n",
+        "data3 = bifrost.ndarray(shape=(2,4096), dtype='f32', space='cuda')\n",
+        "print(type(data2), data2.dtype, data2.shape, data2.bf.space)\n",
+        "print(type(data3), data3.dtype, data3.shape, data3.bf.space)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "million-guess",
+      "metadata": {
+        "id": "million-guess"
+      },
+      "source": [
+        "To move between the different spaces the `bifrost.ndarray` class provides a `copy` method:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "talented-lending",
+      "metadata": {
+        "id": "talented-lending",
+        "outputId": "e415b5c7-78d0-4b2d-8dd3-f11b427cc928"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "<class 'bifrost.ndarray.ndarray'> float64 (2, 4096) cuda\n"
+          ]
+        }
+      ],
+      "source": [
+        "data4 = data.copy(space='cuda')\n",
+        "print(type(data4), data4.dtype, data4.shape, data4.bf.space)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "stable-instrumentation",
+      "metadata": {
+        "id": "stable-instrumentation"
+      },
+      "source": [
+        "Once on the GPU you can take advantage of Bifrost's GPU-based functions, like `bifrost.map`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "prospective-financing",
+      "metadata": {
+        "id": "prospective-financing",
+        "outputId": "618b8df1-f490-4126-9add-c311e79c71a6"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "data4/data = data*10/data = 10: [[10. 10. 10. ... 10. 10. 10.]\n",
+            " [10. 10. 10. ... 10. 10. 10.]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "bifrost.map(\"a(i,j) *= 10\",\n",
+        "            {'a': data4},\n",
+        "            axis_names=('i', 'j'),\n",
+        "            shape=data4.shape)\n",
+        "data4 = data4.copy(space='system')\n",
+        "print('data4/data = data*10/data = 10:', data4/data)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "amateur-bridges",
+      "metadata": {
+        "id": "amateur-bridges"
+      },
+      "source": [
+        "The `bifrost.map` call here compiles and runs a CUDA kernel that does an element-wise multiplication by ten.  In order to view the results of this kernel call we need to copy the memory back to the \"system\" memory space.  In the future we hope to support a \"cuda_managed\" space to make this easier."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "vocational-archives",
+      "metadata": {
+        "id": "vocational-archives"
+      },
+      "source": [
+        "`bifrost.map` is an example of a function that does not require any additional setup to run. This code is converted into a CUDA kernel at runtime, using [NVRTC](https://docs.nvidia.com/cuda/nvrtc/index.html). \n",
+        "\n",
+        "For some Bifrost functions, like `bifrost.fft.Fft`, some setup is required so that the function knows how to run. To show the use of the Bifrost FFT, let us first make some example data on the GPU, using `bf.map`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "restricted-carrier",
+      "metadata": {
+        "id": "restricted-carrier",
+        "outputId": "0b5aeb24-a92d-4f25-8de3-c1ae41b91529"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<matplotlib.legend.Legend at 0x7eff6b0ecc50>"
+            ]
+          },
+          "execution_count": 10,
+          "metadata": {},
+          "output_type": "execute_result"
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEGCAYAAABLgMOSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9eXgc1Zno/Tutbqm7tS/d2rxI8oI3sA0OW2zABsKSAFnIQpIZyIUhuZN8M8ncm0lyM5NMcpMvmXsny0eGmYSELJOQDUISSBh2DDa7AWNsbLxIsiVbUrf2pVtSL+f7o7raLamX6u6qrpKnf8+jR3JVddUpd9V53/OuQkpJkSJFihQpki02swdQpEiRIkUWJ0UBUqRIkSJFcqIoQIoUKVKkSE4UBUiRIkWKFMmJogApUqRIkSI5YTd7AIWkoaFBtrW1mT2MIkWKFFlUvPLKK4NSSs/87f+lBEhbWxt79uwxexhFihQpsqgQQhxPtr1owipSpEiRIjlRFCBFihQpUiQnigKkSJEiRYrkRFGAFClSpEiRnCgKkCJFihQpkhOmChAhxI+FED4hxP4U+4UQ4g4hxFEhxD4hxLkJ+24WQhyJ/dxcuFEXKVKkSBEwfwXyU+DqNPuvAVbFfm4H/h1ACFEHfBm4ADgf+LIQotbQkRYpUqRIkTmYmgcipXxGCNGW5pAbgP+QSs35F4QQNUKIZuAy4DEp5TCAEOIxFEH0KyPGece9f8vEpJ+1pRfSV3sRM/YqIy5jGcJylmPBp7FRwgrXpdhEidlDMpxQNMjR4E7KbJW0OS8qyD0LGaF5Yj/eqUOUhSeZKm2gp/o8xpxLDL82wHR0gmPBZ6goaWBZ2fkIIQpyXTMJREboDO6m1rGU1rJNZg/HcGqCJ3CO7eK18Gt89p3fx9vYquv5rZ5I2Ar0JPy7N7Yt1fYFCCFuR1m9sGzZspwG8fLws+x1zrBl4mX+9fBXuD96Gd8J38gIZ6IgieJcejf28mMA7Ox9mumTHwXO4MlFhHAt/z4lzpMAPD76LDP97zPwgpL32Z7hb+33s1T4F+zdHd3AN8M3cUC2GzcEWwB3279hKx0EYHbwMmYH0xkDFj/CPo5r+fewOSYAmBl4F6GRrSaPyhjOEcf4gv2XeMuO8JfNjQSFjat7X+DyRn2fa6sLkLyRUt4F3AWwZcuWnLpn/fzje/j9od/wpRe/xh/WX8pfHHqav6h+A977Q+i4VNfxms09B+/hmy8d4x8v/EcmZif47qvf5V//SvDOjneaPTTD+N5r3+OufSf5zmXfYZ9/Hz858BN+fONtXNx6sf4XCwzD7z8BRx6BlnPhom9C2zZw1cLocTj4IFtf+Hf+FPgS7PgibP07MGBl8NXnv8r9R0b4/pU/5KHOh/gDf+D+Wz7B+vr1ul/LKnzmqc+w+2SIH131C378xo95xvYwD/73T7KksjArvoIQjcKub8FTX0eWN/CxZeciI5P8/tpfsqxGf4XEbB9IJk4CSxP+vSS2LdV2w3j3WR/g/Kbz+aEcJnTbY+CsgV+8D/bfb+RlC0ooGuIn+3/ClsYtvH/1+/nYho+xqnYVP9j3A87UzpWBUIBfHvwl71j+Dq5YfgWf2vwpWspbuOuNu/S/2MQA/ORa6HwKrv0X+Ksn4ewbobIR7KXQsAq2/R186iVY/2544qvw4N8qk4KODAYH+f3R33Pj6hu5sPlCPvu2z1JVVsXdb9yt63WsRNdYF4+feJxbNtzCRs9GvnjhF7Fh4+79Z9A9RyPwx0/CU1+Ds29k74d+yivT/Xzq3L8xRHiA9QXIA8BfxqKxLgTGpJR9wCPAO4QQtTHn+Tti2wxDCMHN629maHqIZ8LDcOujsORt8Lvb4PCjRl66YOzs2clAYICb19+MEAKbsHHL+lvoGuviNd9rZg/PEP7U+ScmQ5P8xbq/AKC0pJSb1tzEKwOvcHTkqH4XCo7Az94Foyfgo/fD+X+VemXhqoX33Q3b/ie8+jN45AugowD/3eHfEY6G+ejajwJQWVrJe1a+hydPPIkv4NPtOlbi14d+TamtlA+d9SEAvG4v7+x4Jw91PkQgFDB5dDogJfzp0/D6L+GyL8B7f8ivuh6g0lHJDStuMOyyZofx/gp4HjhLCNErhLhVCPEJIcQnYoc8BHQCR4EfAn8NEHOe/2/g5djPV1WHupFc3HIxHpeHB489CK4a+Mi90LQB7r0Z+t8w+vKG82j3o9Q569jWui2+7YplV+Cyu3iw80ETR2YcD3c/TEd1Bxs9G+Pb3rXiXQgEjx7XSTGIhODeW2C4Cz7yW2jflvEjCAGX/yNc+El48fvKj0483P0w5zWeR1t1W3zbe1e9l4iM8Pjxx3W7jlWIyiiPH3+cS5ZcQr2rPr79uhXXEQgHeLLnSRNHpxMv/Du8+h+K0nHZ55mOzLCzZyfXtF+D2+E27LKmChAp5U1SymYppUNKuURKebeU8vtSyu/H9ksp5SellCuklGdLKfckfPbHUsqVsZ+fFGK8dpudHct28Nyp55iNzEJZBXz4Xiirgns/BjOThRiGIcxEZnim9xl2LNtBie10BJLb4WZb6zae6XnmjDNjjc2M8erAq1y+7PI5EUgNrgbObTyXx44/ps+Fdn4DOnfCdd+Ftiydtu/4Gpz1Tnj0H+HkK3kPpWe8h6OjR7l82eVztrdXt9NR3XFmTKbz2Offhy/o44rlV8zZfl7jeTS4Gni652mTRqYT3c/Co/8Aa94F278IwIt9LxIMBxd8z3pjdROW5bhkySUEw0H29MdkWWUjvO+HMHQUHv6cuYPLgz39ewiEA+xYumPBvq2tW/EFfRweOWzCyIzjmd5niMgI25duX7Bvx9IdHB09St9kX34XOfEi7P4ObPoobP5o9p+32eDdd0Jlk6KkzE7lNZynep4CSHrP25duZ0//HiZmJ/K6htV4pvcZ7MLOJUsumbPdJmxc3HIxz/c9TyQaMWl0eTIzCX/4BNS2wXu+rzwvKN9zhaOCtzW9zdDLFwVIlpzfdD6ltlKeO/Xc6Y3tl8DWT8Nrv4CuZ8wbXB683P8ydmHnvMbzFux7e+vbAdh9cnehh2UoL/W/RHVZNesbFkYeXdB8QfyYnAkFlZe7eglc/Y3cz+OqhffepURpPfX/5n4elO+5raotaeTRRS0XEZGRM87f9XL/y6xrWEdlaeWCfVtbtzI2M8b+oaTFMKzP41+G0R54979B2en7e6n/Jc5vOh9HicPQyxcFSJY47U42NGxY+JJd+jlFC/jTZyA8Y8rY8mHPwB7WN6xPai/1ur2srFnJnoEzqxnXqwOvstm7GZtY+Bqsql1FTVlNfgLkue/BcCdc/z1w5pkztPxiOPdmeOHf4NTenE4RlVFe9b2aVEkAOMdzDnabnVcG8jeVWYVgOMj+of1sadySdP+FzRcCnLYoLCZ6X4GXfwQX/ndYdmF8sy/go2eih3Mbz03zYX0oCpAcOLfxXN4cepNgOHh6o8MF7/y2Ysp6/k7zBpcDgVCAA4MHUr5kABs9G3nd/zpRqW9IqVn4A35OTJxIec82YWNL45bcJ5bRHtj1bVh3A3RclvM453DlV8BdDw9/PqeorKOjRxmfHU85sbjsLs5uOPuMUhRe979OOBpO+T3XOmtpq2pjrz83oWwaUirReRWNsP1/zdn16sCrAGnfZ70oCpAc2OzdTFiG2T84b9m78nJYfQ3s/q6SMLZIeGPwDcIynFIzBUWATMxO0D3WXbiBGcgrPkXLPtebWkvb5N3EqalTDAYHs7/A4/+k/H7H13IYXQpctUqI5onn4a3/zPrj6soi3fd8XuN5vDn4JtPh6ZyHaSVeHXgVm7Cx2bs55THneM7hdd/riytI5MD90PMi7PiHOaYrUL5nt93NWXVnGT6MogDJATXkM6mt+PIvweyEkg26SDgwdABQXqRUbPIqdYMWnaaWgn3+fZSVlLGmfk3KY9Ss7AODB7I7+cAB2P87xbRQk1v5nJSc+5dQv0qxfUfCWX30Df8beFweWspbUh6zoWEDYRnmrZG38h2pJTgwdICO6g4qSitSHrPJu4mRmRF6JnpSHmMpIiF4/CvQeDZs+siC3fsG93G252zsNuMLjRQFSA5Ul1WztHIph4YPLdzZuA423gQv/RDGTxV+cDnw5tCbtFa0Ul1WnfKYtqo2qkqr2OffV8CRGceh4UOsrl2Nw5baybiufh02YYsLWM3s/CaUVsDF/0+eo0xCiQOu+DIMHoY3fpvVRw8OH2Rt/dq0RRNVofnm0Jt5DdMqHBw6yLr6dWmPOadBUZxe979eiCHlz77fKAEVO/4BbHOLfoaiIY6MHGFdXfp71ouiAMmRNXVrODh0MPnOSz8H0fCi8YUcHDrI2rq1aY8RQrCmbs0ZEcorpeTQ8CHW1KVefYCSA9NR3bHQVJmOvn1w8AFl9eGuy3OkKVjzLmjcoIQHayxzMh2epmusK+M9N7obqXPWnRECxB/w4w/6Mz7bHTUdOGyOxfFsR8KKdaPpHFh91YLdnaOdhKKhjN+zXhQFSI6srVtL72Rv8pj52uVKjaM9P7G8L2RidoITEydYW5/+JQNYXbuaIyNHFm/MfIyTkyeZmJ3Q9JKtq1/HgaED2u3ju7+tJJZe9Nd5jjINQsDWzyirkEN/0vSRIyNHiMiIJkVhbf3aM0KAHBxWFLxMz7bD5mBlzUreGl4EZrsD9yuRfZf+fdJSOOo9pzPN6klRgOSI6qBK+dC9/dMQmoKXDCjKpyOqGS7TxALKqms6Ms3xieNGD8tQsrnntXVrGZ4eZmh6KPOJR47Dm3+ELR9THN5Gsv49UNehaKMahJvWyRRgXd06jo0eYyay+MLRE3lz6E0EQpOicFbdWbw18pa1HelSKpF93nVKdYIkHBo+hMvuYnnl8oIMqShAckSdfJL6QUDxhay+RqlhNGvdYm2qGU7LxKIKzcPDi2Cpn4aDwwcpESWsql2V8diVtSsBJQQ2Iy/dBQg4//Y8R6gBWwm8/W+hby9078p4+KHhQ1SVVqV1oKucVXcWERmha6xLj5GaxsGhgyyvWk65ozzjsWvq1jA8PZxbxF2h6Hoa/AcV35ot+dR9cOggq2tXzylHZCRFAZIjHreHOmdd+miViz6pVGHd/7vCDSxLjo0do85ZR4OrIeOxHdUd2IU9tdBcJBwePkxbVRtOuzPjsStrFAFybPRY+gOnx+GVnykrg+oC9Zc454PKSuelH2Y89K2Rtzir7ixNXQdXVK8ANApNC3Ns7JgmJQEU8yxg7eizF38A7gZY/96ku6WUHBk5UjD/BxQFSF6sqFlB51hn6gPatoJnLbz8Q13LcetJ52gn7dXaegWUlpTSXtO+OJyNaegc62RFzQpNx9Y766kpq+HIyJH0B772cyV8+6JP6jBCjThcSljvoT/DWOp2OFJKuka76Kju0HTa5VXLsQt7ZqFpYWYjs/RM9Gh+tuOra6s+28NdSu7Plo+BI7ni4w/6mQhNaH629aAoQPKgo7qDrtGu1HZTIeD826Dvdei1XnavlJLOsU7NEwvE7nkRmzZmIjP0TvZqnliEEKysWZleG5dSCZhYcj60Gl8+Yg5bbgUZhVdSF6Qemh5iIjSh+Z4dJQ6WVy1f1ALk+PhxojIaX01loqq0igZXg3Wf7Zd/pJgtt/y3lIeoY9f6PetBUYDkQXt1OxOhifQO1nM+CKWVyirEYgxNDzE+O56VAGmvbufU1KlF62A9MX6CqIxmdc8ra1ZybPRYakXh+HMwdATOu1mnUWZB7XI46xp45acpa7B1jiqr5KwUhZqORS1Ajo0pY++oye7ZtqQACQWVFe7a66EqtQ9LtYZk8z3nS1GA5IH6RakvaFLKKmHTTXDg95YL6VVflqxesqp2ojLKifETRg3LUOIvWRb3vKp2FZOhSQYCA8kPePVnSuju+vfoMcTsedutMOVPWd5EvedsNNOVNSvpmehZtCVNuka7EAjaqto0f6a9ShEglovEOvRnmB6D825Je1jXWBfljnI8Lk9hxoX5HQmvFkK8JYQ4KoT4fJL93xFC7I39HBZCjCbsiyTse6CwI1dQX8i0fhCAzX8BkVnLOdNVDTPbFQhgTU1NA11jysSyvEp7mKM6CSW95+CIErp79o1QmjnaxxA6tkNVK+y9J+ludWJpdDdqP2VNBxK5aL/nzrFOWipaNAVKqLRXtzM+O87IzIiBI8uB136ulMRpS9/JUjVHawmU0AvTBIgQogS4E7gGWAfcJISYk38vpfyMlHKTlHIT8D3g/oTdQXWflPL6gg08gUZ3I+WO8swCpPkcpW5NihfcLDrHOrOeWNSJd7FPLC67S/Nn1HtOuurady+Ep5VS62ZhK4GNH4Kjj8P4wgZYnWOdtFe1ZzWxtFcpisLx8cWZ83Ns7FjWzmS1xa+lnu3RE9D5tFLzKkXorkrXWFdB/R9g7grkfOColLJTSjkL/BpI1/39JuBXBRmZRoQQtFe1ZxYgAJs+DKdeA1+K8icmkMvE4na4aS5vpmvcQi9ZFnSNdc3pBa4Fr9uLy+5KnkD52n9A80Zo2aTPAHNl44cVZ/q+Xy/Y1TmmPdJOZWnlUgBOTCw+U2UkGuH42PGsfQGWXF3vjU15mz6c9rDJ2Ul8Ad9/KQHSCiSWv+yNbVuAEGI50A4kNmx2CiH2CCFeEEK8O9VFhBC3x47b4/f79Rj3HNqr27WVOD/7/WCzw95f6j6GXDk+fjzryRQs7GzMQFRG6R7rznpiEUKwtHLpwhWI7xD0v6FM3mbTsBKWXgiv3TMnZHwqNJXTxOJ2uPG6vIvS19U31cdsdDYr/wdAc3kzZSVl1nm2o1HY+wul42mGqs7d491AYSOwYPE40T8E3CelTCzCtFxKuQX4MPBdIUTS9aqU8i4p5RYp5RaPR3/n0tKqpfgCvsxRSRUeWHWVUkkzyzLcRjAbmWVgaiCuaWZDW1Ub3WPd1nM2ZsAX8DEdmc6pzMPyquULzTlv/BaEDTYkT+wqOJs/okSDJYSM9070AmTl81FZWrV0Ua5A1LLs2T7bNmFjedXy+GRsOieeV0xYmz+a+dCYoM9WaOaLmQLkJJD4DS+JbUvGh5hnvpJSnoz97gR2Aqk7xhjI0sqlSCQnJ1IncsXZdBNMDiglCUymd7IXicxJgCyrWkYgHGB42lpRZZlQJ9Oc7rlyGb0TvYSjMeEvJbxxr9JtsMKr3yDzYd27oaQM9t8X36ROpsl6oGdiWeWyRbkC6Z3M73u2TF+Q/b8DhxvWJK97lYg65paKzKVq9MRMAfIysEoI0S6EKEUREguiqYQQa4Ba4PmEbbVCiLLY3w3A2wFTyoeqD6mmh27llUq454H7Mx9rMPlMpksqlMlIfVEXC/lMLMurlhOWYfomY07qnpcU7fDsD+g5xPxwVsGqK+HAHyBWMVn9nnMSIFXLGJoeYio0peswjaZnogeHzYHXnb1gX1K5hJMTJ81v3RwJw5t/gNVXa4ru653sxePyZBUcogemCRApZRj4FPAIcBD4rZTygBDiq0KIxKiqDwG/lnPtJWuBPUKI14GngG9KKa0vQBxOOOtaOPgghGcNHll68tFM1c+ok9NioWeiB5uw0VTRlPVnVRNQ3JH+xr1gd2rSDgvKhvfCZL+S3Ihyz9Vl1VSVVmV9qmWVit19sa1Ceid6aa1ozamg4NLKpcxGZ/EFfAaMLAu6nobAEGx4n6bDeyZ6clKM8sVUH4iU8iEp5Wop5Qop5ddj274kpXwg4Zh/klJ+ft7nnpNSni2l3Bj7fXehx65SW1ZLuaNc+7J3w3uVpKDOp4wdWAZ6J3px2V3UO+uz/mxrRWv8HIuJ3olemsub03YhTMWyKmUyPT5+XGkpeuB+JQPcmf3EbCirr1bMHrFVbu9kb3zFmC3qPS82P0jPRE9OihEkrK7Nfrb3369YK1Zeoenw3onenO85HxaLE92yqBE6mgVIx3Zw1igPiImoL1kuSUdOuxOvy2sdW7FG8plM6531uO1uZWLpeiamHd6o8wh1oLRcESJv/hEiYXonenPWTNUVyGL6nqWUeWnj8dW1mebZ8IxipVjzrpSFExOZiczgC/hyfrbzoShAdCArAWIvhbXvUsoThMwrE9Ez0cPSityXvEsqlyw+H0geWpoQgpaKFk5OnlRebke5Zu2w4Gx4HwSGCHc+yanJUznfs9vhpsHVsKiSCUdmRpgKTeUsQJormrEJm7lC8+gTMDOm2Xx1cvIkEllcgSxWllQu4eTkSe2tXte/Vyn9ffRxYweWgqiM5qWZQkyAmL3Mz4Kp0BTD08N5vWStFa2cmjypCP/V79CkHZrCyiugrIqBN35DWIbz0kyXVCjP9mIh1xBeFYfNQXN5s7nP9oHfK31eOi7VdHg+ATH5UhQgOrC0cimhaEi74639UnDVKWYGE/AFfMxGZ/MWIJryXyxCPtFIKi0VLZwa74EpH6y9Tq+h6Y/DCauvoue4Ei6ez/fcXNHMqclTeo3McPIVIKAITdNW15EQHH5EaVlbos1Xl09ATL4UBYgOZBWJBVBiVxywRx5RHpgCo4fGsqRiiZL/ski003xCeFVaK1qZiAQZs5fBqnfoNTRjWPNOeqNKK+V8V10DUwPaV9cmoz7baqBHLpi6uu7erZivsojuyycgJl+KAkQHWsuVh/XUVBaa2lnXKtFYx581aFSpUSfTfCYWdSJeLGas+AokD3NOa6yf+Kn2C5Uy/VZm5RX0OMqwI7IqljmflooWwjKMP6h/GSAj6J3oxevyZlWFdz5LKpcwPD1sTv7LoT8rUXQrtmv+iBq2XMgqvCpFAaIDjeXKCxpPMtPCih1gd8GhhwwaVWr6JvsQCJrKs8+HUFlsuSA9Ez1UllZSXVad8zlapicBONVqcuFELZRV0lvTTGtEUiJyf81bYkJzsaw0+6b68s7GNu3ZllIRICt2KO2KNdI7aU4ILxQFiC6UlpTicXnom8pCgJS6lQfl0J8L3i+9b6qPBlcDpSWlOZ+j3llPqa00u3s2kVOTp/IOc2zteQWA3ppmPYZkOH3OclpmgzBwIOdzqJPxYvGD9E310Vye3/ejWhQK/myfeg0mTinhuxqRUjEj52Oyy4eiANGJ5vLm7ExYAGuuhfFepWd6AdHjJRNC0FzRvGgESN9UX14rLoCqtx6hAsGpmdHMB1uAPjlLcziiKCk5oj4ni0GARGWU/qn+nCoNJNJcodxzwZ/tQ38GUQKrr9L8kfHZcYLhYN7vc64UBYhONFc0Z2fCAiXhS9jgrcKasfqn+uMvST40lTctGgHSP9Wf30s23IkYPExLWd2imExnI7MMTg/T5G6GQ3/K+TxOu5N6Z332ypEJDE8PE4qG8p5M65x1OGwOcwTI8ovBXaf5I+oYiwJkkdNS3kL/VH92RdjKG2DZRXlpiNkipdRlBQLKQ9s/2a/DqIxlYnaCydBkfvd8+FEAWmtWLooEyoEppX97c/O50L9PKfyYIy0VLYtCaKoKXL7Ptk3YaCpvKuyzPXQM/Aezrq3WP6WMsShAFjlN5U3MRmezL3F+1rUwsB9Gug0Z13yGp4eZiczkbc4B5aH1B/2ETAhFzgb1Jcvrno88AvWraK1bxanJU5bvhdIfiE0s7TuUDYcfyflci0WAqKskvZSjgq5A3vpP5fdZ12b1sfgKRAeLQi4UBYhOqM7GnMxYAEce03lEydFTY2kub0YiGQgM5H0uI1FfspwFyMykEp+/+iqay5sJhAOMzYzpOEL9iU8sLVugtj2v56ulvIW+qT7zS5xnIP5sL0bz7JFHwbMGarNr/NU31YfdZqfOqd3spSdFAaITcWdjtrbi+hVQ21awsibqS6FH4xnTnI1ZkrfQ7HoaIrOw6h1xIWR5oRlTZBrLG5Wkx65nIBTM6VwtFS2EoiEGg4N6DlF3+qb6KHeUU+nIP0cnvrqOFmB1PTOplN9fdWXWH+2f7KfJ3YQtj1DtfCgKEJ2IT6bZrkCEUF7wzqcLUlxRT6ebeg51grYqfVN92IWdBldDbic4/DCUVsKyi+ICZDHcc52zjrKSWNZ8OAjduSWtLpZQ3r5JxbenR0JdS0ULURnFHyhAAmXX0xAN5VTdoG+qzzTzFRQFiG5UlVZR4ajITRtXX/Dju/Uf2Dz6pvpw2V05NRiaj5rhvBhWII3ljTk1GEJKxfyzYjvYSxeNAJkTddb2diVp9cijOZ1LPY/Vv2c9QrVV1PMU5J6PPAalFbD0wqw/2h/IM7owT0wVIEKIq4UQbwkhjgohPp9k/y1CCL8QYm/s57aEfTcLIY7Efm4u7MiT01TelFu4Y9tWpbvdEePNWHpqaU67kzqn9cNa+6b6ci/n0b8PJvrivqp6Zz12Ybe+CSsx0s7hgvZLlECAHJz/cbPdlPXvWc2cz5eCCU1VQem4TGn1kAXhaBhfwKeb0MwF0wSIEKIEuBO4BlgH3CSEWJfk0N9IKTfFfn4U+2wd8GXgAuB84MtCiNoCDT0lLRUt2ZuwQHnB27blrCFmg14hvCrN5c2LQxvPdZkfC99V7dMlthI8bo+l71lKqSTUJU4sq65UIv2GjmV9vgpHBW6729JCMxAKMDozqps5p2ArTd9BJZk4B/+HP+AnKqP/ZVcg5wNHpZSdUspZ4NfADRo/exXwmJRyWEo5AjwGXG3QODWTUza6yqorYfhYTi94NuhtM22paLG0aSMSjTAwNZD7S3bkEWg5Fyq88U1N5U3xMFkrMj47TiAcmHvP6gSVg5IihKCxvNHSAkT9PvTSxl12F7VltbkphNlwNBYdtzJ7AZJ3dKEOmClAWoHE+ue9sW3zeZ8QYp8Q4j4hhFqLW+tnEULcLoTYI4TY4/cb6xBrKm9iYnaCQCiQ/YfV7nYGRmNNh6cZnh7WVWNRwx2tmhcxGBwkLMO53XNwBE6+sqDzYJO7ydIrkKThrLVt0HBWzqvcRnejpU1YatKfEc+2oRx5DLzroTr7WlZmZ6GD9Z3oDwJtUspzUFYZP8v2BFLKu6SUW6SUWzwej+4DTES1s2tuLJVI/QqoX2moGUvVIPU2YQXDQcZnx3U7p57kpZl2PQMyCisvn7O5sVyZTK0qNFNOLKuuVNoHzExmfc5Gd6OlV11GTKaGJxNOj0pdz3kAACAASURBVMOJ53MyX4FOCbJ5YqYAOQkkdvdZEtsWR0o5JKVUW979CDhP62fNQBUgOS/1V16pJKzlGK+fCSOWvFaPSsrrno89qYTvtp43Z7NadWBkZkSPIepOynteeYWSz5JDD5rG8kZlNRcN6zFE3emb6sMmbHjc+imJTeUGrzQ7d0I0nLMA6Zvqo6q0inJHub7jygIzBcjLwCohRLsQohT4EPBA4gFCiER14nrgYOzvR4B3CCFqY87zd8S2mYrXrdjJc1qBgKLphqcVrcQAVBNEk1s/AaLes1Xt4zmbNqRUBEj7JQtai6r/f1YWmg6bY2F28rKLlGi/Y09lfc6m8iaiMmrZZMKBwAANzgYcNm1tYLXgdXuZDE3mZpLWwrEnFAVl6QU5fTzvAqE6YJoAkVKGgU+hTPwHgd9KKQ8IIb4qhLg+dtjfCCEOCCFeB/4GuCX22WHgf6MIoZeBr8a2mUrek+nyi8HmyOkF14LaVU5PLS3vVZfBxLOTS7PMTh7uVAoQJukMpzYQs6pPoH+qn0Z348LsZIdTESKd2T9f6vdsVaHpD/h1fa6hAMrRsaegfZvm3ufz0TPvJVdM9YFIKR+SUq6WUq6QUn49tu1LUsoHYn9/QUq5Xkq5UUq5XUp5KOGzP5ZSroz9/MSse0jE7XBTWVqZ+8RSWq5oIzm84FrwBXxUllbm1e5zPvWuegQi91WXwfiD/txyQI49qfxesWPBrrjZzqI+AX/AH5/8FrBiO/gPwXh20YJWVxT8Qf0FSF4+zUwMd8HocSX/I0fSfs8FwupO9EVHozvPcMcVl0H/GzClv6nAH/Djden7wDlsDupd9ZYVIL6AL7eJ5dhTULMM6joW7Kpz1mG32a2rjQfTTCwdsRVV586szmn1ZEIjnm11pWnIs63+/3do732eSCgSYmRmRHehmS1FAaIzje7G/B64jpjGm+ULrgVfMMfJNANet9e6mmnAj8eV5T1HQtC9S1l9JMnYtwmbEpVkUQGSVmg2bgB3Q9Zm0qrSKpwlTkt+z7ORWUMmU0NNWJ1PQWULNKzK6eOqL0pvoZktRQGiM3knXLVsAme1IWaswcCgIUvevIWmQUgpczNtnHwFZsaTmq9U8l5pGsRUaIpgOJh6YrHZFLNJ586sypoIIWgqb7LkPccnU52fbZfdRWVppf7PdjSihIiv2J5UQdGCL6iMqbgCOcPwur0MBYdyLwNtK1Eif47tzKluUSqklMoKJFttXANet9eSAmRsZoxQNJS9lnbsSaXVcPslKQ8xPMQzR9TvIe3EsmI7TPlg4EBW57ZqMmH8ng14tg1Rjvr3KUmqHZflfAq1SnDRB3KG0ehuRCIZDOThw+jYrtTH0bGsyejMKOFo2BCNpdHdyNjMGNNh48vRZ0POWtqxJ5XcD1fq8mrqxGK1ZEJNE0vcD5LdKrex3JrJhGp0oRGTqdft1V9oqubD9ktzPoWRQjMbigJEZ3Sxm3ZcpvzW0YylPnBGvWSJ17AKOWlpwVHFhJXBuel1ewlFQ5brTBgXmukmlupWaFidtR+k0d2IP+AnEo3kM0TdUZ+7nPu9pMGQ1XXnTqV8SWWOFaJRhKZd2Kl1mltDtihAdEaXcMe6DiUCSMd8kHgOiEEmLLBeiGdOWppaviSN/wNOr2rUCdsqqEIz46qrY7vSBS+LJmaN7kYiMsLQ9FA+Q9Qdf8C4ydTr9jI4rWMGfigIJ17Iy3wFyrNd76o3rROhSlGA6IwuseNCKC949y6I6PPgap5YcsDQePk8yClxsnsXOMphyZa0h6lCsyAd67LAF/Dhtrszl7dYsV1pYtbzouZzq2GtVvP9+IN+GtwNhkymje5GojLKUFAnoXnieYjM5C1ABoPGBMRkS1GA6Ex1WTVlJWX5201XbFcigU69qsu4jLSZWtWE5Qv4qCqtUtq6aqV7Nyy7MGN2sPr/aLV7TpsDkkjbVrDZswoXjwvNoLWEphE5ICq6P9udO5VqE8svzus0voAxATHZUhQgOiOE0Mdu2n4pIHTLB/EH/dSU1VBakl3XMy1UlCoNh6w2mWatpU0Ngu9NZXLNQNyEZbF71lzSo6xS6XPSvUvzua266jIiC13FEAGy9Hwoq8jrNEbeczYUBYgB6JIj4K6Dpg2KTV4Hcs7I1ogVkwmzTiJUq9RqECBlJWXUlNVYTxsPZnHP7dvg5KswM6Hp8NqyWkpEieWEppHauK7+vakh6NuXc/a5ykxkhrGZsaIJ60xFt8m07RLoeSkrR2cqjFzmg2Ift9zEkm3mffducLihZbOmwz1uj6XuWUqZXX2ktm0gI3BcW/XnElsJ9a56SwnN6fA047Pjhk2matkaXb7n7mcACR25h+9Cgj+zaMI6M1En07xzBNq3KQ633pfzHpPRS16rZaNHZTT7zHuN/g8Vr8trKXPORGiC6ci09nDWpRdASWlsYtOGx+Wx1D0bUWE6EZuw4XXpFMrbvVsJ0NCooKTC6HvOhqIAMYBGdyOhaCj/hkPLL1YyorOwUydD7eNgpMbidSuTaVRGDbtGNoxMjxCWYe2T6dSQZv+HisftsVQYb9Z5L6VuWPI26NL+fHncHkutQOL3bODqWjeLQvezWSkoqSiuQM5w1Ekrb03NWQ3NG7N6wZMxPD1MREYMtZl63V7CMszwtOltWYAcspPj/o9tmq/hcXkYCg5ZJrEup0i7tm3Q97pSWkMDVlt1qQK8wa1/EqGKLkExk37wH8xKQUmFkZn32WKqABFCXC2EeEsIcVQI8fkk+/9OCPGmEGKfEOIJIcTyhH0RIcTe2M8D8z9rJuoXq0v3trZtiglrNveuaEbmgKhYLZkway0tS/8HKPcckZHFKzRBMZMilaRCDXjcHkZmRpiNzOYwQv0p5AokL5N0FgEamfAFfNhtdmrKavI+V76YJkCEECXAncA1wDrgJiHEunmHvQZskVKeA9wH/J+EfUEp5abYz/VYCHUFoovdtP0SiIaySviaj5FZ6CrxZMIpa5h0sp5Ms/R/JJ7bKmYsdTLNqqTHkrcpbW41rnJ1VY50wB/w47A5qC6rNuwaje5GguEgk6HJ3E9y/NmsFZRUqAExIsdKvnpi5grkfOColLJTSjkL/Bq4IfEAKeVTUkpV9X4BWFLgMeaEOlHr8pItuxBESV5+ECPrYKmo92wV+3hW9ZGmhsB3IGvt0Gp5Ef6gn0pHJW6HW/uH7GWKM13j82W1BEo1cdLIyVRduef1bOegoKTCF/QZarLLBjMFSCvQk/Dv3ti2VNwK/GfCv51CiD1CiBeEEO9O9SEhxO2x4/b4/YV50Z12p359BMoqofXcvPwg6gRX76rPfzwpUFvbWkWA+AN+astqtSVO5uD/AOtNpjnn+rRvg4H9iiDNgC6TqY7k1DAsS+LKUa6KghqgsfztuozH6JD8bLCbPQAtCCE+CmwBEgOol0spTwohOoAnhRBvSCkX1D+XUt4F3AWwZcuWgtXe9rq8+i3z27bBc3fAzGROGay+oI86Zx0OW/7aTyrsNqWYnVW08ay0tBT+j1AoRG9vL9PTyfNwpJR8d913qZyu5ODBg/kOOW/eU/UeRJXIOBan08mSJUtwOGLPQ1us70n3LlifUhcDdJhMdcYX9LGyZqWh11Cfo5yFZo4KSir8QT8XNF+gy7nyxUwBchJYmvDvJbFtcxBCXAF8EbhUSjmjbpdSnoz97hRC7AQ2A/o10MiTBneDfrbx9m2w+9tKFc9VV2T98aySy/LA69ZRaObJYGBQu5aWwrzQ29tLZWUlbW1tKU0kJcMlVJRW0FqRbvFcGA6PHMZtd7OkMrWlV0rJ0NAQvb29tLe3Kxtbz1XyEzQIkFpnLXZht9QK5OKW/OpKZUJ9jnLu8ZNDgEYqguEgE7MTlojAAnNNWC8Dq4QQ7UKIUuBDwJxoKiHEZuAHwPVSSl/C9lohRFns7wbg7cCbBRu5Brwub35NpRJZeqFSgC2LhK9EClV4rcHVYB1zjtYs9DT+j+npaerr69Pa1+02u36lvvNASkk4GsZuS68TCiGor6+fu6oqcSgCVIOZ1CZsinJkge85EAowGZo0/Nkud5TjsrtyVwi7dyt+Jnv+dejUOcUKOSBgogCRUoaBTwGPAAeB30opDwghviqEUKOq/i9QAdw7L1x3LbBHCPE68BTwTSmlpQRIg7sBf9CvT8e6UrdSXjxHP0ihSj97XB5LrEAi0QhDwSFtL1kG80Im56zD5rCEAInICFJKTWbKpPfUfgkMvgUTmcOwrZILUqh8CCGE8mznohDGFRR9/B9W6YWuYqoPREr5EPDQvG1fSvg7qb1GSvkccLaxo8sPr+t0x7oapw7x2m3bYNe/wPSYkmCokXA0zND0UEEeOI/bw9C0klhXYisx/HqpGJkZ0Z44mad5wW6zEwjnnqOjF6oQy7QCSUl7TIB274Kzb0x7qMft4fj48dyuoyNGdiKcT4OrITez3YlYfo1e/o8C5L1kQzET3SDydrzNp32b0ilPY+E7leHpYaIyWpAlr8flISqjpifWxTOytQhN1byQY3il3WYnEo0YVsKlpKSETZs2sWHDBq677jpGR0eTHqcKkGgoygc/+EFWrlzJBRdcQHd3t7YLNW2EsipN1Z89LmsUkcypZXGO5FzCpXs32F1K6XwdyOrZLgBFAWIQqoag21J/yflQUpZ1efdC1s2xSoin5nvOMf8jEdVkZJQZy+VysXfvXvbv309dXR133nln0uNC0RAAP//pz6mtreXo0aN85jOf4XOf+5y2C5XYldprGvJBPG4P47PjTIfzrxKdD4UsKphzEcnu3Ur/Dx38H6CYo0ttpVSVVulyvnwpChCD0D2xzuFUHsQsHemFSCJU0TWBMg8028Z1CK9UTUaF8INcdNFFnDypBCoeO3aMq6++mvPOO49t27bFQ3f/9OCfuPnmmwG48cYbeeKJJ7T74dq2wXAnjJ9Ke5hlvueAH2eJk0pHpeHX8rg9BMIBpkJT2j8UGIaBA7qZr+B0cIgVstBhkeSBLEZ0N2GBoinv/KZS+M5Vq+kjhdbSwPzEOs2Jk1n4P77y4AHePDW+YHtURpkOBymzj1AisvP7rGup4svXrdd0bCQS4YknnuDWW28F4Pbbb+f73/8+q1at4sUXX+R/fPp/8KP7f8Spk6dYulSJjrfb7VRXVzM0NERDgwY/gboS694N53wg5WGJrW3ThQwbTSEn08T8l/LqDP3mVY4/B0hd6l+pFCokXyvFFYhBuOwuKh2V+kartKmF77T7QXwBHzZho85Zp984UhCvQmyyCUtz4uTxZ/MOr1QnL2mQDyQYDLJp0yaampoYGBjgyiuvZHJykueee473v//9bNq0iY9//OP09/djL8lTH2w6WwnQyGDGsko730JkoavkZJ7t3q3UGWvVx/8B1umFrlJcgRiIGsqrG63nKQ9k925Yc62mj/iDfuqd9blH52SBo8RBbVmtfvkvOaJJSwsMK+U7dvyjpnOmWilIKTk4fJB6Zz2N5Y3ZDjUjqg8kEAhw1VVXceedd3LLLbdQU1PD3r1748d1jnZiEzZaW1vp6elhyZIlhMNhxsbGqK/XWMLGVqKU2+jenfYw3f17OeIP+llbt7Yg18opA/+46v8o020c/qCfra36rWjypbgCMRDd4+UdTqV6ahZ+EKN7oc9H1wz8HNGkpelUXkIIgV0Yn0zodru54447+Na3voXb7aa9vZ17770XUITY/n37cdgcXH/99fzsZz8D4L777mPHjh3ZmXjatip+kLEFRSHiVJdV47A5TP2epZQFfbazXl0HhqF/v67+j0BI8cEUImxZK0UBYiC6r0BAeSD79ysPqAYKXXhN1wz8HNHUvlfH8hJ2mz0eBWUkmzdv5pxzzuFXv/oV99xzD3fffTcbN25k/fr1PPrQo9htdm699VaGhoZYuXIl3/72t/nmN7+Z3UUS/SApUBPrzFyBTIWmCIaDBXu2q0qrKCsp0x44cOJ5dPd/WKiRlIpmu4YQwp1QWr2IBtQViJRSP0df21ZAKg/omndmPNwf9HOO5xx9rq2BBlcDR0aPFOx68wlHla6IGVcgOpaXsNvszEaNabA0OTm3B8WDDz4Y//vhhx8GlHt+a/gt7DY7TqczvjLJicYNp/0gGz+Y8jCzW9sWOiNbCJFdqZ64/+M83cZgtRwQ0LACEUJcLIR4EzgU+/dGIcS/GT6yM4AGVwOz0VnGZxdG7+TMki2n/SAZCEVDymRawAfO4/YwHBw2rTe6mjiZVktT/R86aYcOm4NwxLxyJqr5TJdqy7YSWL41oyPd6za3nIkZfcGzKhbavTvWrEtH/4fFstBBmwnrO8BVwBCAlPJ14BIjB3WmYEjDIXtZLB8kc8LXUFDp71DIl8zj8hCWYUamtfXY1htNE4vO5bXtNjsRaVw2eiZU85lugRJtW2GkG0Z7Uh5idjZ6IcPTVTSXMwmOQP8buvo/wJx7zoQmH4iUcv6TFDFgLGcchoW1avSDFDKJUMXsbHRN96yj/wMKm0yYjLzrYM1HXZmpgjYJHreHydAkgZA5Vu1CljFR0ez3Oa76P/QpoKjiC/hw2V1UOLLvCWQUWgRIjxDiYkAKIRxCiP+JUj23SAYSE650RfWDHH8u7WFmLPPNbjikSUvTubyEajoqhCM9GbqvQBo3gLMmbfVns3uj+wI+3HY35Q6NSX06oArNYDiY/sDjzyplh1q36Hp9f8BPg6vBMlnooE2AfAL4JEq72ZPApti/i2QgvgLRezJNzAdJgxmln9VrmTmxCETqxEmd/R9gjRVIia0Em9ApqNJmU/5/0phJzU4aVXuhF5J4CZdMUYbduxQFxeHU9fr+YOESJ7WS8YmTUg5KKT8ipWyUUnqllB+VUmZunlwEt0PRkHR/yeJ+kPQCxB/wUyJKCpKFrqJOLGbZxweDg9S70iRO6uz/AGsIEN0TRdu2wuhxGD2RdLfZyYT+gIZQbZ2Jl+pJl/8SHIW+fbr1P0/EDKGZCS1RWD8RQvx4/k8hBncmYFi8fNs2RZNO4wfxBXw0uBr000w1UFZSRnVZtak+kLRams7ltQFKRAlCCENMWFrKuYej4bgZ7dvf/jbr1q3jnHPO4fLLL+f48Rz7dqgCtju5H8TsciZmlPTQ5N878QJ6539A4RMntaJlZvkT8OfYzxNAFTCZ9hMaEUJcLYR4SwhxVAjx+ST7y4QQv4ntf1EI0Zaw7wux7W8JIa7SYzxGYFi8fLwuVmo/iFkai5mdCTPec/duWKZP/oeKEMKw1rZayrmHoqH4CmTz5s3s2bOHffv2ceONN/L3f//3uV3Yu04p2JnCjKUm1pmhKEgpTTVhpVUIu3cp/o8lb9P12oVOnNSKFhPW7xJ+7gE+AOTtHRJClAB3AtcA64CbhBDr5h12KzAipVyJEk78z7HPrkPpob4euBr4t9j5LIdhK5DWcxVNOo0ZyyybaYOrwTTTRlotzQD/h0oheqOnKuf+4Ws/TNfhLgC2b9+O2+0G4MILL6S3tze3i9lssbpYyQWImlhnhgAZnx1nJjJT8GdbLeGS9p67dyu5Wjr7P6zWylYlF8PpKkAPMXg+cFRK2QkghPg1cAOQ2Nv8BuCfYn/fB/yrUEIQbgB+LaWcAbqEEEdj58uuXV8B8Lg88d7oukZPaPCD+AN+zvXqZ6rRitft5eX+lwt+XTVxMqWWlo//4z8/r8T2p6AlMq3kgdjd2s/ZdDZco63USKpy7m0r2rjvsfv4wt99gV075072d999N9dcc4328cynbRsc+hOMHIfa5Qt2m5VMGI8uLPBkmrE3+vQY9O+DSz6r+7XNiKjUQkYBIoSYACQgYr/7AY1tztLSCiTml/QCF6Q6RkoZFkKMAfWx7S/M+2xrivHfDtwOsGzZMh2GnR0et4eZyAwToQn9u4i1bYOnvqZo1u65jvLZyCyjM6PmrUCMEJoZUBMn1V4sC+h+Vnf/h4oQQnvjpixQy7mfPHmStWvXLijnHpVRZiOzyPDca//iF79gz549PP3007lfPN4nfXdSAeJxeTg8cjj38+dIPFTbjGc7XbHQEy8obacNWOFaMYkQNAgQKaXx7b4MREp5F3AXwJYtW/R/wzOQaDfVX4AkJHytvW7OLjMLr3lcHsLRMKMzo9Q6tTW+0oOMpR7y8X9kWCmMB/z4Aj7W1K2hxKafNTVTOfeJ2QlOjJ+gvbo9/pnHH3+cr3/96zz99NOUleVRSsOzFlx1yv/b5o8s2O11e3n2VOpkQ6Mw+9nuHutOvrN7F5SU6u7/AHMSJ7WQ0gcihDg33Y8O1z4JLE3495LYtqTHCCHsQDVKSRUtn7UEhmZmt56X0g9i1jI/8ZqFto+ntRMb6P+AhN7o0hg/SKpy7qFoCCklb76hWH5fe+01Pv7xj/PAAw/g9eY52dhsSjZ1CjNpg6uBqdBUwbPR1cgvM8qaqybppHTvVpIHHS7dr2tG4qQW0jnRv5Xm5190uPbLwCohRLsQohTFKf7AvGMeAG6O/X0j8KRU7AQPAB+KRWm1o/hlXtJhTLpjaGa2vVTRqJO84PHKnSYs883KRk+rpcXbi+pbn0ilELkgycq5b3vbNm7YegN/fvDPAHz2s59lcnIy3q3w+uuvz++ibZfA2AmlNtY8DKu0kAF/wE+loxK3Iwt/k0543B7GZ8eZDk/P3TE9Dn2vG6agWDEHBNKYsKSU2428cMyn8SngEaAE+LGU8oAQ4qvAHinlA8DdwM9jTvJhFCFD7Ljfojjcw8AnpZSWrM9l+EvWthWeXOgHMXuZnziGQuEL+CgRJdSWJTGbGZD/kYhRAiRTOfdTk6cYnx1nTd0aQDFf6Upif5Datjm7EnNBllct9JEYhaZ+LwYRz0YPDs7tB2+g/wPMSZzUgqYoLCHEBpRQ23hsmpTyP/K9uJTyIeChedu+lPD3NPD+FJ/9OvD1fMdgNPFsdKO0cVWjnucH8QV82G12aspqjLluGlQndqFzQfxBP/Wu+uQ+CAPyPxIxqx5WYhKhIXjWgLs+5gf56JxdZmWjm5lQl1iqZ44A6d4FNoch/g9Q7vlsz9mGnDsftGSifxn4XuxnO/B/gDzXxf+1MLT0dUssH2Re4Tu1E6EZhddcdheVjsqCZyn7AynyXlT/x3LjeknbhA0hRMHLmSQmERpCvC7WbpgXZaYqCmaYsMxKqIuXM5n/bB9/Vsn/KNXfrCalZDA4aLkkQtCWiX4jcDnQL6X8GLARxZldRCNet9e4lyyFH8QXNLfsgcdd+Gz0lKaNuP/DOAFiZDZ6OgxfgYCyyh3rWeAHqXRU4ixxFnQFIqU09dlOGiAyMwGn9hpS/wpgIjTBdGTakiYsLQJkWkoZBcJCiCrAx9wIqCIZ8LgNbr7Ttg18B2DqdI3LwcCgqU43M3pmp9RMVf9Hq7FJlQ6bo6ACREppTCHF+aToky6EUJ7tdMUFdWZ0ZpRwNGxaQl1NWQ12YZ+rHJ14AWTkdN6Mzlg1hBfSh/HeKYTYCrwkhKgBfgi8AryKBTO+rUxib3RDSPSDxPAFfaaEOao0uAtb5mI2MsvIzEhyLS3e/0O/9qLJsNvsBfWB6N5IKhWeNeBuSBrtV2hFweyEOpuwUe+qn6sQxv0f5xtyTTMjKjORbgVyGPi/wLuA/wW8CFwJ3BwzZRXRiCG90RNp2ax02Iu94MFwkInZCVM1FsOF5jxUjXDBPcfzP4zRDhMptAkrLkCEwQJEiNP9QeZ9n4U2VVpBG1/QG12tf2WA/wPMjajMREoBIqX8/6SUF6H0Px8Cfgw8DLxHCLGqQOM7IzCkN3oi9lJYetoPotbqMVNjMVxoziOlllYA/4eKw+YgKqNEovpFlKcr566udhJ9ID/96U/xeDxs2rSJTZs28aMf/UifgbRthfGTMNI1Z3Ohe6NbQRtvcDWcvufpcUP9H2Bu4mQmtFTjPS6l/Gcp5WbgJuDdwCHDR3YGEY+XN9JW3LY15gcZtETlzrizsUDmjZSmjQL5P8CYXJB05dzVrPf5JqwPfvCD7N27l71793LbbbfpM5C2hLpYCXjdXgLhAFOhKX2ukwGzTVgwr11Bz4uK/8NABWUwOEiFo8KUxMlMaAnjtQshrhNC3AP8J/AW8F7DR3YGUZB4+fZLlN/Hn81cE6oAaOrepiMpq5V274albzPc/wGnTUlGmbHml3O/8bob+cDlH2DHZTs4dMhgnc5zFpR7FoSLF1pR8AV8VJdVU1Zi/PeZCo/bw+jMKLOR2dP+j6XG+D/A3LyXTKQ0ngohrkRZcVyLUibk18DtUsrCqBpnEAWJl0/wg/iWKwlHZj50qtmuUPZxf9CPXdjnFm8MDMPAG7D9H/I+/z+/9M8cGk4/SUdllGA4SFlJmSbH9pq6NXzufG2FrZOVc//Kt76Cd5mX0SOj/PVf/zVPPvkkAL/73e945plnWL16Nd/5zndYulSHoMm4HySWDxLLL0qsOtBW3Zb/dTKQMtengCRWl2jtflapSVdqXI0qK9xzKtKtQL4APAeslVJeL6X8ZVF45IbL7qKy1ODEuhIHLLsQunfjD/opKynTv/pvFhS6N7ov4KPBPa99rxqVZlB45XzUpE2JfoEDajn3pqYmBgYG5pRz//hffpz3XPoePv7xj9PX1wfAddddR3d3N/v27ePKK6/k5ptvznCFLGjbChOnYLgzvqnQrW2tUBMqLjTHjsOp1wz3r1nhnlORrhbWjkIO5ExHjUoylLat8MRX8Y330OBqMCULXcXtcBc0G90X8C002XXtUlZlOtS/0rJSkFJyaPgQtc5amsqb8r4mpC/n/uAzD+KwOVhWdbrPTX19ffzv2267LfeWtsloi5lJu3dD/Qqg8OVMfAHfnNL1ZqBO5r4Tzxnu/7BqL3QVLYmERXSgIAlXMUenf7STRnejsdfSQCE71vkDSbS07t1KdJpB9a/mo2ajG5ELkqyc+4O/fxC7zY6UktdfqhLGOAAAIABJREFUfx0gvhIBeOCBB1i7dq1+g2hYBeXeOW1uyx3luOyuguT8RGWUweCg6c923ITV/5rh/o/RmVFC0ZAly5hAUYAUjIJMpi2bwVGOPzBgCY2lkFnKC8pbTA0qUWkFCN9NxMhckMRy7j//xc+57+f3ceVFV7J+/Xr++Mc/AnDHHXewfv16Nm7cyB133MFPf/pT/QYw3w/C6TavhVAUhqeHiciI6c92TVkNdpsd38hRw/0f6gp+0ZmwiuiL2ogmKqNz7fR6UuJALr2AgfBRtlrA6eZ1e3mp3/g2LUkTJ+P+j0sMv34iDpuDYDio2/lSlXOfjczyg9/+gJaKljmBA9/4xjf4xje+odv1F9C2FQ7cr/hBYmasQikK8cnUZG1cCIHX2YBvvBPWvMvQa1k5iRCKK5CC4XGfbvNqJFPLLyAooNFufucyr9vLYGCQqIwaep2kiZNdu8BRrqzKCoi6AjE6A79gZUzmowrkrmfimwri38MaWegq3hIn/hKb8Q50EzuLaqEoQAqE4dnoMXyN6wDwTA5lONJ4PC4PYRlmZHrE0OsMBAaU6yW+ZN27lKi0EoMr1c7DbrMTlVHDhaYqQAyvxDuf+pVQ0TgnodDjVlbXRgtNKyTIqnhCIXx2u6H+D7BG5n06TBEgQog6IcRjQogjsd8LWsgJITYJIZ4XQhwQQuwTQnwwYd9PhRBdQoi9sZ9Nhb2D7ClUlz5fhdKV0Dt03NDraCEerWJwJFZ8ma+aNib94D+kS/hutpNivDe6wTWxVEd9LiuQvCb6JH4Qj8tDMBw0PBvdF/AhENS76jMfbDDeqWF8doeh/g9Q7rmmrIbSksIEgmSLWSuQzwNPSClXAU/E/j2fAPCXUsr1wNXAd2NVgVU+K6XcFPvZa/yQ86NQGbv+GUXb9/btN/Q6WihUz+y4bbw8JkDUKKE8Cyg6nU6GhoaymnDVCd3oqrzhaBghBCUiSffFNEgpGRoawul0Zj44FW3bYLIfho4CBSrVg/Lu1LvqC7/qms/MBN6xfqaENF5oBn2WMNmlwiwn+g3AZbG/fwbsBOYE2kspDyf8fUoI4QM8gLFOBINI2clMZ+JLXv9hRROvMD8b3fAVSMCPs8RJpaNS2dC9G0oroDm/hemSJUvo7e3F79cuAMPRML6Aj+myaUNrF41OjzITnUH4ss/1cTqdLFmyJPOBqYjXxdoFDavmmGc7qjtyP28GfAGfNUw5J17EE1YUBH/AT3m1wVnoFjDZpcIsAdIopVQD1vuBtIHdQojzgVLgWMLmrwshvkRsBSOlnEnx2duB2wGWLVuW7JCCUFpSSk1ZTUG08YoSF24p4fhuWP8eQ6+XjnpXPQJhvNCMhfDGEye7d8Gyi6Akv8fb4XDQ3p5d0logFODDv/wwnz7309y69ta8rp+O2x69jWA4yD3X3mPYNVJSvwIqmhRBveW/Fc48G/DplqCZF8d3440tSn0Bn6ElXPwBP6trVxt2/nwxzIQlhHhcCLE/yc8NicdJxT6Q0kYghGgGfg58LNYZEZQyK2uAtwF1zFu9zDv/XVLKLVLKLR6PuZLc8M6ExMoeVDQpGniSBkCFxGFzUOesK8iqK66ZTgzA4OGClS+Zj9vhptxRbngNMH/Ab15CnRDK/2/MD1Iw82yqlsWFpns33nolQdNIs10kGmFwetAa95wCwwSIlPIKKeWGJD9/BAZigkEVEEm/hVgL3T8DX5RSvpBw7j6pMAP8BDA2FEInChHuqJQ98MbrYpmNof3gY8zJQo/7PwqbQJhIIXpkmF5gr20rTA7A4BHKHeW47W5D7zkUCTE8PWy+P2BmEk6+ineZ0v/DyHsemh4iKqOm572kwywn+gOAWuXtZuCP8w8QQpQCvwf+Q0p537x9qvARKP1JzPcYa6AQCVfxmlBtW5VIpMnC9iWfj9GrLinl3GJz3bugrAqaNhp2zUwYLTQDoQAToQlzNdNEPwjG33O846TZk+lxpf5VeccO3Ha3oQqh1XNAwDwB8k3gSiHEEeCK2L8RQmwRQqgt1D6A0g3xliThuvcIId4A3gAagK8Vdvi54XF5GAoO6dqxLpGojJ5e5sf7pJu7CvG6vYYKkMnQJMFwMEGA7NbF/5EPRgvNlO17C0ldB1Q2x1e5Hrex5UyS5vqYQedOKCmDZRca/myr5za79lc6THnLpJRDwOVJtu8Bbov9/QvgFyk+vygrBXvdXiIywsjMiCHtKUdnRglHw8rE0rxJ8YN07TLVke51eRmeHiYUCeEwIKlvTiOp8T4ltPS8W3S/TjYk9oM3oiKyJZLLhFCUlM6dih/E5eGNwTcMu5y6ujF9Mu16GpZdAA6X4QLECt0XM1HMRC8gRvdOmFPqocSuaOIm+0HUezbKqTxHM7WA/wOM7wdvmQJ7bVthygeDh+MFFY3KRo8LTTMn00k/DOyH9ksB4812voAPm7BR56wz7Br5UhQgBcTo3gnxyVTVTNu2wuBbMFmYirjJiOeCGOT7mVNsrnMnuGpN9X/Ex4KBioJVCuypgrp7Fx63h+nINBOhCUMu5Qv4sNvs1JTVZD7YKLpj9b86LgNOmyqNFJr1zvrC1zvLgqIAKSBGZ+yqgim+zI87Os1bhRg9mcY1U2eDIkDaLwWbuY91PKzVIO3UF/DhsruocFQYcn7N1HVAVSt07TrdwjhgzEpTjTozrJK1FjqfVgI0YgmqXpeXUDRkWIHUBS0KLEhRgBQQtYaPUSsQVTDF/SvNG6G00lQBYnQGvj/gp9JRiXv8FIyfjGuHZmL0SlOdTM3sOAnMqYvlUVsYG6QcWaKkR9fTyv3GAjQMX2kma5JmMYoCpICoiXVGaqZ1zrrTzuoSOyw31w9S66zFbrMbN5mqUWedO5UNHZcZcp1saHArk6lh37OVNNO2rRAYxBNU+pYYphwFTBYgI93KT8z/AcbXevMH/OaHLWegKEAKjJGdCZNqLKofZGLAkGtmwiZshibWDajdFzt3Qs1yqDO3XzaAy+6istS4fvBJ+7+bRcwP4hl4EzBWGzc16qzzaeV3x2XxTUYGxcxGZhmZGbGOopCCogApMEZOpkmLzamOThPzQYxMoPQH/HidDUq4csdlhlwjF4xq8yqltFaBvdp2qFqC+8SLVDgqDIm2C4QCTIYmzV2BdD2t1P/ynBXfZKR51jKBEhkoCpACY2ToX9JlfpP5fpBGd6Mhk6maOOmNSpgZs5YAMUhoToQmmI5MW2diSfSDGJRAafpkKqXSgbH9EuV+Y5SWlFJbVmvMPSfmN1mYogApMB63ko2ud7+IUFSpFbRAM1X9IF27dL1eNhi16hqZHiEcDeOZiAmnBPu02XhdXkMiknxTFskBSaRtKwSG8JS4DVGOTM8B8b0JU37oWPh8GZWBr4bkW+p7TkJRgBQYr9uLROo+uQwFh5DI5A9c+yUwdATGenW9plY8bg+ToUkCoYCu5+0P9APQNNQNTedAufmd6lTUFYjeOQLxe7ZCWXOVWOVjTzhsiKJg+mSq+j+SKChet9eQlWb/lAW/5yQUBUiBaXIrD4Q6EehF/IFzJ3ngVsSqxhx7UtdrakXNS9FbOx2YUiaWpoGDljJfgTKxhKNh3XME0n7PZlGzHKqX0jg1zEBgQPd+8Kbfc+dOJeelZumCXUaVMxkIDOCyu6gqrdL93HpSFCAFRtUo1JdCL9TzNZYnqRXkXQuVLXD0CV2vqRWjolXi9zwzbTkBYpSDdSAwgEDEQ4UtgRDQcRlNQycIR8MMTw/revr+qX4qSysN7fCYkvCMUiJnRfLye2qB1HA0rOtl+6f6aXQ3mp/rk4GiACkwRguQpEteIZQXoHMnGFQJOB3qCkT3ew7048BGnYjV/bIQRmWj90/143F5zO8LPp+VV9A0o+SC6P09D0wNmGfKOfEChAKw8oqkuxvLGxWTtM7RZ6becxYUBUiBqSytpNxRbshk6ra7T/cFn8/KHTA9Cidf1fW6WjBKaA5MDeCNSmxLL4BSE7TTNBi1Aumf6rfmxNJxGU0Rxd9jxLNtmvnq6ONgc5wuCzQPdVx9U31J9+dKf6Df/MrDGigKEBNocjcZsgJpKm9KveTt2A4IOFZ4M5bL7qKmrEb/ex4/QdNMMKV2aCaN7kYEQn+hGRhIbqY0G1cNTd6zAWNW16YJzWNPKt09y5LXHWsubwb0vedwNMxgcNCaisI8TBEgQog6IcRjQogjsd+1KY6LJDSTeiBhe7sQ4kUhxFEhxG9i3QsXDU3lTbo70TMued110HquaX6Q5vJm3bW0gfEemiIRWHWlrufVA0eJgwZXg64Ti5Qybhu3IjUrrqQsGqV/tEu3cwbDQUZnRs2ZTMf7lPLtKxe0LoqjjkvPZ9sf8BOV0aIAScPngSeklKuAJ2L/TkZQSrkp9nN9wvZ/Br4jpVwJjAC3GjtcfWkqN2AFEtCgpa28Ak7ugeCIrtfWQmN5o65CMyqjDITGabK5wLtOt/Pqid5Cc3x2nGA4aNmJRay6guZwhH6/fh2m45F2ZtyzGrWYZoVbUVpBpaNS1/dZDVu2qqKQiFkC5AbgZ7G/f4bS11wTsT7oOwC1T3pWn7cCjeWNDE8PMxuZ1eV8oUiIoeBQZjvxistBRk/HtReQ5vJm+if1e8mGp3yEkTTWr56THWwl9FYU1InFqgKE5s00Sht94yd0O2U878UMH8jRx6GiERo3pD2sqaJJV0VhseSAgHkCpFFKqf6P9wOpRK1TCLFHCPGCEEIVEvXAqJRSjZvrBVpTXUgIcXvsHHv8fuO6h2WD+jKo2lW+DAQGkMjMD1zreVBWbYofpKm8iYnQBJOzk7qcr7/rKeW8rRfocj4jUFcgeiUTxsOWraqZ2mw0lTfSH5qAqD65IKZNptEIdD6lKF0ZFJQmd5Nu7zIUBQgAQojHhRD7k/zckHicVN6uVG/YcinlFuDDwHeFECuyHYeU8i4p5RYp5RaPxxp1ZeJRSTqZdNLmgCRSYlfKMRx9UqnvU0D0djb2H48JkPbk8flWoLmimZnIjG7JhIthYmmqP4tBG4RPvabL+dSJueCBA6deU0y9afwfKnqbKvsD/ZQ7yqksTRFRaSEMEyBSyiv+//bOPDqu4kz0v68ltSxLsqxd1mJLxpbkFbywLwEDYR0gwUlgJsRhyMtL5mROZpKZQN5M5uRNXk4gJ8m88OBNkgkJTMIEyAYOsQ3GrI/FC+BFsi1LtrW7JWtXa5e63h91W5asxa3ue3sx9TunT9+uW7e6qu699VV99dVXSqnV03xeAFpEZBGA9T2traNSqsn6PgG8DqwD2oGFIuLf57EQaHKqHE5gt1nrnNxbLLseehrhdJUt/x0odgvNFs9+AHIzltmSnhPYbeLZ0t9CnMRFtYO9vPxL8IlwuvpFW9Lz9HtIT0wnMS7RlvQCpuYVQCzrxdnJS86ja6iLgdEBW/66pa8lekeZZxEpFdZWYIt1vAV44ewIIpIuIonWcRZwJXDYGrG8Bmye7fpoxnYBMhdXD/4JweqXbfnvQPGPQGxpTHtb8PS1kChxpCdOa8AXFeSl2CtAPH0espKyiHPF2ZKeE+RllgLg8e8fHiIRM+Gt2aWtFgPwr+bE+xzNo8yJREqAPAzcKCLVwA3Wb0Rko4j83IqzAtgnIgfQAuNhpdRh69yDwNdEpAY9J/JEWHMfIknxSaQlptn6wAXs6iGtEHLXwLEdtvx3oGQlZeESlz1lPr4LT3wcuUlZUe3qwW61XSysTh739dZ+FAZCV915+jzhV195T0PjXlgWmHm4rZ0jArSojBLizx3FfpRS7cAU5aJSah/wBev4HWDNDNefAC5xMo9OkzffvrUgLf1zbFjKboa3fgT9HXp9SBiId8WTMz/Hnsa0eieexCTyFiwOPS0H8ateTnntU2GVZZSdO2IEGe+Nx1mLVlffHVJ6LX0tbMzdaEfWAqf6ZUBB2S0BRfeX2Y6JdL9FpVFhGWbFThPPlr6WuZk5lt4CaszS84YPW1bgj41AzS5a3EnkRpNH2mkQEW2+bENHIdoXEfpJcaeQkpCCZ14KVG0PKa2+kT56R3rD3xs/tl07H110YUDR/V4H7BiBtA60BmZRGSUYARIh8pLtsx2fs840fx0k54T8gs8VW6xV6t5mdKibVjUSEy9ZbnKuLfe5Y7CDwbFB8lPybciVs+Ql53FqQZ7uyY8Fv3FaRKzORofg+GtQelPA64vs9DrQ7G0GzqjFoh0jQCJEXnIevcO9IW+y1D/ST+dQ59waFpcLSj+uJwpDeMHnSl6KtpcPab+Io9vwJM5nDB+FqYX2Zc4h7FpA6W9YClJmXPIUNeQl5+FxJ8Jgt/ZmGyRNXm1cGdYy174Fw96A1Vd+7DLljUiZQ8AIkAhhlw+doB+40lv0PuL174b0/3Mhb34ew77h4PeLUAqqttNcpHXisfCSLUpexOmB04yEKKib+vR9joURyKLkRXjG+iHOHdIo1/9sh7XMVdshYb7exXMO5Cbn2jYCEcSMQAyzU5iie8/+lyRYgu6ZXnAdxCVCVfissUK2SmqpgO56mvLKgdhpTBVq3A1JsDT1xk7PND8ln86hLvqLr4aqbUEvWm32NuN2uclKCtPmWUrp92HpdZCQNKdLFyUvwtPnCdnrQJO3iZz5OSTERdl+LzNgBEiE8KtfGntD26e80auvn3Nj6k7Wvaxj28O2Kn1RihYgfqE3Z6q2A0JTqjYJjoU5ELvWCDR7m1mYuJDkhGQ7suUo48928aXQeRLajgWVTpO3ifyUfFwSpmaqpUIvsi27ec6XLkpexODYIJ1DoTkqbfY2x0QnwY8RIBEic14m8+LmjQuAYGn2NpMUn0TmvHMveJpC6U3QcSLoF3yu+F+MoEddR/8MhRfTPNxN7vzc6NuVbxr8gj3UkWZTX1NMjLjgzOi6MdvyPFS1Lah0mrxN4W1Mq3YAAqVzFyB+oekfKQZL2MscIkaARAgRIT8l35YHLj85P7gFdeW36e8jW2ePZxOp7lQWJi4MbtTV3QSn9kPZLeM901ggPzkfQWzpKMRKwzLeUfANaFPYozEiQI5shcKLISVnzpeOC80Q7vOIb4SW/paYebbBCJCIUpBSEHrPNJTGdEE+FF0GleHzBFOYUhjcS+bvxZbdGlO9tIS4BPKS80JSVSqlYkqA+FVtTd4mKL8dGvdAz9zUlt5hL91D3eFrTDtOgOcgrLzz3HGnoSBV35tQ7rPfQjFW7jMYARJRClMLafI2hTTxFnJjuvJOaDkE7ceDT2MOFKYWBveSHX4BssoYziihtb81pl6yotQiGnobgr6+fbCdobGhmOmZiojuHPU2wUprF4bDcxvljlsXpobpPvvzt/KO2ePNQFJ8EllJWSGNQGLNhBeMAIkoBSkFeEd0TysYeoZ76B3uDW09xIq/0N+HwzMKKUwtpNnbzJhvLPCLelug9v/Bqk/gsfY+iZXGFEIQmhax2LAUpBToxjS7FHJWweHn53S9v8x+1ZDjHH4B8tfDwuDd4xSmhHaf/cYlsfRsGwESQUI15fXPn4T0wC0sgoKN4RMgKYWMqtG5mbUe2QooWHXXeA8vlhrTotQi2gfbg140GkuLCP341bNK6ftG/btzUmOFtTHtqofmD4JWX/mxo6PgElf4nUeGgBEgEWRcbxrksNe2hmXlnXqCurM2tHQCICjz5crnIbscclbEZGMa6gSrv4MRK4vLQN/ngdEBvWg0CDVWk7eJpPik8LjrD1F95acwtRBPvyfoRaNN3iby5ufFhHWhHyNAIkioZq229cb9L04YRiHjAiTQxrTXA3Vvw6pP6Ot6G4kX7dk3VihKLQKCn2Bt6G0gY15GYO76o4RJQjMINVajt5GClILwuOs//ALkrYWMpSElU5hSiE/5aO4Lbp1TY29j+OZ8bMIIkAiS6k4lLTEtpIYl1Z3KAveC0DKSXqwdLFb+MbR0AiB3fi7xEh94mY/8CVDjvdj63noKUwuJd0VkJ4Kg8AvNYCfS63rqKF5QbGOOnGe8c+Q3U191l/aLFaAaq7G3MTy+zrrqtZVYiOorCH1xcH1vPYtTo3uLgrMxAiTCFKQUBP3A+RsWW3ppqzfrfaDbqkNPaxbiXfEsSlkUeJkr/mCpr7T7ktqeWhZH+T4gZ5OWmEaqOzX4hqWnPubKPEU9u/IuQAU0yh3zjVHfUx8eoXnwOf29ZvPs8QJgfNQVxH3uGe6hY7CDJQuWhJyPcBIRASIiGSKyU0Sqre8pik4RuU5E9k/4DIrIXda5J0Xk5IRzF4W/FPawJHUJ9b31QV1b11Nn3wO3ZjOICw48Y096sxDwWpDOWqh/B9Z8CgCf8tHQ0xBzLxnoMjd45z4C6R/p5/TA6Zgrc1J8EtlJ2dT11OmA7FK9qDCA58vT72HYN+x8mZWCg8/C4sv1KDxEsudn43a5g5rrqu/RbUCs3edIjUAeAnYppZYDu6zfk1BKvaaUukgpdRGwCegHJm7k/Y/+80qp/WHJtQMUpxXT7G1mcHRwTtcNjg7i6fPY1zNNzdNO5A4+B74Q3K0HQGFqYWBC88CzgMDazwDQ2t/K4NggS1Jj6yUDa81PEF4H/A1wrKk2AErSSqjtqT0TcOG92lij9cis1/nL7Hhjemq/duNjPV+h4hIXBakFQakqw1Zmm4mUALkTeMo6fgq46xzxNwPblVKhbZ4RhRQvKEah5vzQNfQ2oFD2DvMvvAe66x138V68oJjuoW46B2dxPKcUHPgNlFytTY0500uLNXUOaAHQ6G1k1Dc6p+vqemOzYQF9n2u7a88slF29GVzx+r7OQtga04PPaZfzq87V/ASOv8xzpb6nHkFiYo+biURKgOQqpfwbYXiAcxk+3wOc/dR9V0QOisi/iUjiTBeKyBdFZJ+I7Dt9+nQIWXaG4rRigMk9tQBw5CUrvw0SkuGgs2qskrQSAE52n5w5UsNu7cn1wnvHg/x1FIuNaUlaCaO+0Tnrx/1C02/JFUsUpxXTM9xzxkNtSjYsu9Ea5c68kLSup25cBeYYY6Nw6HfaoWiSfabCJWkl1PXWzbmjUNtTy6LkRSTGzdiURSWOCRAReUVEKqb5TDJ3ULp7MqMvDxFZBKwBXpoQ/E2gHLgYyAAenOl6pdTPlFIblVIbs7MdfCCDxD+CmGuvxZHG1J2sTXorX4CRuanU5oJfgJzoPjFzpAO/0Rv7+FfKoxtTt8sdE27czyagMk9DXU8dOUk5MWXC62faZ/uie6H3FJx4bcbr/HN7jprwHn8V+lptU1/5WZq2lFHf6JxN82PRUAIcFCBKqRuUUqun+bwAtFiCwS8gWmdJ6tPAH5VS46tzlFKnlGYI+CVwiVPlcJr5CfPJmZ8z5xFIfU89WUlZ9u8PceG9eqdCBz305qfkkxiXOPMIZLgfKv4IK+6AxNTx4LreOhYvWBy+/SFsJKBR1zTU99SzJC32Rlwww+i69GaYtxD2z6zGstU4ZCbefxKSs2H5TbYmO95R6Aq8o6CUoq43DGV2gEi9iVuBLdbxFmA22757OUt9NUH4CHr+pMKBPIaNkgUlcx6BOPaSFV8NGRfAvl/Yn7aFS1wULyieuTGt/IMWYus+Oym4trs2JieTQa/5yUnKmdMIRClFbU9tTDYsoF3Zu13uyc92fCKs/bTuoPS1TblmZGyEJm+Ts/e5pxmO7dDPV7zb1qTHOwo9gXcUOgY76B3ujcn7HCkB8jBwo4hUAzdYvxGRjSLyc38kESkGioA3zrr+aRE5BBwCsoD/FYY8O0ZxWjEne04G7JVXKcWJ7hPO2Mm7XLDxfj2R3nLY/vQtStJKZhYge5+ArDIovmo8aGhsiIbeBpalL3MsT05Tkja3jkL7YDtdQ10sWxibZY5zxbF4weKpjenGB2BsGD781ZRr6nrq8CnfeEPsCB/8CtQYrP+c7UmnulPJTsqe0wjkeJf2hB2L9zkiAkQp1a6Uul4ptdxSdXVY4fuUUl+YEK9WKVWglPKddf0mpdQaSyX2WaWUN9xlsJPiBcX0Dvdqv0EB0DbQRtdQF8vTlzuToQv/Uu+X7uAopCSthCZv01Tz5eYPtWO7jX8NE3Tgtd21jKkxli90qMxhoCSthBPdJwLuKFR36kWdsdiw+JnWKimnHJZcpZ+vsybTq7t0mUvTS53JkG8MPvhPbbIeouuSmShJK5nTCMRf5li8z7GnTD4PWbpQP8j+nsi58D9wjjWmyZnatPHAMzDkjGwuSStBoc4sNPOz9wk9eX7hPZOCY/kl81OSVoJ3xEvbwFTVzXT4n4cLFl7gZLYcpSSthIbeBobGhiafuPgB7Uak5pVJwdWd1cRJnHMjkOqX9b7nG+93Jn3OjK4D7SjUdNWQlphGVlKWY3lyCiNAooCy9DIAjnYcDSj+eM/USXXOxgdguNcxk96laVpoTpoT6O+Ait/D6rshaeGk+Me7jhPvio9JPbGf8Y5Cd2AdhZquGtIT04Pb7z5KKMsoY0yNTe0cld8OKbmw9+eTgmu6aliyYAnuOHvnJsZ593FYUABltzqTPlqA9A73BtxRqOmsYdnCZeFxHGkzRoBEAZlJmWQlZVHVWRVQ/JquGjLnZZIxL8O5TBVdAgUb4J3HZrXZD5aStBLiJX6y0Nz7BIz0w2VfnhK/prOG4gXFJMTFjqvrs/GPGKs6ArvP1V3VLEuPzYbFj79zNKXM8W7YcL8eEZw+c666s9o51Wzzfqh9Cy79Ejj4HPnVb4F0CJVS1HTVxOzI2giQKKEsvYxjnccCiuvoS+ZHBK78ql7Md+RPtifvjnNzwcILzrxkIwOw+yd6oVnuqinxq7uqY/Yl85OZlEnO/JyAG5bjXce5IC121VegF0AmxSdN3zm65L9BfBK8/WNA+/1q9DY6d5/ffQzcqbBhy7njhkB5hnb8Gch9bulvwTvijdln2wiQKKE0o5TjXcfPuRnNmG+ME90nwvPAld+uJxrf/rF2LWJ38hnlHO04qnVLWb4YAAAQ6ElEQVTF+/8L+tvgqr+bEs877KXJ2xSzL9lEVmSsCKhhafQ20jfS53xHwWHiXHEsT18+/agrOUtbQh18Frobx9VcjpS5q0F7dt6wBeal2Z/+BFLdqRSmFHKkY3afX8B4pzFW77MRIFFCWXoZI76Rc64TqO2pZWB0YLyX4yiuOLjib7VV1MmzLalDZ0XmCjoGO2j1NsM7j2qV2ZIrp8Q73K7NiVdlTR2ZxBrlGeWc6D7BwOjArPEq2yuB86PMZellVHVWTT+pfMVX9Pc7j43fZ0ee7bd+qL1NX/ol+9OehhWZgXUUKtoqEIQVGSvCkCv7MQIkSvDris+lxjrUdgiANdlrHM8ToE16U/Nh13dsH4X4G4qqfT/Rrtuv+cdJprt+Ktr1OtFVmbHfmK7IWIFP+cYNIWaisq2SBFcCpQsdMmcNI2XpZfQO93Kq79TUkwsXw5pPw/tPcujUbjLmZZCfbPM+6J21es3Jhi3jjjmdpjyjnIbeBnqHe2eNV9FWwdK0pTHpqgaMAIkaitOKSYpP4uDpg7PGq2irICUhJXw71CXMg2sfhKZ9ULXN1qT9QvPwkd9D4SXazcU0VLRVUJBSQPq8MOyP7TDlmYHpxyvbKynPKI9powE/KzNXAmc6P1O49kHwjVLR+Dars1bbbzTwxve1F+Cr/8HedGchkHkQpRSV7ZUxPco0AiRKiHfFszZrLQdOH5g13qG2Q6zKXBVef1AXfRYyl8Guf7XVIivFncIF7nT2yzBc/y/Tjj5A98ZXZ6227X8jSX5yPhnzMma9zz7l43D74fGGN9YpzyxnXtw89rfOsG1PejHeDVs4MdbH6qRF9v55y2HtmHPjA7DA5rRnYU2W1hDMdp9P9Z2iY7Ajpp9tI0CiiItyLqKqs4q+kb5pzw+ODnKs41j4H7i4eNj0z3D6KLz/S/vS7fWwvtPDgfnJjC25YtoobQNtNPc1j7+QsY6IsCF3A++3vD9jnONdx+kb6TtvypzgSmBV1qqZBQhQufImlAhrjr9jn6pUKdj+DT1pfk34Rh8A6fPSWZq2lA9aPpgxjl/bEMv32QiQKGJdzjp8yjejGmv/6f2MqlHW5awLc87Qe1qXfAxe+VfobbEnzZf/mfUDA3jxzTj3s+fUHgA25m605z+jgPU562nyNuHp80x7fo9Hl/nivIvDmS1HWZezjqMdR2c0HtjXXY0LYe3Jd+zzBF35R73uY9O3YL6Da6ZmYH3uej5s/ZCxGUbtezx7SE5IDo9BjEMYARJFrM1ei0tcM/ZOd5/aTZzEsSF3Q5hzhlYv3fYjGB2Al74Zeno1r8Ch37JhzX0AfNA6fU9tj2cPqQmpMf2SnY3//s10n/d69lKQUkB+is2TyRFkXc46RtXojCqd3ad2szJzJQty1sC2b8Bgd2h/2NcG2x/U+7Bv+HxoaQXJ+pz1eEe84254zmavZy/rc9YT74oPc87swwiQKCLVncrarLW81fTWtOd3n9rN6qzVpLhTwpwzi6xlcM03tLuRA88Gn05fOzz/N5BdzqLrvkVhSiHvNL8zbdQ9nj1syNtAnCsu+P+LMkrTS0l1p/Ju89Stg8d8Y+xr2XdejT5AjyATXAm81Tj12e4f6efQ6UNcuugyuONRvdHTi18LXpWlFPzpqzDYBXf9uzZHjwD+ezjdfW7tb6W2p5ZL8mJ2KyPACJCo42NFH+Nw+2FO90/efrdtoI3K9kouz788QjmzuOrvYfEV8OLfQ9vspqjT4huD578MA51w988hIYlri67lveb36B+ZvOX98a7jNPQ2cGX+1LUhsUycK46rC67mzcY3p6g3Pmj9gO6hbq4quGqGq2OT+QnzuSTvEt5sfHPKuXea32FUjepnO38dXPc/oOJ3etOnYNjzH3D0Ra26msarQbjIS86jPKOc1xqm7r74esPrAFxZENvPthEgUcbVBVcD8Hrj65PCd9Xtwqd8fHzJxyOQqwnExeuGPz4Rnv4UeOe4z/zL34Lql+Dm70Genjy8rug6hn3DU3pqO+t2IgjXL77ertxHDZsWb6JzqJMPWz+cFL6rfheJcYnjz8H5xDWF11DbUztlsezLtS+Tnph+RjV71dfhguv1BPiJ1+f2J8dfhR0PQektcPlX7Ml4CGwq2sT+1v20D7RPCt9Zt5PiBcUx713BCJAoozS9lKVpS3m++vlJ4dtObqMkrSQ6Hri0AvjL56DXA0/fHZgQUQpe/S689zhc8t/h4vFtX1iXu47MeZk8X3OmzD7l488n/sy6nHVkz4++vexD5aqCq0iKT2Lr8TMTxiNjI+w4uYMr86+M2YVls3HjkhuJk7hJz7Z32Mvrja9z/ZLrz8wFuFyw+QltOv7MX0H9e4H9wck3dfzscrj7P3Q6EebGJTeiUPzp+Bl/cp4+D3s9e7lhyQ0x7SgTIiRARORTIlIpIj4RmdG8RkRuFpEqEakRkYcmhJeIyG4r/FkRccj3c/gRETaXbuZg20Eq2vQK7Mq2Sj5o/YC7l98dPQ9c0cXwmV/B6WPwxI3gmWVX4eF+2PoVePP7sO4+PfqYQIIrgbtL7+aNxjdo6GkAtFqjtqeWzaWbnSxFxEhOSOb2pbez7eS28Y3EdtTuoH2wnU+VfSrCuXOG7PnZXFt0Lc/XPD+urvx99e8ZGB3g7uV3T46clA73/VG7fH/qDr2H+kxzIkrpTaJ+vRkWLoHPPQ+JqQ6XJjCWpS9jfc56nql6hlHfKADPHH0Gn/JNLXMMEikRXQF8EpiqELUQkTjgceAWYCVwr4j4V1Y9AvybUmoZ0Ak84Gx2w8tdy+4iPTGdh/c8TP9IP4/sfYS0xLToe+CW3whb/gTDffCzj8GOb0L7hH0fhrzaSeK/Xw4fPq1dlfzFo9NOan6m7DPMi5/H9/Z8j76RPn6474fkJ+dzU/FNYSxQePnsys8y5hvjB3t/QNdgF49++Chl6WVckT/9mpjzgc+v+jydQ508vv9xWvpa+NnBn3Fp3qXTr21KzYMvvAKFG+H5L8HTm6H27TOLWX0+Per41V2w9W9hyeXw+T9DSk54C3UO7l99P03eJp6sfJKT3Sf59ZFfc1PxTRSmFkY6ayEjge6a5cifi7wO/INSat805y4Hvq2Uusn67bcdfRg4DeQppUbPjjcbGzduVPv2TfmrqGTbiW08+NaDuF1uhn3DfO/q73H70tsjna3p6WuHnd/SOxiqMUjOhoQk6G7Sv3NX61FHyTWzJvP0kad5eM/DuF1uRtUoj216jKsLz7+5gIk89uFj/PTgT3G73CgUv7z5l1yYfWGks+Uo33n3Ozx37DncLjfxrnh+c9tvxjfbmpaxUdjzU3jjEW3e607Rnny9rXr/mKR0+NhD2j18FFrrKaX4+htfZ2fdTtwuNynuFJ69/VnykvMinbWAEZH3lVJTtEXRLEA2Azf790gXkfuAS4FvA+9Zow9EpAjYrpSadnm2iHwR+CLA4sWLN9TV1U0XLSrZVb+LV+tf5bqi67hhyQ2Rzs656WqAqu3gOQhjw5BWBMuuh6LLAtZHv3jiRd5rfo9bS27lioLztyfuRynFb4/9lkNth/jk8k9GZpFomBn1jfL0kac52X2Se8rvCXyNz3Cffr4a9mgrvuQsPTopvQXc0T1nNDw2zJOVT+Lp83Dfyvuc27LXIcIuQETkFWA6EftPSqkXrDiv47AAmUgsjUAMBoMhWphJgDi2BFIpFWqXuQmY6Hu50AprBxaKSLxSanRCuMFgMBjCSOTt3GZmL7DcsrhyA/cAW5UeMr0G+M1ztgAvRCiPBoPB8JElUma8nxCRRuBy4M8i8pIVni8i2wCs0cVXgJeAI8BzSqlKK4kHga+JSA2QCTwR7jIYDAbDR52ITqKHGzMHYjAYDHNnpjmQaFZhGQwGgyGKMQLEYDAYDEFhBIjBYDAYgsIIEIPBYDAExUdqEl1ETgPBLkXPAtpszM75iqmnwDF1FRimngLDyXpaopSa4hb7IyVAQkFE9k1nhWCYjKmnwDF1FRimngIjEvVkVFgGg8FgCAojQAwGg8EQFEaABM7PIp2BGMHUU+CYugoMU0+BEfZ6MnMgBoPBYAgKMwIxGAwGQ1AYAWIwGAyGoDACJABE5GYRqRKRGhF5KNL5CTci8gsRaRWRiglhGSKyU0Sqre90K1xE5FGrrg6KyPoJ12yx4leLyJZIlMVJRKRIRF4TkcMiUikiX7XCTV1NQETmicgeETlg1dP/tMJLRGS3VR/PWts4ICKJ1u8a63zxhLS+aYVXicg5t7WORUQkTkQ+FJEXrd/RU09KKfOZ5QPEAceBpYAbOACsjHS+wlwH1wDrgYoJYd8HHrKOHwIesY5vBbYDAlwG7LbCM4AT1ne6dZwe6bLZXE+LgPXWcSpwDFhp6mpKPQmQYh0nALut8j8H3GOF/wT4snX8N8BPrON7gGet45XW+5gIlFjvaVyky+dAfX0N+C/gRet31NSTGYGcm0uAGqXUCaXUMPAMcGeE8xRWlFJvAh1nBd8JPGUdPwXcNSH8P5XmPfTukYuAm4CdSqkOpVQnsBO42fnchw+l1Cml1AfWcS96H5sCTF1Nwiqv1/qZYH0UsAn4nRV+dj356+93wPUiIlb4M0qpIaXUSaAG/b6eN4hIIXAb8HPrtxBF9WQEyLkpABom/G60wj7q5CqlTlnHHiDXOp6pvj5S9WipD9ahe9emrs7CUsvsB1rRAvI40KX0RnIwuczj9WGd70ZvJHfe1xPwv4FvAD7rdyZRVE9GgBhCRulxsrEHtxCRFOD3wN8ppXomnjN1pVFKjSmlLgIK0b3h8ghnKeoQkduBVqXU+5HOy0wYAXJumoCiCb8LrbCPOi2WugXru9UKn6m+PhL1KCIJaOHxtFLqD1awqasZUEp1Aa+ht7deKCLx1qmJZR6vD+t8GtDO+V9PVwJ3iEgtWnW+CfgxUVRPRoCcm73AcsvywY2enNoa4TxFA1sBv3XQFuCFCeGfsyyMLgO6LfXNS8DHRSTdskL6uBV23mDpm58AjiilfjThlKmrCYhItogstI6TgBvR80WvAZutaGfXk7/+NgOvWiO5rcA9lvVRCbAc2BOeUjiPUuqbSqlCpVQxut15VSn1V0RTPUXawiAWPmhrmWNoPe0/RTo/ESj/b4BTwAhaf/oAWre6C6gGXgEyrLgCPG7V1SFg44R0/ho9gVcD3B/pcjlQT1eh1VMHgf3W51ZTV1PqaS3woVVPFcC/WOFLrYatBvgtkGiFz7N+11jnl05I65+s+qsCbol02Ryss2s5Y4UVNfVkXJkYDAaDISiMCstgMBgMQWEEiMFgMBiCwggQg8FgMASFESAGg8FgCAojQAwGg8EQFEaAGAwOICKZIrLf+nhEpMk69orI/410/gwGOzBmvAaDw4jItwGvUuoHkc6LwWAnZgRiMIQREbl2wr4O3xaRp0TkLRGpE5FPisj3ReSQiOyw3KIgIhtE5A0ReV9EXvK7RTEYIo0RIAZDZLkA7ePoDuDXwGtKqTXAAHCbJUT+D7BZKbUB+AXw3Uhl1mCYSPy5oxgMBgfZrpQaEZFD6M3Ldljhh4BioAxYDezUrraIQ7uVMRgijhEgBkNkGQJQSvlEZESdmZT0od9PASqVUpdHKoMGw0wYFZbBEN1UAdkicjlod/EisirCeTIYACNADIaoRultlDcDj4jIAbSH3ysimyuDQWPMeA0Gg8EQFGYEYjAYDIagMALEYDAYDEFhBIjBYDAYgsIIEIPBYDAEhREgBoPBYAgKI0AMBoPBEBRGgBgMBoMhKP4/Rn2H5wyDs1gAAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "data = bifrost.ndarray(shape=(16, 4096), dtype='cf32', space='cuda')\n",
+        "bifrost.map(\"a(i,j) = exp(Complex<float>(0.0, 2*3.14*i*j/4096))\",\n",
+        "            {'a': data},\n",
+        "            axis_names=('i', 'j'),\n",
+        "            shape=data.shape)\n",
+        "data2 = data.copy(space='system')\n",
+        "\n",
+        "import pylab\n",
+        "pylab.plot(data2[0,:].real, label='Re0')\n",
+        "#pylab.plot(data2[0,:].imag, label='Im0')\n",
+        "pylab.plot(data2[2,:].real, label='Re2')\n",
+        "#pylab.plot(data2[2,:].imag, label='Im2')\n",
+        "pylab.plot(data2[5,:].real, label='Re5')\n",
+        "#pylab.plot(data2[5,:].imag, label='Im5')\n",
+        "pylab.xlabel('Time')\n",
+        "pylab.ylabel('Value')\n",
+        "pylab.legend(loc=0)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "soviet-conference",
+      "metadata": {
+        "id": "soviet-conference"
+      },
+      "source": [
+        "Now run the FFT and plot the results. The FFT is initialised using its `.init` method, and then executed using its `.execute` method.  An output data array also needs to be pre-allocated :"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "moral-worship",
+      "metadata": {
+        "id": "moral-worship",
+        "outputId": "859202c4-b770-4327-f4fb-58ac177c89a7"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<matplotlib.legend.Legend at 0x7eff6b1b8b38>"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZUAAAEGCAYAAACtqQjWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3de3xdZZno8d+T+/1+a5O2aWlJs1sQSy0DIsJwK4hcPQOoHDzwsaLi0WF0ZERndJwz4O0oCsrxwqB8HJBRVHAKLaiAXHsDhKZNk7aBJrRJm3vS3POeP961k500adJk7bX25fl+PvuTvVfWXuvJzt77We/7vOtdYoxBKaWUckOC3wEopZSKHZpUlFJKuUaTilJKKddoUlFKKeUaTSpKKaVck+R3AOFQVFRkKisr/Q5DKaWiyvbt248YY4rns42YTCqVlZVs27bN7zCUUiqqiMhb892Gdn8ppZRyjSYVpZRSrtGkopRSyjUxWVNRSik/DA0N0djYSH9/v9+hHFdaWhoVFRUkJye7vm1NKkop5ZLGxkays7OprKxERPwOZ0rGGFpbW2lsbGTp0qWub1+7v5RSyiX9/f0UFhZGbEIBEBEKCwvD1prSpKKUUi6K5IQSFM4YNako5ZH23kE2vnHQ7zCg9glon/fpCL574/AbvH74db/DUJNoUlHKIxse3ManfrmDlm4fi7hDffDwR+D57/oXg0v+9eV/5asvftXvMCLSk08+SVVVFcuXL+euu+7ydN+aVJTySGN7HwDDIz5eGO/IHjAj0FLjXwwuGBgZoL69nn2d+zg6dNTvcCLKyMgIn/70p3niiSeoqanhoYceoqbGu/+3JhWl4knLrvGfUXzV1z1texg2w4yaUfa07/E7nIiyZcsWli9fzrJly0hJSeG6667j97//vWf71yHFSsWTYAtloAu6miC3wt945qimdfzIe2frTk4rOc3HaKb2tcd3UvNOl6vbDCzM4V8+uOq46zQ1NbFo0aKxxxUVFbzyyiuuxnE82lJRKp4010BC0vj9KFXTVkNuai6FaYUTEozyn7ZUlIonLbtg2XlQ/5RttZx8kd8RzUlNaw2BggBJCUkRm1RmalGES3l5OQcOHBh73NjYSHl5uWf715aKUvGivxO6GmHJWZC9YLy+EmWCRfpAYYBAYYB9nfvoG+7zO6yI8Z73vIe6ujr279/P4OAgDz/8MJdffrln+9eWilLxomW3/Vm6CkoCUTsCrK69jmEzTKDQtlRGzSi1bbURWVfxQ1JSEvfccw8XX3wxIyMj3HTTTaxa5V2rSZOKUvGiZaf9WVJtb1ueh5FhSIyur4Fgd1cwqQSXaVIZd+mll3LppZf6sm/t/lIqXrTsgpQsyF1kWyojA9C+3++oTlhNaw05KTmUZ5VTmlFKQVpBxNZV4pEmFaXiRcsu20IRsT8hKrvAalprCBQGEBFEhEBhgJq26Ps7YpUmFaXigTHQvNO2UACKVwISdcX6wZFB6jrqCBQGxpYFCgPs69hH/3BkX8MkXmhSUSoe9LRAX9t4UknJgIKlUddSqWuvY3h0+JikMmJGqG2v9TEyFaRJRal4EEwewW4vsAkmyk6A3NlqBxuEJpVVhXZkk9ZVIoMmFaXiQbCbq2T8y5iSamjbC0PR020ULNJXZI1PL6PF+siiSUWpeNBSA5nFkFU8vqwkAGbUzlwcJWpaa6gurJ5wkSkRobqwWpOK48CBA5x33nkEAgFWrVrF3Xff7en+NakoFQ9aaiZ2fcF4qyVKivVTFemDAgUB9nbs1WI99uTH73znO9TU1PDyyy9z77336tT3oUQkQUT+j4j8QERu9DsepaLO6Kg9m75k0pdx4UmQkDx+UmSEq+s4tkgftKpwFSNmRKfBBxYsWMCaNWsAyM7Oprq6mqamJs/278uptCJyP3AZ0GKMWR2yfD1wN5AI/NQYcxdwBVABtAKNPoSrVHTrfBuGeo9tqSQmQ9HJUdNSCXZvrSo4dsqRYKKpaa3h1OJTPY1rWk/cDofecHebZafAJbO/kmNDQwOvvvoqZ5xxhrtxHIdfLZUHgPWhC0QkEbgXuAQIANeLSACoAl40xtwGfNLjOJWKfmNF+inmfyoNRFVSyU7JpiL72GvAlGWWkZ+ar3WVED09PVxzzTV873vfIycnx7P9+tJSMcY8JyKVkxavA+qNMfsARORhbCvlADDorDMy3TZFZAOwAWDx4sUuR6xUFGt2ureKq479XUk1vPFf0N8Fad598czFziM7CRQEJhTpg8bOrI+kpHICLQq3DQ0Ncc011/CRj3yEq6++2tN9R1JNpRybQIIanWWPAheLyA+A56Z7sjHmx8aYtcaYtcXFxdOtplT8adkFuYunThpRUqw/XpE+KFBoi/UDIwMeRhZ5jDHcfPPNVFdXc9ttt3m+/0hKKlMyxhw1xtxsjPmMMeZev+NRar48vzJ8cM6vqUTJHGBjRfqi4yeVYTPMnrb4Lta/8MILPPjgg/zpT3/itNNO47TTTmPjxo2e7T+S5rxuAhaFPK5wliml5mpkyJ6HMt0VHnMX25mLI7ylcrwifVBosf6U4lM8iSsSnX322Rjj+aHLmEhqqWwFVojIUhFJAa4DHvM5JqVcd2xFIIxa62F06NjhxEEJCXZyyQhvqRyvSB+0IHMBeal5OmOxz3xJKiLyEPASUCUijSJyszFmGLgV2ATsAh4xxkTHAHqlItVUc35NVlJt1/Px6HYmwWvST1WkD4rIYn0c8iWpGGOuN8YsMMYkG2MqjDE/c5ZvNMacbIw5yRjzf/yITalw8/Sru2UXSKI9H2U6JQE42gq9h72L6wQMjQxR1378In1QoDBAfXt93Bfr/RRJ3V9KKbe17ILC5ZCUOv06pcERYJF5hF/XUcfQ6NCsk8qwGaauvc6DyNRUNKko5TFPayrNO4/f9QURP6w49Jr0Mwkt1it/aFJRKlYN9kJ7w/RF+qDMYsgoHD9JMsLUtNaQnZzNouxFM667MHMhuam5mlR8FElDipWKC57VVA7X2r3N1FIRsYknglsqk6e7n46IECjQYn1lZSXZ2dkkJiaSlJTEtm3bPNu3tlSUilXBGknp9Od2jCkJwOHddkbjCDI0MsSe9j2z6voKChQGqOuoY3BkcOaVY9if//xnXnvtNU8TCmhSUcpzntVUWnZBUhrkV868bkk1DPZA54GZ1/VQfUf9rIv0QYHCAMOjWqz3i3Z/KRWrWmrsJJIJiTOvWxIyAix/SXjjOgEnUqQPCq67s3Unq4pm0UoLk29s+Qa723a7us2VBSv54rovzrieiHDRRRchInziE59gw4YNrsZxPJpUlIpVLbtg2XmzW7dkpfOcGqi6JHwxnaCa1hqykrNmVaQPKs8qJyclJ67rKs8//zzl5eW0tLRw4YUXsnLlSs455xxP9q1JRalYdLQNug/OXKQPSsuF3EURV6wPFukTZPY99ZFyZv1sWhThUl5eDkBJSQlXXXUVW7Zs8SypaE1FqVg0dmGu2Xcb2elaIiepDI06RfqCE/gbHPFcrO/t7aW7u3vs/ubNm1m9evUMz3KPtlSUikWzmfNrspJq2PtnO7NxYnJ44joBezv2Mjg6eEL1lKCxYn1HHasK/aur+KG5uZmrrroKgOHhYT784Q+zfv36GZ7lHk0qSsWill22Sytn4eyfUxKwMxq37h2vsfhoLkX6oNAz6+MtqSxbtozXX3/dt/1r95dSsailxiaJWZwwOKYksuYAq2mtITM5k8U5J3558Iqsirgv1vtFk4pSscYYJ6mcQNcX2JmMJSFi6io1rTVUF5xYkT5IRKgurNak4gNNKkp5LOzTtHQfhP7OEyvSAySnQcFJEdFSGRodoratdl5dV4HCAHXtdQyNDLkY2cz8vOribIUzRk0qSsWasSL9idcixi7Y5bP5FOmDAoUBhkaHqOvw7sz6tLQ0WltbIzqxGGNobW0lLS0tLNvXQr1SHgv7NC3Ncxj5FVS6CnY9DoNHISXD3bhOwHyK9EHB69nXtNbMazsnoqKigsbGRg4fjswLngWlpaVRUTH9pZnnQ5OKUrGmZRdklUFGwYk/t6QaMHCkFha+2/XQZms+RfqgiuwKslOyPa2rJCcns3TpUs/2F4m0+0spj4W9Y2QuRfqgYJdZs79dYPMp0gfpNPj+0KSiVCwZHbHXUZnNdPdTyV8Kiam+1lWCRXo3uqwChQH2tO/xvFgfzzSpKOWxsNZU2htguG/uLZXEJDuzsY/Divd17Jt3kT4oWKyv76h3ITI1G5pUlIolc5meZTKfrwLpRpE+SK9Z772oSCoikiki20TkMr9jUWq+wlpTadkFCBTPY5qVkmrofgf62l0L60TsbN1JZnImS3Lmf12XRdmLyE72tlgf73xJKiJyv4i0iMibk5avF5FaEakXkdtDfvVF4BFvo1QqCrXU2Cs9pmTOfRtj07X401rZ1bqLlQUr51WkD9Iz673nV0vlAWDCtJkikgjcC1wCBIDrRSQgIhcCNUCL10EqFQ5hrak018ztpMdQpf7NATY8OkxtuztF+qCxYv2oFuu94EtSMcY8B7RNWrwOqDfG7DPGDAIPA1cA5wJ/A3wY+LjI1IcvIrLB6SLbFuknHikVFsMD0Fo/v3oKQE45pOb40lLZ27GXgZEB15PK4Oggezv2urZNNb1IqqmUAwdCHjcC5caYO4wxnwP+E/iJMWZ0qicbY35sjFlrjFlbXFzsQbhKzU3YaipH6sCMzD+piPh2wS43i/RBWqz3ViQlleMyxjxgjPmD33EoFbGCSWCu56iEKqmG5p12xmMP1bTWkJGUQWVOpWvbXJS9iKzkLE0qHomkpNIELAp5XOEsUyqmhK2m0rITEpLtTMPzVbIK+jug+9D8t3UCatpqXCvSByVIghbrPRRJSWUrsEJElopICnAd8JjPMSnlurAd+7fsgqIVkJQy/20Fu9A8LNYPjw6zp21PWCZ/DBQEqG2r1WK9B/waUvwQ8BJQJSKNInKzMWYYuBXYBOwCHjHG7PQjPqWi0nzm/JpsLKl4V1fZ17mP/pH+8CQVp1i/r2Of69tWE/kyS7Ex5vpplm8ENnocjlLRb6AbOt6GNTe6s73MIsgs8bSlEuyeCsc15UOL9VUFVa5vX42LpO4vpdRctey2P+d7jkqo0oDnSSU9Kd2VM+knW5yzmMzkTHa2audHuGlSUcpjYbkqoBtzfk1WErDJanTKUfyuC053n5iQ6Pq2EySB6oJqdrX6N6dZvNCkolQsaNkFyZmQ5+JRfkm1nfG4o8G9bU5jeHTYtenupxMoDFDbXsvw6HDY9qE0qSgVG1pqoGQlJLj4kfbwgl3hLNIHBQoDDIwM6Jn1YaZJRalY4ObIr6DgTMcejAALZ5E+SM+s94YmFaU85npJpecw9B52t0gPkJplu9M8KNaHs0gftCRnCZnJmZpUwkyTilLR7rDTknC7pQKeXbArnEX6oARJYGXBSmraNKmEkyYVpaJd8Eu/JAxdRyXV0FoHw4Pub9vhRZE+KFAYYE/bHi3Wh5EmFaWiXfNOSC+ArBL3t126CkaHbWIJk/2d+8NepA8KFAboH+lnX6eeWR8umlSUinYtu2w3lYRhqkoPpmsJx3T309FiffhpUlEqmhnjJJUw1FMACldAQlJYi/XBIr2b091PpzKnkoykDE0qYaRJRalo1tkIg93jlwB2W1IKFC4P67kqNa12uvtwFumDxor1mlTCRpOKUtFsbHqWMHYdlYRvDrCR0RHXr0k/k0ChnQZfi/XhoUlFKY+5ep5K8Ms+eKJiOJQEoOMtGOhxfdP7O/fTN9zneVLpH+lnf+d+z/YZTzSpKBXNWnZBTgWk54VvH8F6zeFa1zcdPGckUOBdUgmeta9dYOGhSUWpaNYchulZJhsbAeb+tPHBIv3S3KWub3s6S3KWkJ6UrkklTDSpKOUx49YFhUeG4Uht+JNK/lJISg/LsOKa1hqq8qs8KdIHJSYkUl2g16wPF00qSnnE9bNI2vbByGB4i/RgZz4uWel6sX5kdITdbbs9racEBafBHxkd8XzfsU6TilIecf3SXMEv+XANJw4VhjnAGroaPC/SBwUKA/QN92mxPgw0qSgVrVpqQBKg6OTw76skAD3N0Nvq2ia9PJN+srEz63VySddpUlHKY64NKW6pgYJlkJzu0gaPY6xY796XsB9F+qDKnEot1oeJJhWlPOJ6TSWc07NMFqzbuNgFFizSJyUkubbN2UpMSNQz68Mk4pOKiFwpIj8RkV+JyEV+x6PUXLlaUxnqs4X6cEx3P5XsMkjLc62lMjI6wq62Xb50fQUFCgPsbtutxXqX+ZJUROR+EWkRkTcnLV8vIrUiUi8itwMYY35njPk4cAtwrR/xKhVxDteCGfWupSJip8F3Kan4WaQPChbrG7oafIshFvnVUnkAWB+6QEQSgXuBS4AAcL2IhL7jvuz8Xqmo5kqLZezCXB5+KZdU2/26UBR6+eDLgD9F+qDgWfzbm7f7FkMs8iWpGGOeA9omLV4H1Btj9hljBoGHgSvE+gbwhDFmh9exKhWRWmogMdUW6r1SUg0DXdDVNOdNHOw5yOef/Tx3bbmL5XnLfSnSBy3NXcri7MX828v/xtde+hpt/ZO/ktRcRFJNpRw4EPK40Vn2GeAC4EMicst0TxaRDSKyTUS2HT58OLyRKuW3ll1QfDIkeljknkexvn+4nx+99iMu/93lPHPgGT71rk/xnx/4T1+K9EGJCYk8dNlD3BC4gd/V/Y7LHr2MB2seZGh0yLeYYkEkJZUpGWO+b4w53RhzizHmvuOs92NjzFpjzNri4mIvQ1TKey013nZ9wZyGFRtj2Nywmct/dzk/fP2HvH/R+3n8ysf55GmfJD3Jg6HQM8hJyeEL7/kCv7niN5xacirf3PpNrnnsGl5oesHv0KLWjElFRBJFZLcHsTQBi0IeVzjLlIopZr41ib4O2wXlVZE+KD0fshfO+oJde9r3cPPmm/mHZ/+B7JRs7r/4fr79/m+zIGtBmAM9cctyl/Gj83/Eveffy6gZ5Zanb+Ezf/wMb3W95XdoUWfGtqcxZsQZkbXYGPN2GGPZCqwQkaXYZHId8OEw7k+p6HTYOcbzuqUCTrH++Emlc6CTe169h0f2PEJ2SjZfPuPLXHPyNb52dc2GiHBOxTmcueBMfrnrl9z31/u48vdXckPgBjacsoGslCy/Q4wKs/0v5wM7RWQL0BtcaIy5fC47FZGHgHOBIhFpBP7FGPMzEbkV2AQkAvcbY9yfa1upaOfF1R6nU1INW56H0RGYNLPw8Ogwv97za+557R56Bnu4tupaPn3ap8lNzfU+znlITkzmY6s/xmUnXcbdO+7mP978Dx7f+zifXfNZLj/pchIk4qsGvpptUvmKmzs1xlw/zfKNwEY396VUpJn3gNzmGkjJhtwKN8I5MaWrYGQA2vZD0fKxxVsPbeXOLXdS117HGWVn8MV1X2RF/grv43NRUXoRX3/v17m26lru2nIXX3nhK/xq96+4/YzbeVfxu/wOL2LNKuUaY54FGoBk5/5WQIf3KnUCXJumJTg9i7g+8cvMJl2w652ed7jtmdu4adNNHB06ynfP/S4/uegnUZ9QQq0uWs2DlzzIv5/977QcbeGjGz/Kl/7yJVqOtvgdWkSaVUtFRD4ObAAKgJOwQ33vA84PX2hKxRZXTno0xnZ/VX/Qja2duKIqQOg79Ab/MdjE/W/ejyB8+rRP87FVHyMtKc2fuMJMRPjgSR/k/MXn89M3fsoDOx/g6befZsOpG7ghcAOpial+hxgxZtv99WnsyYmvABhj6kSkJGxRKaWm1tMCfW22G8oH9b3v8OSCxfyu8VGaDwxxSeUl3Lb2Nsoyy3yJx2sZyRn87zX/m6tWXMW3t36bu3fcza/3/JqrV1zN+sr1LM5Z7HeIvpttUhkwxgyK09wWkSTCcM0hpeLBvEYUB68T7+Fw4obOBp5seJJNDZuo76gnIQ3eMzTCNy57gNNLT/csjkiyKHsRd//t3bz0zkvc9/p9/ODVH/CDV39AdUE165eu5+LKiynPKvc7TF/MNqk8KyJfAtJF5ELgU8Dj4QtLqdjjSgXEozm/Grsb2dSwiScbnmR3mx3CvKZkDV8640tceKCGohfvhQJ/WkuR5MyFZ3LmwjM51HuITQ2b2NSwie9u/y7f3f5dTi06lYsrL+aiyovipiUHs08qtwM3A28An8CO0PppuIJSKhbNu2k/1A/7noHMYsgsciGiiUK/GN848gYApxadyhfWfmHiF+Pwo2BGbCxV66ffYBwpyyzjxlU3cuOqG8cS8qaGTXxr27f41rZvsaZkzViCKUp3/38XSWQ2Z/eKyPnAi8aYvvCHNH9r164127Zt8zsMpSY4884/crCzn6dvez/LS07gRDpjYPcfYNMd0PEWvPezcOG/uhLTkb4jbG7YzJMNT/Jqy6sAM3fh9ByG//c+6D4I7/owXPAv9nor6hgNnQ1jLb76jnoSJIG1pWu5uPJiLlhyAQVpBX6HOIGIbDfGrJ3XNmaZVH4OnImdWfgvwHPA88aY9vnsPFw0qahINJ5UzmF5SfbsntSyG578om0VFFfDJXfBsnPnFUdbfxtPv/U0mxo2sa15G6NmlOV5y1lfuZ71S9ezJGfJzBsZ6IbnvgUv/RCSUuGcL8DffNLeV1Oqb68fq001dDWQKImsK1vH+qXrOX/x+RFxkqhnSSVkhwuBDwGfBxYaYyJy3gVNKioSnXXnH3lntkmlrx2euQu2/ARSs+C8O2DtzXOalbi5t5kdLTvY3ryd7c3bqe+oB+x12tcvXc/6yvWclHfSXP4kaN1rW1B7nrDT8F/873Dyen/OoYkSxhhq22t5cv+TPNnwJE09TQhCVUEVp5eezpqSNawpXeNLN5mXLZWPAu8DTgGOAM8DfzHGvDSfnYeLJhUViWbVUhkdgR0/hz9+Hfo74PSPwXlfhszCWe3DGENjdyPbmrexvXk7O1p2cKDbXlEiIymDd5e8mzWlazin4hyq8qsQt77865+GJ/8JjuyBk86H9XfZqfnVcRlj2Nm6k+can2NH8w5eP/w6/SP9gE36p5eePnZbmLUw7PG4kVRme9jzPWAv9oTHPxtjGuazU6XUFBpesF1dh96AJe+1X8wLTj3uU0bNKHs79rKjebwl0tJnz/TOTc3l9JLTubbqWtaWrqWqoCp8kzouvwA++X7bsnrmLvjRmbDuE/D+f4T0vPDsMwaICKuLVrO6aDUAQyND7GzdOday3Nywmd/U/QaABZkLJiSZypxK9w4KXDTr7i8RWQWcA5wNrABqjTE3hDG2OdOWiopEwZbKU39/DitKQ1oqHQfgqa/Azt9CTgVc9HVYddWUXUjDo8PUttVOaIl0DnQCUJJeMuFLZ1neMn8mP+w5DH/6Ouz4BWQUwvlfgXffcMwElGpmI6Mj1HXUjR0wbG/ePnaFyoK0ggn/7xV5K0ic52vsWUtFRHKAxcASoBLIBUbns2Ol4s0xKWKoD174Pjz/XcDA+2+3I7tSMgDoGexhT/sedrftpra9lt1tu6lvr2dwdBCwJ+Cdt+i8sS+ViqyKyDhyzSqGy78Pa2+CJ74Ij38Wtv4MLvkmLDnT7+iiSmJCIisLVrKyYCUfqf4IxhgauhomtEyfeuspANIS0zg5/2SqCqpYWbCSqoIqVuStICM5w9OYZ1tT+Su2jvI88JwxpjHcgc2HtlRUJBprqXzufaxo/RNs/gp0vo2pvoLmcz5H7XD3hAQSrIUA5KXmjX25BAoDnF56OiUZUTBTkjHw5m/gqX+2FxZb/SE7HDo3Ps82D4eDPQfZ1ryNmtaasfdO92A3AIKwJGfJWJKpyrcJpyi9aMoDED9Gf2UBGGN65rPTcNOkoiLRmXf+kZyuXXx72W9p6KihNn8hu4uXUtvXTMdAx9h6i7MXjx1trixYSVV+FSUZJZHRCpmrwV54/nvwwt22G+zs2+CsWyHZ/0sKxxpjDAd7D9oDlLbasQOVpp7xC+kWpBWMJZqV+fbnkpwlJCcmezb6azXwIHaWYgEOAzcaY96cz87DRZOK8lv3YDcNnQ00dDWwv62WhqZXqDlcx+GkYQYTbHJISUhhRf6K8Q93wUpOzj+ZzORMn6MPo/a3YPOXYddjkL0AVl8Dq6+GhWt0GHKYdQ12sadtz1hrpratlrqOOoZHhwFITUxl+w3bPUsqLwJ3GGP+7Dw+F/h3Y8xZ89l5uGhSUV4YGR3hnZ532N+1n/2d+2noahhLJEf6joytl2gMFcPDlA0l0D9Qxnln3cj7V7yXytzKiL/Ebtjsfw5evAf2/glGhyC/0g5OWHU1lJ2iCcYjQyND7OvcR217LbVttfzjun/0LKm8box510zLIoUmFeWWkdERDvcdprG7kcaeRt7qessmkM4G3u5+m6HRobF181JzqUzOpbKvl8q2t1naf5TK5FwWVV1O8in/g7Me7OSdrkE2//05nFw6yzPqY11fO+z6A+x8FPY9a+cUK1xhWy+rroaSlX5HGFe8PE9ln4h8BdsFBvBRYN98dqxUJDDG0DHQQVNPE409jTR1N9HUY2+N3Y280/vOWPcAQJIksShnEZU5lZyz6ByWZlVQ2d1KZcMr5O95CgZ7IKMIAlfaL8bFZ44NpTXyR2efvvypkSk9H9bcYG+9R2y32JuPwrPfhGe/YWdjXnW1fS0L53jWv/LUbJPKTcDXgEexk63+xVmmVEQzxtA91M2h3kO80/POWLIITSJHh49OeE5+aj7lWeVUF1ZzwZILKM8qpyKrgvLschZmLSTZYI+qdz4Ku74HA52Qlme7b1ZfA5Xvm3I6Fe3QmUFmkR2GvPYm6G6Gmt/b1/jP/2ZvZaeOt2DyZzE/mfLFcZOKiKQBtwDLsdPe/4MxZuh4z1HKSz2DPRzqPUTz0WYO9R7i0NFD9nFv89j9vuGJk2unJ6WPJYp1Zesozyofu1VkV0xdKB/qhwMvw7P/F2oes1dfTM2BlR+wX3LLzoWklOPGqg2UE5BdCmdssLfORtj5O5tgnv6qvZWfbl/3lR+w9RitwUSMmVoqPweGsC2TS4Bq4HPhDkqpYLdUy9EWjvQdoeVoy8Tk4dzvGZo4ujRpAXcAABabSURBVF0QitKLKMssY3nect678L2UZZZRmlnKwsyFlGeVU5BWMPPw3IFuOPAKvPWivTVth5FBSM601xBZdbWdmiQ5Nq/JHlFyK+zw47NuhfYGO/PAm4/C5jvsLafcdjMuOctOb1NcpUnGRzMllYAx5hQAEfkZsCX8IalYNmpGaetv40jfEQ4fPczhvsMTfh7pO0JLn00kobWMoMK0Qsoyy6jMreSMBWdQlllmk0ZGKWWZZRRnFJOckHzigfW2wtsv2dtbL8DB18GMgiTCwtNg3Qb7hbXs3LEz3ufKaJtl7vIr4ey/t7fWvXb02NsvQcPz8Oav7ToZhSFJ5iwoPWVOszuruZnplR7r6jLGDPtx8pWIZAI/BAaBZ4wxv/Q8CHVco2aUroEu2vrbaO1vtbc+ewsuCyaOtr42hs2xySI3NZfi9GKK04tZl7uOovQiSjJKKEovsssziinNKCUl8fhdTLPW9c54K+StF+Gwc5nexFSoWAvv+wf7hVSxzk497wI9dnZZ4Un2tu7jdvRD+/6J/9Pdf7DrpWTD4jPs/3PxWVC+Rq/7EkYzJZV3iUiXc1+w16jvcu4bY0zOXHYqIvcDlwEtxpjVIcvXA3cDicBPjTF3AVcDvzbGPC4ivwI0qXhgYGSA9v522vvbxxJDW1/bWMIIXdbWP3WiSJAE8lPzKUwvpDi9mBX5KyhOL56YMDLs49TEMH7IR0ehbZ+tibz1om2JtDfY36VkwaIz4JQP2ZZIGL9wtH0SRiL2ei4Fy+DdH7XLQg8c3n4J/uhcLTMxFSre47RkzrQnXupMyq45blIxxoRrWtEHgHuAXwQXiEgicC9wIdAIbBWRx4AK7CABgJEwxRPTRs0o3YPdNkkMtI8li+D9joEO2vrb6OjvGFs2eURUUEpCCoXphRSmFVKaUUp1QfXY44K0gvH76QXkpeZ5P0vu4FFo2QWH/mqnkD/0BjTvhKFe+/v0Avtlsm6D7SIpO1W7RmJVzkJ7sHDKh+zjo21O96ZzYPGX78BzzldK3mL7Xig7ZfyWu0hrM3Pgy6fJGPOciFROWrwOqDfG7AMQkYeBK7AJpgJ4DZj2G0pENgAbABYvXux+0BFicGSQjoEOOgY66BzopHOg85j7oY/bB9rpHOhkxEydj9OT0slLzSM/LZ/81HwqcyvJS82jIK2AvLS8sZZGMGlkJmdGzhxUPYcnJo9Db0Brna2FgO32KDvFHrmWrbZHp0VVkODDdPAh9DwVn2QU2NFiKz9gHw90Q+NWWz8Lvn92/zdjbcq0XJtoSlePJ5rilTOO8ot3kXSIVg4cCHncCJwBfB+4R0Q+ADw+3ZONMT8Gfgz2jPowxjlvxhh6h3rpGuyic6CTrsEuexvoonOwk66BrrHfdQ5OTByTh8eGSklIIS81j9y0XPJS81iau5R3p72b/NR88tPyJySLglT7Mz0pCib0Gx2Btv3HJpCeQ+Pr5C6yH/pVV45/CeQt8T2BhIqQVKyCUrPhpL+1t6DB3mNbujt+DkNOyz0h2SaW0BZN2Wp7EqcCIiupTMkY0wv8L7/jmGxoZIjuoW66B+2ta7CLnsGeCY+DiSJ4P5hAuge7p205gD1rOyc1h5yUHPJS8yjNKOXk/JPJS82zSSM1l9zU3LH7wZ9piWmR04qYi74OaK2HI3W2xXHEubXtg5EBu05Ckv1Qn3Te+Ie6dLU9Co1wEX2ko6yUTDtQoyJkppKpDmr2/gle/8/xdTJLoGgFFC53fq6wP/OWxF33aiT9tU3AopDHFc4y142aUY4OHaVnyCaBsZ+DPfQM9Yw9nipZdA920z3UfdwWA0CiJJKdkk1uai45KTZBVGRVjCWL0OWTl6UnpUd3cjiekWHoeGti4mitt9c27z08vp4kQsFS++FcccH40WHxSh25o7yVkAhFy+1t9dXjy3tanJrdm+MHQLv/AEdbQ56bbAcPTJVwouBAaC4iKalsBVaIyFJsMrkO+PBcNtR8tJmvv/R1uofGE0UwefQM9tA71DvjuQLBpBB6K84otveTJy7PSck55nFMJ4aZjAxB5wE7zXnHW/YoL9gCadtnZ6UNyii0H7KTLx7/sBWdbM9HSJzD+SZRQGsqMSKrBJafb2+hjraNHyiNHTTVwZ5NE9/76QXjSabwJPuez18CeZU24UTp94cvSUVEHgLOBYpEpBH4F2PMz0TkVmATdkjx/caYnXPZfmtfK0+//TRZyVlkpWSRnZzN4uzF9n5KNlnJ9mdmcubY74M/M5MzyU7Jju+kMJPRUehptgkjmDjaG8bvdzWNF8th4tFa1SXjiaNwecwerU1F301xIqMAMtbBonUTl0/XSq/bDK+1TFw3Jct2neUvcX5WhtxfYrvpIpRfo7+un2b5RmDjfLcfKAzw7LXPzncz8SuYNLqa7LxLHW/bpDGWRN4er3EEZS+wb/glZ036MCyx02gkhGt0evTQBkqcS0waP2GT9RN/1981xefMaeXve2Z8oEBQRtHEz1h+pR2sklthh1Kn+ndphUjq/lJeMMZOMd7VCJ1N44mjq8meLNbZBN3vwOQpUtLy7Ju3pNrOfRU8espbYsf46xxYs6bTtKhjpOXYUWRlq4/9XfAzG+wRCE0677xqLxcw+fOamgu55TbB5JSPJ5vQ+2Fq7WhSiSXDA7aF0d1sh9t2H7KJoqvJSSCN9vHI4MTnJaY4b7gKe4ZxTrnzhnTefHmL9YxjF2j3l5oTEcgqtreKKa6fNTriHBAecH42hnzmm+x5OKGDYILS8pwE4ySf3HJXwtWkEg0Gj44nie5DTuII+dl9yP6+r/3Y5yYkQbbzhilfC9ULx99IwcSRWRS1RUGl4l5CIuQtsrfpDPVD98FjDzCD95u2TRy1Ng+aVPwy2GuHJPYegd4WeyTRc3ji/Z5mexvoOvb5CcmQVWqvO1F4kq1lZJc5y8qc+2U2YWg9IyJop5fyTXKaHaJfsHT6dYb64Gvzm4EbNKm4Z2TIDiU82gpHjzjJwkkYockjeD84F9Vkqbm2mZtZDKUBe7ZvdqlNEKHJIj0/os4WV7OnQ4pVREp2Z3YNTSpTMcZea7z3iJMojthk0XtkPGkcbZv4uL9z6m1Jgj0XI7PEthoWrRu/n1Uy8X5GkRa8Y5h2MKp4EPtJZXjQXvr1aJutOUx7v33i8snF7KCEZJsEMgrtbcG7Jj7OKBx/nFlix6xr95NSKk7EZlI5XAvfXW2TxHTdTGBHPaUX2C/+9HxbmwjezyialCQK7LLUbC1qqznRXi8VD2IzqSQmQ+XZTsLIt0kiNHkE7ydnaIJQSikXxWZSKVgGV93ndxRKTaCHLyoe6PAhpTyi3V8qHmhSUUop5RpNKkp5TM9TUbFMk4pSHtGaiooHmlSU8og2UFQ80KSilFLKNZpUlPKYXk9FxTJNKkp5RGsqKh5oUlHKI9o+UfFAk4pSHtMhxSqWaVJRyiPa/aXigSYVpZRSromKCSVF5ErgA0AO8DNjzGafQ1LqhGmvl4oHYW+piMj9ItIiIm9OWr5eRGpFpF5Ebj/eNowxvzPGfBy4Bbg2nPEqFW6aXFQs86Kl8gBwD/CL4AIRSQTuBS4EGoGtIvIYkAjcOen5NxljWpz7X3aep1TU0ZqKigdhTyrGmOdEpHLS4nVAvTFmH4CIPAxcYYy5E7hs8jZERIC7gCeMMTum2o+IbAA2ACxevNi1+JVSSs2eX4X6cuBAyONGZ9l0PgNcAHxIRG6ZagVjzI+NMWuNMWuLi4vdi1Qpl2i3l4oHUVGoN8Z8H/i+33Eo5QajJ6qoGOZXS6UJWBTyuMJZplTM0pqKigd+JZWtwAoRWSoiKcB1wGM+xaKUUsolXgwpfgh4CagSkUYRudkYMwzcCmwCdgGPGGN2hjsWpfyknV4qHngx+uv6aZZvBDaGe/9KRRpNLiqW6TQtSnlEayoqHmhSUcoj2kJR8UCTilIe0xHFKpZpUlHKI9r9peKBJhWllFKu0aSilEe010vFA00qSnlO04uKXZpUlPKI1lRUPNCkopRSyjWaVJTyiHZ6qXigSUUpj+l5KiqWaVJRyiNaU1HxQJOKUkop12hSUcoj2uul4oEmFaU8pslFxTJNKkp5RGsqKh5oUlFKKeUaTSpKeUS7vVQ80KSilMf0PBUVyzSpKOURramoeKBJRSmllGs0qSjlMaP9XyqGaVJRSinlmqhIKiKSKSLbROQyv2NRSik1vbAmFRG5X0RaROTNScvXi0itiNSLyO2z2NQXgUfCE6VSSim3JIV5+w8A9wC/CC4QkUTgXuBCoBHYKiKPAYnAnZOefxPwLqAGSAtzrEp5QisqKpaFNakYY54TkcpJi9cB9caYfQAi8jBwhTHmTuCY7i0RORfIBAJAn4hsNMaMTrHeBmADwOLFi138K5RSSs1WuFsqUykHDoQ8bgTOmG5lY8wdACLyMeDIVAnFWe/HwI8B1q5dqweDSinlAz+SypwYYx7wOwal5kOPdFQ88GP0VxOwKORxhbNMqbigp6moWOZHUtkKrBCRpSKSAlwHPOZDHEp5SqdpUfEg3EOKHwJeAqpEpFFEbjbGDAO3ApuAXcAjxpid4YxDKaWUN8I9+uv6aZZvBDaGc99KRRrt9VLxICrOqFcqlhhNLyqGaVJRyiNaU1HxQJOKUkop12hSUcpr2vulYpgmFaWUUq7RpKKUUso1mlSUUkq5RpOKUh7TkoqKZZpUlFJKuUaTilJKKddoUlFKKeUaTSpKeUynvlexTJOKUkop12hSUUop5RpNKkoppVyjSUUpj+nU9yqWaVJRSinlGk0qSimlXKNJRSmP6ZBiFcvExOA7XES6gVq/45iFIuCI30HMQjTEGQ0xgsbpNo3TXVXGmOz5bCDJrUgiTK0xZq3fQcxERLZpnO6IhhhB43SbxukuEdk2321o95dSSinXaFJRSinlmlhNKj/2O4BZ0jjdEw0xgsbpNo3TXfOOMyYL9UoppfwRqy0VpZRSPtCkopRSyjVRm1RE5H+IyE4RGRWRtZN+908iUi8itSJy8TTPXyoirzjr/UpEUjyI+Vci8ppzaxCR16ZZr0FE3nDWm/cQvznE+VURaQqJ9dJp1lvvvMb1InK7xzF+S0R2i8hfReS3IpI3zXq+vJYzvTYikuq8H+qd92GlV7GFxLBIRP4sIjXOZ+mzU6xzroh0hrwX/tnrOJ04jvt/FOv7zuv5VxFZ40OMVSGv02si0iUin5u0ji+vp4jcLyItIvJmyLICEXlKROqcn/nTPPdGZ506Eblxxp0ZY6LyBlQDVcAzwNqQ5QHgdSAVWArsBRKneP4jwHXO/fuAT3oc/3eAf57mdw1AkY+v7VeBz8+wTqLz2i4DUpzXPOBhjBcBSc79bwDfiJTXcjavDfAp4D7n/nXAr3z4Py8A1jj3s4E9U8R5LvAHr2M70f8jcCnwBCDA3wCv+BxvInAIWBIJrydwDrAGeDNk2TeB2537t0/1GQIKgH3Oz3znfv7x9hW1LRVjzC5jzFRnzV8BPGyMGTDG7AfqgXWhK4iIAH8L/NpZ9HPgynDGO8X+/w54yKt9hsE6oN4Ys88YMwg8jH3tPWGM2WyMGXYevgxUeLXvWZjNa3MF9n0H9n14vvO+8Iwx5qAxZodzvxvYBZR7GYOLrgB+YayXgTwRWeBjPOcDe40xb/kYwxhjzHNA26TFoe/B6b4DLwaeMsa0GWPagaeA9cfbV9QmleMoBw6EPG7k2A9KIdAR8qU01Trh9D6g2RhTN83vDbBZRLaLyAYP4wp1q9ONcP80zeLZvM5euQl7lDoVP17L2bw2Y+s478NO7PvSF07327uBV6b49Zki8rqIPCEiqzwNbNxM/8dIej+CbX1Od9AYCa8nQKkx5qBz/xBQOsU6J/y6RvQ0LSLyNFA2xa/uMMb83ut4ZmOWMV/P8VspZxtjmkSkBHhKRHY7RxqexAn8CPg69oP8dWxX3U1u7n82ZvNaisgdwDDwy2k2E/bXMtqJSBbwG+BzxpiuSb/ege3C6XFqa78DVngdI1H0f3Tqs5cD/zTFryPl9ZzAGGNExJXzSyI6qRhjLpjD05qARSGPK5xloVqxzeMk5yhxqnXmZKaYRSQJuBo4/TjbaHJ+tojIb7HdKa5+gGb72orIT4A/TPGr2bzO8zKL1/JjwGXA+cbpAJ5iG2F/Lacwm9cmuE6j857Ixb4vPSUiydiE8ktjzKOTfx+aZIwxG0XkhyJSZIzxdHLEWfwfw/5+PAGXADuMMc2TfxEpr6ejWUQWGGMOOl2FLVOs04StAwVVYOvY04rF7q/HgOuc0TVLsUcBW0JXcL6A/gx8yFl0I+BVy+cCYLcxpnGqX4pIpohkB+9jC9JvTrVuuEzqi75qmv1vBVaIHUWXgm3uP+ZFfGBHVwH/CFxujDk6zTp+vZazeW0ew77vwL4P/zRdYgwXp4bzM2CXMeb/TrNOWbDWIyLrsN8Znia/Wf4fHwP+pzMK7G+AzpCuHa9N2xMRCa9niND34HTfgZuAi0Qk3+kGv8hZNj2vRyG4dcN+2TUCA0AzsCnkd3dgR9/UApeELN8ILHTuL8Mmm3rgv4BUj+J+ALhl0rKFwMaQuF53bjuxXT1ev7YPAm8Af3XeeAsmx+k8vhQ7Ymiv13E6/7cDwGvO7b7JMfr5Wk712gD/ik2CAGnO+67eeR8u8+H/fDa2i/OvIa/jpcAtwfcocKvz2r2OHRBxlg9xTvl/nBSnAPc6r/cbhIwI9TjWTGySyA1Z5vvriU1yB4Eh53vzZmwN749AHfA0UOCsuxb4achzb3Lep/XA/5ppXzpNi1JKKdfEYveXUkopn2hSUUop5RpNKkoppVyjSUUppZRrNKkopZRyTUSf/KiUl0RkBDscNehKY0yDT+EoFZV0SLFSDhHpMcZkTfM7wX5eRj0OS6moot1fSk1DRCrFXhPlF9gzuBeJyBdEZKsz2ebXQta9Q0T2iMjzIvKQiHzeWf6MONf7EZEiEWlw7ieKvSZMcFufcJaf6zzn12KvF/PLkDOw3yMiLzqTEW4RkWwReU5ETguJ43kReZdnL5JSk2j3l1Lj0mX8wmn7gb/HTvNzozHmZRG5yHm8DnsG92Micg7Qi52K5TTsZ2oHsH2Gfd2MnUrkPSKSCrwgIpud370bWAW8A7wAvFdEtgC/Aq41xmwVkRygDzvNyseAz4nIyUCaMeb1+b4QSs2VJhWlxvUZY0KP+iuBt4y9PgfYeY8uAl51Hmdhk0w28FvjzEEmIrOZA+0i4FQRCc4/l+tsaxDYYpy54ZwkV4mdGv+gMWYrjE9MKCL/BXxFRL6AnU7jgRP9o5VykyYVpY6vN+S+AHcaY/5f6Aoy6ZKxkwwz3s2cNmlbnzHGTJicT0TOxc5nFzTCcT6nxpijIvIU9oJLf8dxZr9WygtaU1Fq9jYBNznXH0FEyp3rezwHXCki6c5suh8MeU4D41/0H5q0rU86U88jIic7M/BOpxZYICLvcdbPdqbMB/gp8H1gq7FX51PKN9pSUWqWjDGbRaQaeMmpnfcAHzXG7BCRX2Fnnm3BTn0f9G3gEbFXK/zvkOU/xXZr7XAK8Yc5ziWtjTGDInIt8AMRScfWUy4Aeowx20WkC/gPl/5UpeZMhxQr5TIR+Sr2y/7bHu1vIfbCSSt1yLPym3Z/KRXFROR/Yq8rf4cmFBUJtKWilFLKNdpSUUop5RpNKkoppVyjSUUppZRrNKkopZRyjSYVpZRSrvn/+UurlXGAKb8AAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "fdata = bifrost.ndarray(shape=data.shape, dtype='cf32', space='cuda')\n",
+        "f = bifrost.fft.Fft()\n",
+        "f.init(data, fdata, axes=1, apply_fftshift=True)\n",
+        "f.execute(data, fdata)\n",
+        "fdata2 = fdata.copy(space='system')\n",
+        "ffreqs = numpy.fft.fftfreq(fdata2.shape[1], d=1/4096.)\n",
+        "ffreqs = numpy.fft.fftshift(ffreqs)\n",
+        "\n",
+        "pylab.semilogy(ffreqs, numpy.abs(fdata2[0,:])**2, label='0')\n",
+        "pylab.semilogy(ffreqs, numpy.abs(fdata2[2,:])**2, label='2')\n",
+        "pylab.semilogy(ffreqs, numpy.abs(fdata2[5,:])**2, label='5')\n",
+        "pylab.xlabel('Frequency')\n",
+        "pylab.ylabel('Power')\n",
+        "pylab.xlim(-10, 10)\n",
+        "pylab.legend(loc=0)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "geological-occasions",
+      "metadata": {
+        "id": "geological-occasions"
+      },
+      "outputs": [],
+      "source": [
+        ""
+      ]
     }
-   ],
-   "source": [
-    "fdata = bifrost.ndarray(shape=data.shape, dtype='cf32', space='cuda')\n",
-    "f = bifrost.fft.Fft()\n",
-    "f.init(data, fdata, axes=1, apply_fftshift=True)\n",
-    "f.execute(data, fdata)\n",
-    "fdata2 = fdata.copy(space='system')\n",
-    "ffreqs = numpy.fft.fftfreq(fdata2.shape[1], d=1/4096.)\n",
-    "ffreqs = numpy.fft.fftshift(ffreqs)\n",
-    "\n",
-    "pylab.semilogy(ffreqs, numpy.abs(fdata2[0,:])**2, label='0')\n",
-    "pylab.semilogy(ffreqs, numpy.abs(fdata2[2,:])**2, label='2')\n",
-    "pylab.semilogy(ffreqs, numpy.abs(fdata2[5,:])**2, label='5')\n",
-    "pylab.xlabel('Frequency')\n",
-    "pylab.ylabel('Power')\n",
-    "pylab.xlim(-10, 10)\n",
-    "pylab.legend(loc=0)"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.6"
+    },
+    "colab": {
+      "name": "00_getting_started.ipynb",
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "geological-occasions",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/00_getting_started.ipynb
+++ b/00_getting_started.ipynb
@@ -14,40 +14,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "source": [
+        "%%bash\n",
+        "# @title Build and install\n",
+        "export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}\n",
+        "if python -c 'import bifrost' 2>/dev/null; then\n",
+        "    echo \"Great, bifrost import seems to work.\"\n",
+        "    exit 0\n",
+        "else\n",
+        "    if python -c 'import google.colab' 2>/dev/null; then\n",
+        "        echo \"No bifrost but we're on Google Colab, so will try to install.\"\n",
+        "    else\n",
+        "        echo \"Sorry, please use a runtime with access to Bifrost.\"\n",
+        "        exit 1\n",
+        "    fi\n",
+        "fi\n",
+        "sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
+        "pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
+        "if [ ! -d ~/bifrost/.git ]; then\n",
+        "  git clone --branch autoconf https://github.com/ledatelescope/bifrost ~/bifrost\n",
+        "fi\n",
+        "cd ~/bifrost\n",
+        "./configure && make -j all && sudo make install"
+      ],
+      "metadata": {
+        "id": "S-IQgISobCvU"
+      },
+      "id": "S-IQgISobCvU",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
       "id": "proud-container",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 306
-        },
-        "id": "proud-container",
-        "outputId": "5633f081-04ce-43c4-d3d4-dcb8941fade1"
+        "id": "proud-container"
       },
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "ModuleNotFoundError",
-          "evalue": "ignored",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-            "\u001b[0;32m<ipython-input-1-ffe2c8b74e15>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mbifrost\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bifrost'",
-            "",
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0;32m\nNOTE: If your import is failing due to a missing package, you can\nmanually install dependencies using either !pip or !apt.\n\nTo view examples of installing some common dependencies, click the\n\"Open Examples\" button below.\n\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n"
-          ],
-          "errorDetails": {
-            "actions": [
-              {
-                "action": "open_url",
-                "actionText": "Open Examples",
-                "url": "/notebooks/snippets/importing_libraries.ipynb"
-              }
-            ]
-          }
-        }
-      ],
+      "outputs": [],
       "source": [
         "import bifrost"
       ]
@@ -64,22 +68,25 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 11,
       "id": "subject-quebec",
       "metadata": {
         "id": "subject-quebec",
-        "outputId": "7d9ff2dd-dfea-4cc1-9a68-efe5aa914dde"
+        "outputId": "ecc41d4f-726a-4c2e-f009-a32825e32838",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) system\n",
-            "[[1.9045215e+31 1.6631021e+22 2.7229835e+20 ... 0.0000000e+00\n",
-            "  0.0000000e+00 0.0000000e+00]\n",
-            " [0.0000000e+00 0.0000000e+00 0.0000000e+00 ... 4.5557614e-41\n",
-            "  1.4012985e-45 0.0000000e+00]]\n"
+            "[[ 0.0000000e+00  0.0000000e+00 -1.8241284e+25 ...  1.5554413e-43\n",
+            "   1.5554413e-43  1.4012985e-43]\n",
+            " [ 4.4841551e-44  1.1210388e-43  1.6955711e-43 ...  0.0000000e+00\n",
+            "   0.0000000e+00  0.0000000e+00]]\n"
           ]
         }
       ],
@@ -112,26 +119,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "id": "lightweight-madrid",
       "metadata": {
         "id": "lightweight-madrid",
-        "outputId": "192b8c53-93a9-4fbe-f0c4-6d35813e1c49"
+        "outputId": "b504c202-8395-4365-ce14-7bebf478dfe3",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "<class 'bifrost.ndarray.ndarray'> float64 (2, 4096) system\n",
-            "r: [[ 0.13445404  0.3175441   0.53332765 ...  1.18956152 -1.15990205\n",
-            "  -0.64751085]\n",
-            " [ 0.45399238 -0.42930972  0.47645107 ...  2.00526937  2.27132679\n",
-            "   0.78468687]]\n",
-            "data: [[ 0.13445404  0.3175441   0.53332765 ...  1.18956152 -1.15990205\n",
-            "  -0.64751085]\n",
-            " [ 0.45399238 -0.42930972  0.47645107 ...  2.00526937  2.27132679\n",
-            "   0.78468687]]\n"
+            "r: [[ 0.17851579 -0.9965826   0.39835836 ...  0.06416343  0.7667563\n",
+            "  -0.53529951]\n",
+            " [ 1.30749412 -1.05996732  1.20367584 ...  0.29484387 -1.37285379\n",
+            "  -0.45451832]]\n",
+            "data: [[ 0.17851579 -0.9965826   0.39835836 ...  0.06416343  0.7667563\n",
+            "  -0.53529951]\n",
+            " [ 1.30749412 -1.05996732  1.20367584 ...  0.29484387 -1.37285379\n",
+            "  -0.45451832]]\n"
           ]
         }
       ],
@@ -156,23 +166,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 13,
       "id": "regional-darkness",
       "metadata": {
         "id": "regional-darkness",
-        "outputId": "b0014540-15ea-4a4d-9aa1-c9af6c8f9193"
+        "outputId": "729d29ad-1a50-4e47-91df-bf38c5be5348",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
-            "data += 2.0: [[2.13445404 2.3175441  2.53332765 ... 3.18956152 0.84009795 1.35248915]\n",
-            " [2.45399238 1.57069028 2.47645107 ... 4.00526937 4.27132679 2.78468687]]\n",
+            "data += 2.0: [[2.17851579 1.0034174  2.39835836 ... 2.06416343 2.7667563  1.46470049]\n",
+            " [3.30749412 0.94003268 3.20367584 ... 2.29484387 0.62714621 1.54548168]]\n",
             "data[0,:] = 55: [[55.         55.         55.         ... 55.         55.\n",
             "  55.        ]\n",
-            " [ 2.45399238  1.57069028  2.47645107 ...  4.00526937  4.27132679\n",
-            "   2.78468687]]\n"
+            " [ 3.30749412  0.94003268  3.20367584 ...  2.29484387  0.62714621\n",
+            "   1.54548168]]\n"
           ]
         }
       ],
@@ -185,21 +198,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 14,
       "id": "artificial-spider",
       "metadata": {
         "id": "artificial-spider",
-        "outputId": "4f1ae3cd-105b-4730-e1fc-b7bbb9916324"
+        "outputId": "03abaeb3-6e01-4b4c-f1e8-20caa413366b",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "data[:,[1,3,5,7]] = 10: [[55.         55.         55.         ... 55.         55.\n",
             "  55.        ]\n",
-            " [ 2.45399238  1.57069028  2.47645107 ...  4.00526937  4.27132679\n",
-            "   2.78468687]]\n"
+            " [ 3.30749412  0.94003268  3.20367584 ...  2.29484387  0.62714621\n",
+            "   1.54548168]]\n"
           ]
         }
       ],
@@ -220,21 +236,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 15,
       "id": "smaller-organizer",
       "metadata": {
         "id": "smaller-organizer",
-        "outputId": "b33a3ea8-8aaf-4518-b351-39433408d557"
+        "outputId": "bdec8c2e-83cc-4ef1-8ce2-5e688215baa0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "<class 'bifrost.ndarray.ndarray'> [[65.         65.         65.         ... 65.         65.\n",
             "  65.        ]\n",
-            " [12.45399238 11.57069028 12.47645107 ... 14.00526937 14.27132679\n",
-            "  12.78468687]]\n"
+            " [13.30749412 10.94003268 13.20367584 ... 12.29484387 10.62714621\n",
+            "  11.54548168]]\n"
           ]
         }
       ],
@@ -273,16 +292,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 16,
       "id": "changing-enhancement",
       "metadata": {
         "id": "changing-enhancement",
-        "outputId": "84f7c97b-9de7-418b-b748-7ede65a98640"
+        "outputId": "0f55e47c-78d3-46ac-a5d3-d0237a4d58c7",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) cuda_host\n",
             "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) cuda\n"
@@ -308,16 +330,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 17,
       "id": "talented-lending",
       "metadata": {
         "id": "talented-lending",
-        "outputId": "e415b5c7-78d0-4b2d-8dd3-f11b427cc928"
+        "outputId": "aaedd4e9-78b5-4c9b-caa1-d74bef03f55e",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "<class 'bifrost.ndarray.ndarray'> float64 (2, 4096) cuda\n"
           ]
@@ -340,16 +365,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 18,
       "id": "prospective-financing",
       "metadata": {
         "id": "prospective-financing",
-        "outputId": "618b8df1-f490-4126-9add-c311e79c71a6"
+        "outputId": "b45d4064-d869-418d-b432-32b506e232b6",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "data4/data = data*10/data = 10: [[10. 10. 10. ... 10. 10. 10.]\n",
             " [10. 10. 10. ... 10. 10. 10.]]\n"
@@ -389,24 +417,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 21,
       "id": "restricted-carrier",
       "metadata": {
         "id": "restricted-carrier",
-        "outputId": "0b5aeb24-a92d-4f25-8de3-c1ae41b91529"
+        "outputId": "53a29b5e-99ca-4ff7-db75-30705a1863e7",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 296
+        }
       },
       "outputs": [
         {
+          "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "<matplotlib.legend.Legend at 0x7eff6b0ecc50>"
+              "<matplotlib.legend.Legend at 0x7f10ae361610>"
             ]
           },
-          "execution_count": 10,
           "metadata": {},
-          "output_type": "execute_result"
+          "execution_count": 21
         },
         {
+          "output_type": "display_data",
           "data": {
             "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEGCAYAAABLgMOSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9eXgc1Zno/Tutbqm7tS/d2rxI8oI3sA0OW2zABsKSAFnIQpIZyIUhuZN8M8ncm0lyM5NMcpMvmXsny0eGmYSELJOQDUISSBh2DDa7AWNsbLxIsiVbUrf2pVtSL+f7o7raLamX6u6qrpKnf8+jR3JVddUpd9V53/OuQkpJkSJFihQpki02swdQpEiRIkUWJ0UBUqRIkSJFcqIoQIoUKVKkSE4UBUiRIkWKFMmJogApUqRIkSI5YTd7AIWkoaFBtrW1mT2MIkWKFFlUvPLKK4NSSs/87f+lBEhbWxt79uwxexhFihQpsqgQQhxPtr1owipSpEiRIjlRFCBFihQpUiQnigKkSJEiRYrkRFGAFClSpEiRnCgKkCJFihQpkhOmChAhxI+FED4hxP4U+4UQ4g4hxFEhxD4hxLkJ+24WQhyJ/dxcuFEXKVKkSBEwfwXyU+DqNPuvAVbFfm4H/h1ACFEHfBm4ADgf+LIQotbQkRYpUqRIkTmYmgcipXxGCNGW5pAbgP+QSs35F4QQNUKIZuAy4DEp5TCAEOIxFEH0KyPGece9f8vEpJ+1pRfSV3sRM/YqIy5jGcJylmPBp7FRwgrXpdhEidlDMpxQNMjR4E7KbJW0OS8qyD0LGaF5Yj/eqUOUhSeZKm2gp/o8xpxLDL82wHR0gmPBZ6goaWBZ2fkIIQpyXTMJREboDO6m1rGU1rJNZg/HcGqCJ3CO7eK18Gt89p3fx9vYquv5rZ5I2Ar0JPy7N7Yt1fYFCCFuR1m9sGzZspwG8fLws+x1zrBl4mX+9fBXuD96Gd8J38gIZ6IgieJcejf28mMA7Ox9mumTHwXO4MlFhHAt/z4lzpMAPD76LDP97zPwgpL32Z7hb+33s1T4F+zdHd3AN8M3cUC2GzcEWwB3279hKx0EYHbwMmYH0xkDFj/CPo5r+fewOSYAmBl4F6GRrSaPyhjOEcf4gv2XeMuO8JfNjQSFjat7X+DyRn2fa6sLkLyRUt4F3AWwZcuWnLpn/fzje/j9od/wpRe/xh/WX8pfHHqav6h+A977Q+i4VNfxms09B+/hmy8d4x8v/EcmZif47qvf5V//SvDOjneaPTTD+N5r3+OufSf5zmXfYZ9/Hz858BN+fONtXNx6sf4XCwzD7z8BRx6BlnPhom9C2zZw1cLocTj4IFtf+Hf+FPgS7PgibP07MGBl8NXnv8r9R0b4/pU/5KHOh/gDf+D+Wz7B+vr1ul/LKnzmqc+w+2SIH131C378xo95xvYwD/73T7KksjArvoIQjcKub8FTX0eWN/CxZeciI5P8/tpfsqxGf4XEbB9IJk4CSxP+vSS2LdV2w3j3WR/g/Kbz+aEcJnTbY+CsgV+8D/bfb+RlC0ooGuIn+3/ClsYtvH/1+/nYho+xqnYVP9j3A87UzpWBUIBfHvwl71j+Dq5YfgWf2vwpWspbuOuNu/S/2MQA/ORa6HwKrv0X+Ksn4ewbobIR7KXQsAq2/R186iVY/2544qvw4N8qk4KODAYH+f3R33Pj6hu5sPlCPvu2z1JVVsXdb9yt63WsRNdYF4+feJxbNtzCRs9GvnjhF7Fh4+79Z9A9RyPwx0/CU1+Ds29k74d+yivT/Xzq3L8xRHiA9QXIA8BfxqKxLgTGpJR9wCPAO4QQtTHn+Tti2wxDCMHN629maHqIZ8LDcOujsORt8Lvb4PCjRl66YOzs2clAYICb19+MEAKbsHHL+lvoGuviNd9rZg/PEP7U+ScmQ5P8xbq/AKC0pJSb1tzEKwOvcHTkqH4XCo7Az94Foyfgo/fD+X+VemXhqoX33Q3b/ie8+jN45AugowD/3eHfEY6G+ejajwJQWVrJe1a+hydPPIkv4NPtOlbi14d+TamtlA+d9SEAvG4v7+x4Jw91PkQgFDB5dDogJfzp0/D6L+GyL8B7f8ivuh6g0lHJDStuMOyyZofx/gp4HjhLCNErhLhVCPEJIcQnYoc8BHQCR4EfAn8NEHOe/2/g5djPV1WHupFc3HIxHpeHB489CK4a+Mi90LQB7r0Z+t8w+vKG82j3o9Q569jWui2+7YplV+Cyu3iw80ETR2YcD3c/TEd1Bxs9G+Pb3rXiXQgEjx7XSTGIhODeW2C4Cz7yW2jflvEjCAGX/yNc+El48fvKj0483P0w5zWeR1t1W3zbe1e9l4iM8Pjxx3W7jlWIyiiPH3+cS5ZcQr2rPr79uhXXEQgHeLLnSRNHpxMv/Du8+h+K0nHZ55mOzLCzZyfXtF+D2+E27LKmChAp5U1SymYppUNKuURKebeU8vtSyu/H9ksp5SellCuklGdLKfckfPbHUsqVsZ+fFGK8dpudHct28Nyp55iNzEJZBXz4Xiirgns/BjOThRiGIcxEZnim9xl2LNtBie10BJLb4WZb6zae6XnmjDNjjc2M8erAq1y+7PI5EUgNrgbObTyXx44/ps+Fdn4DOnfCdd+Ftiydtu/4Gpz1Tnj0H+HkK3kPpWe8h6OjR7l82eVztrdXt9NR3XFmTKbz2Offhy/o44rlV8zZfl7jeTS4Gni652mTRqYT3c/Co/8Aa94F278IwIt9LxIMBxd8z3pjdROW5bhkySUEw0H29MdkWWUjvO+HMHQUHv6cuYPLgz39ewiEA+xYumPBvq2tW/EFfRweOWzCyIzjmd5niMgI25duX7Bvx9IdHB09St9kX34XOfEi7P4ObPoobP5o9p+32eDdd0Jlk6KkzE7lNZynep4CSHrP25duZ0//HiZmJ/K6htV4pvcZ7MLOJUsumbPdJmxc3HIxz/c9TyQaMWl0eTIzCX/4BNS2wXu+rzwvKN9zhaOCtzW9zdDLFwVIlpzfdD6ltlKeO/Xc6Y3tl8DWT8Nrv4CuZ8wbXB683P8ydmHnvMbzFux7e+vbAdh9cnehh2UoL/W/RHVZNesbFkYeXdB8QfyYnAkFlZe7eglc/Y3cz+OqhffepURpPfX/5n4elO+5raotaeTRRS0XEZGRM87f9XL/y6xrWEdlaeWCfVtbtzI2M8b+oaTFMKzP41+G0R54979B2en7e6n/Jc5vOh9HicPQyxcFSJY47U42NGxY+JJd+jlFC/jTZyA8Y8rY8mHPwB7WN6xPai/1ur2srFnJnoEzqxnXqwOvstm7GZtY+Bqsql1FTVlNfgLkue/BcCdc/z1w5pkztPxiOPdmeOHf4NTenE4RlVFe9b2aVEkAOMdzDnabnVcG8jeVWYVgOMj+of1sadySdP+FzRcCnLYoLCZ6X4GXfwQX/ndYdmF8sy/go2eih3Mbz03zYX0oCpAcOLfxXN4cepNgOHh6o8MF7/y2Ysp6/k7zBpcDgVCAA4MHUr5kABs9G3nd/zpRqW9IqVn4A35OTJxIec82YWNL45bcJ5bRHtj1bVh3A3RclvM453DlV8BdDw9/PqeorKOjRxmfHU85sbjsLs5uOPuMUhRe979OOBpO+T3XOmtpq2pjrz83oWwaUirReRWNsP1/zdn16sCrAGnfZ70oCpAc2OzdTFiG2T84b9m78nJYfQ3s/q6SMLZIeGPwDcIynFIzBUWATMxO0D3WXbiBGcgrPkXLPtebWkvb5N3EqalTDAYHs7/A4/+k/H7H13IYXQpctUqI5onn4a3/zPrj6soi3fd8XuN5vDn4JtPh6ZyHaSVeHXgVm7Cx2bs55THneM7hdd/riytI5MD90PMi7PiHOaYrUL5nt93NWXVnGT6MogDJATXkM6mt+PIvweyEkg26SDgwdABQXqRUbPIqdYMWnaaWgn3+fZSVlLGmfk3KY9Ss7AODB7I7+cAB2P87xbRQk1v5nJSc+5dQv0qxfUfCWX30Df8beFweWspbUh6zoWEDYRnmrZG38h2pJTgwdICO6g4qSitSHrPJu4mRmRF6JnpSHmMpIiF4/CvQeDZs+siC3fsG93G252zsNuMLjRQFSA5Ul1WztHIph4YPLdzZuA423gQv/RDGTxV+cDnw5tCbtFa0Ul1WnfKYtqo2qkqr2OffV8CRGceh4UOsrl2Nw5baybiufh02YYsLWM3s/CaUVsDF/0+eo0xCiQOu+DIMHoY3fpvVRw8OH2Rt/dq0RRNVofnm0Jt5DdMqHBw6yLr6dWmPOadBUZxe979eiCHlz77fKAEVO/4BbHOLfoaiIY6MHGFdXfp71ouiAMmRNXVrODh0MPnOSz8H0fCi8YUcHDrI2rq1aY8RQrCmbs0ZEcorpeTQ8CHW1KVefYCSA9NR3bHQVJmOvn1w8AFl9eGuy3OkKVjzLmjcoIQHayxzMh2epmusK+M9N7obqXPWnRECxB/w4w/6Mz7bHTUdOGyOxfFsR8KKdaPpHFh91YLdnaOdhKKhjN+zXhQFSI6srVtL72Rv8pj52uVKjaM9P7G8L2RidoITEydYW5/+JQNYXbuaIyNHFm/MfIyTkyeZmJ3Q9JKtq1/HgaED2u3ju7+tJJZe9Nd5jjINQsDWzyirkEN/0vSRIyNHiMiIJkVhbf3aM0KAHBxWFLxMz7bD5mBlzUreGl4EZrsD9yuRfZf+fdJSOOo9pzPN6klRgOSI6qBK+dC9/dMQmoKXDCjKpyOqGS7TxALKqms6Ms3xieNGD8tQsrnntXVrGZ4eZmh6KPOJR47Dm3+ELR9THN5Gsv49UNehaKMahJvWyRRgXd06jo0eYyay+MLRE3lz6E0EQpOicFbdWbw18pa1HelSKpF93nVKdYIkHBo+hMvuYnnl8oIMqShAckSdfJL6QUDxhay+RqlhNGvdYm2qGU7LxKIKzcPDi2Cpn4aDwwcpESWsql2V8diVtSsBJQQ2Iy/dBQg4//Y8R6gBWwm8/W+hby9078p4+KHhQ1SVVqV1oKucVXcWERmha6xLj5GaxsGhgyyvWk65ozzjsWvq1jA8PZxbxF2h6Hoa/AcV35ot+dR9cOggq2tXzylHZCRFAZIjHreHOmdd+miViz6pVGHd/7vCDSxLjo0do85ZR4OrIeOxHdUd2IU9tdBcJBwePkxbVRtOuzPjsStrFAFybPRY+gOnx+GVnykrg+oC9Zc454PKSuelH2Y89K2Rtzir7ixNXQdXVK8ANApNC3Ns7JgmJQEU8yxg7eizF38A7gZY/96ku6WUHBk5UjD/BxQFSF6sqFlB51hn6gPatoJnLbz8Q13LcetJ52gn7dXaegWUlpTSXtO+OJyNaegc62RFzQpNx9Y766kpq+HIyJH0B772cyV8+6JP6jBCjThcSljvoT/DWOp2OFJKuka76Kju0HTa5VXLsQt7ZqFpYWYjs/RM9Gh+tuOra6s+28NdSu7Plo+BI7ni4w/6mQhNaH629aAoQPKgo7qDrtGu1HZTIeD826Dvdei1XnavlJLOsU7NEwvE7nkRmzZmIjP0TvZqnliEEKysWZleG5dSCZhYcj60Gl8+Yg5bbgUZhVdSF6Qemh5iIjSh+Z4dJQ6WVy1f1ALk+PhxojIaX01loqq0igZXg3Wf7Zd/pJgtt/y3lIeoY9f6PetBUYDkQXt1OxOhifQO1nM+CKWVyirEYgxNDzE+O56VAGmvbufU1KlF62A9MX6CqIxmdc8ra1ZybPRYakXh+HMwdATOu1mnUWZB7XI46xp45acpa7B1jiqr5KwUhZqORS1Ajo0pY++oye7ZtqQACQWVFe7a66EqtQ9LtYZk8z3nS1GA5IH6RakvaFLKKmHTTXDg95YL6VVflqxesqp2ojLKifETRg3LUOIvWRb3vKp2FZOhSQYCA8kPePVnSuju+vfoMcTsedutMOVPWd5EvedsNNOVNSvpmehZtCVNuka7EAjaqto0f6a9ShEglovEOvRnmB6D825Je1jXWBfljnI8Lk9hxoX5HQmvFkK8JYQ4KoT4fJL93xFC7I39HBZCjCbsiyTse6CwI1dQX8i0fhCAzX8BkVnLOdNVDTPbFQhgTU1NA11jysSyvEp7mKM6CSW95+CIErp79o1QmjnaxxA6tkNVK+y9J+ludWJpdDdqP2VNBxK5aL/nzrFOWipaNAVKqLRXtzM+O87IzIiBI8uB136ulMRpS9/JUjVHawmU0AvTBIgQogS4E7gGWAfcJISYk38vpfyMlHKTlHIT8D3g/oTdQXWflPL6gg08gUZ3I+WO8swCpPkcpW5NihfcLDrHOrOeWNSJd7FPLC67S/Nn1HtOuurady+Ep5VS62ZhK4GNH4Kjj8P4wgZYnWOdtFe1ZzWxtFcpisLx8cWZ83Ns7FjWzmS1xa+lnu3RE9D5tFLzKkXorkrXWFdB/R9g7grkfOColLJTSjkL/BpI1/39JuBXBRmZRoQQtFe1ZxYgAJs+DKdeA1+K8icmkMvE4na4aS5vpmvcQi9ZFnSNdc3pBa4Fr9uLy+5KnkD52n9A80Zo2aTPAHNl44cVZ/q+Xy/Y1TmmPdJOZWnlUgBOTCw+U2UkGuH42PGsfQGWXF3vjU15mz6c9rDJ2Ul8Ad9/KQHSCiSWv+yNbVuAEGI50A4kNmx2CiH2CCFeEEK8O9VFhBC3x47b4/f79Rj3HNqr27WVOD/7/WCzw95f6j6GXDk+fjzryRQs7GzMQFRG6R7rznpiEUKwtHLpwhWI7xD0v6FM3mbTsBKWXgiv3TMnZHwqNJXTxOJ2uPG6vIvS19U31cdsdDYr/wdAc3kzZSVl1nm2o1HY+wul42mGqs7d491AYSOwYPE40T8E3CelTCzCtFxKuQX4MPBdIUTS9aqU8i4p5RYp5RaPR3/n0tKqpfgCvsxRSRUeWHWVUkkzyzLcRjAbmWVgaiCuaWZDW1Ub3WPd1nM2ZsAX8DEdmc6pzMPyquULzTlv/BaEDTYkT+wqOJs/okSDJYSM9070AmTl81FZWrV0Ua5A1LLs2T7bNmFjedXy+GRsOieeV0xYmz+a+dCYoM9WaOaLmQLkJJD4DS+JbUvGh5hnvpJSnoz97gR2Aqk7xhjI0sqlSCQnJ1IncsXZdBNMDiglCUymd7IXicxJgCyrWkYgHGB42lpRZZlQJ9Oc7rlyGb0TvYSjMeEvJbxxr9JtsMKr3yDzYd27oaQM9t8X36ROpsl6oGdiWeWyRbkC6Z3M73u2TF+Q/b8DhxvWJK97lYg65paKzKVq9MRMAfIysEoI0S6EKEUREguiqYQQa4Ba4PmEbbVCiLLY3w3A2wFTyoeqD6mmh27llUq454H7Mx9rMPlMpksqlMlIfVEXC/lMLMurlhOWYfomY07qnpcU7fDsD+g5xPxwVsGqK+HAHyBWMVn9nnMSIFXLGJoeYio0peswjaZnogeHzYHXnb1gX1K5hJMTJ81v3RwJw5t/gNVXa4ru653sxePyZBUcogemCRApZRj4FPAIcBD4rZTygBDiq0KIxKiqDwG/lnPtJWuBPUKI14GngG9KKa0vQBxOOOtaOPgghGcNHll68tFM1c+ok9NioWeiB5uw0VTRlPVnVRNQ3JH+xr1gd2rSDgvKhvfCZL+S3Ihyz9Vl1VSVVmV9qmWVit19sa1Ceid6aa1ozamg4NLKpcxGZ/EFfAaMLAu6nobAEGx4n6bDeyZ6clKM8sVUH4iU8iEp5Wop5Qop5ddj274kpXwg4Zh/klJ+ft7nnpNSni2l3Bj7fXehx65SW1ZLuaNc+7J3w3uVpKDOp4wdWAZ6J3px2V3UO+uz/mxrRWv8HIuJ3olemsub03YhTMWyKmUyPT5+XGkpeuB+JQPcmf3EbCirr1bMHrFVbu9kb3zFmC3qPS82P0jPRE9OihEkrK7Nfrb3369YK1Zeoenw3onenO85HxaLE92yqBE6mgVIx3Zw1igPiImoL1kuSUdOuxOvy2sdW7FG8plM6531uO1uZWLpeiamHd6o8wh1oLRcESJv/hEiYXonenPWTNUVyGL6nqWUeWnj8dW1mebZ8IxipVjzrpSFExOZiczgC/hyfrbzoShAdCArAWIvhbXvUsoThMwrE9Ez0cPSityXvEsqlyw+H0geWpoQgpaKFk5OnlRebke5Zu2w4Gx4HwSGCHc+yanJUznfs9vhpsHVsKiSCUdmRpgKTeUsQJormrEJm7lC8+gTMDOm2Xx1cvIkEllcgSxWllQu4eTkSe2tXte/Vyn9ffRxYweWgqiM5qWZQkyAmL3Mz4Kp0BTD08N5vWStFa2cmjypCP/V79CkHZrCyiugrIqBN35DWIbz0kyXVCjP9mIh1xBeFYfNQXN5s7nP9oHfK31eOi7VdHg+ATH5UhQgOrC0cimhaEi74639UnDVKWYGE/AFfMxGZ/MWIJryXyxCPtFIKi0VLZwa74EpH6y9Tq+h6Y/DCauvoue4Ei6ez/fcXNHMqclTeo3McPIVIKAITdNW15EQHH5EaVlbos1Xl09ATL4UBYgOZBWJBVBiVxywRx5RHpgCo4fGsqRiiZL/ski003xCeFVaK1qZiAQZs5fBqnfoNTRjWPNOeqNKK+V8V10DUwPaV9cmoz7baqBHLpi6uu7erZivsojuyycgJl+KAkQHWsuVh/XUVBaa2lnXKtFYx581aFSpUSfTfCYWdSJeLGas+AokD3NOa6yf+Kn2C5Uy/VZm5RX0OMqwI7IqljmflooWwjKMP6h/GSAj6J3oxevyZlWFdz5LKpcwPD1sTv7LoT8rUXQrtmv+iBq2XMgqvCpFAaIDjeXKCxpPMtPCih1gd8GhhwwaVWr6JvsQCJrKs8+HUFlsuSA9Ez1UllZSXVad8zlapicBONVqcuFELZRV0lvTTGtEUiJyf81bYkJzsaw0+6b68s7GNu3ZllIRICt2KO2KNdI7aU4ILxQFiC6UlpTicXnom8pCgJS6lQfl0J8L3i+9b6qPBlcDpSWlOZ+j3llPqa00u3s2kVOTp/IOc2zteQWA3ppmPYZkOH3OclpmgzBwIOdzqJPxYvGD9E310Vye3/ejWhQK/myfeg0mTinhuxqRUjEj52Oyy4eiANGJ5vLm7ExYAGuuhfFepWd6AdHjJRNC0FzRvGgESN9UX14rLoCqtx6hAsGpmdHMB1uAPjlLcziiKCk5oj4ni0GARGWU/qn+nCoNJNJcodxzwZ/tQ38GUQKrr9L8kfHZcYLhYN7vc64UBYhONFc0Z2fCAiXhS9jgrcKasfqn+uMvST40lTctGgHSP9Wf30s23IkYPExLWd2imExnI7MMTg/T5G6GQ3/K+TxOu5N6Z332ypEJDE8PE4qG8p5M65x1OGwOcwTI8ovBXaf5I+oYiwJkkdNS3kL/VH92RdjKG2DZRXlpiNkipdRlBQLKQ9s/2a/DqIxlYnaCydBkfvd8+FEAWmtWLooEyoEppX97c/O50L9PKfyYIy0VLYtCaKoKXL7Ptk3YaCpvKuyzPXQM/Aezrq3WP6WMsShAFjlN5U3MRmezL3F+1rUwsB9Gug0Z13yGp4eZiczkbc4B5aH1B/2ETAhFzgb1Jcvrno88AvWraK1bxanJU5bvhdIfiE0s7TuUDYcfyflci0WAqKskvZSjgq5A3vpP5fdZ12b1sfgKRAeLQi4UBYhOqM7GnMxYAEce03lEydFTY2kub0YiGQgM5H0uI1FfspwFyMykEp+/+iqay5sJhAOMzYzpOEL9iU8sLVugtj2v56ulvIW+qT7zS5xnIP5sL0bz7JFHwbMGarNr/NU31YfdZqfOqd3spSdFAaITcWdjtrbi+hVQ21awsibqS6FH4xnTnI1ZkrfQ7HoaIrOw6h1xIWR5oRlTZBrLG5Wkx65nIBTM6VwtFS2EoiEGg4N6DlF3+qb6KHeUU+nIP0cnvrqOFmB1PTOplN9fdWXWH+2f7KfJ3YQtj1DtfCgKEJ2IT6bZrkCEUF7wzqcLUlxRT6ebeg51grYqfVN92IWdBldDbic4/DCUVsKyi+ICZDHcc52zjrKSWNZ8OAjduSWtLpZQ3r5JxbenR0JdS0ULURnFHyhAAmXX0xAN5VTdoG+qzzTzFRQFiG5UlVZR4ajITRtXX/Dju/Uf2Dz6pvpw2V05NRiaj5rhvBhWII3ljTk1GEJKxfyzYjvYSxeNAJkTddb2diVp9cijOZ1LPY/Vv2c9QrVV1PMU5J6PPAalFbD0wqw/2h/IM7owT0wVIEKIq4UQbwkhjgohPp9k/y1CCL8QYm/s57aEfTcLIY7Efm4u7MiT01TelFu4Y9tWpbvdEePNWHpqaU67kzqn9cNa+6b6ci/n0b8PJvrivqp6Zz12Ybe+CSsx0s7hgvZLlECAHJz/cbPdlPXvWc2cz5eCCU1VQem4TGn1kAXhaBhfwKeb0MwF0wSIEKIEuBO4BlgH3CSEWJfk0N9IKTfFfn4U+2wd8GXgAuB84MtCiNoCDT0lLRUt2ZuwQHnB27blrCFmg14hvCrN5c2LQxvPdZkfC99V7dMlthI8bo+l71lKqSTUJU4sq65UIv2GjmV9vgpHBW6729JCMxAKMDozqps5p2ArTd9BJZk4B/+HP+AnKqP/ZVcg5wNHpZSdUspZ4NfADRo/exXwmJRyWEo5AjwGXG3QODWTUza6yqorYfhYTi94NuhtM22paLG0aSMSjTAwNZD7S3bkEWg5Fyq88U1N5U3xMFkrMj47TiAcmHvP6gSVg5IihKCxvNHSAkT9PvTSxl12F7VltbkphNlwNBYdtzJ7AZJ3dKEOmClAWoHE+ue9sW3zeZ8QYp8Q4j4hhFqLW+tnEULcLoTYI4TY4/cb6xBrKm9iYnaCQCiQ/YfV7nYGRmNNh6cZnh7WVWNRwx2tmhcxGBwkLMO53XNwBE6+sqDzYJO7ydIrkKThrLVt0HBWzqvcRnejpU1YatKfEc+2oRx5DLzroTr7WlZmZ6GD9Z3oDwJtUspzUFYZP8v2BFLKu6SUW6SUWzwej+4DTES1s2tuLJVI/QqoX2moGUvVIPU2YQXDQcZnx3U7p57kpZl2PQMyCisvn7O5sVyZTK0qNFNOLKuuVNoHzExmfc5Gd6OlV11GTKaGJxNOj0pdz3kAACAASURBVMOJ53MyX4FOCbJ5YqYAOQkkdvdZEtsWR0o5JKVUW979CDhP62fNQBUgOS/1V16pJKzlGK+fCSOWvFaPSsrrno89qYTvtp43Z7NadWBkZkSPIepOynteeYWSz5JDD5rG8kZlNRcN6zFE3emb6sMmbHjc+imJTeUGrzQ7d0I0nLMA6Zvqo6q0inJHub7jygIzBcjLwCohRLsQohT4EPBA4gFCiER14nrgYOzvR4B3CCFqY87zd8S2mYrXrdjJc1qBgKLphqcVrcQAVBNEk1s/AaLes1Xt4zmbNqRUBEj7JQtai6r/f1YWmg6bY2F28rKLlGi/Y09lfc6m8iaiMmrZZMKBwAANzgYcNm1tYLXgdXuZDE3mZpLWwrEnFAVl6QU5fTzvAqE6YJoAkVKGgU+hTPwHgd9KKQ8IIb4qhLg+dtjfCCEOCCFeB/4GuCX22WHgf6MIoZeBr8a2mUrek+nyi8HmyOkF14LaVU5PLS3vVZfBxLOTS7PMTh7uVAoQJukMpzYQs6pPoH+qn0Z348LsZIdTESKd2T9f6vdsVaHpD/h1fa6hAMrRsaegfZvm3ufz0TPvJVdM9YFIKR+SUq6WUq6QUn49tu1LUsoHYn9/QUq5Xkq5UUq5XUp5KOGzP5ZSroz9/MSse0jE7XBTWVqZ+8RSWq5oIzm84FrwBXxUllbm1e5zPvWuegQi91WXwfiD/txyQI49qfxesWPBrrjZzqI+AX/AH5/8FrBiO/gPwXh20YJWVxT8Qf0FSF4+zUwMd8HocSX/I0fSfs8FwupO9EVHozvPcMcVl0H/GzClv6nAH/Djden7wDlsDupd9ZYVIL6AL7eJ5dhTULMM6joW7Kpz1mG32a2rjQfTTCwdsRVV586szmn1ZEIjnm11pWnIs63+/3do732eSCgSYmRmRHehmS1FAaIzje7G/B64jpjGm+ULrgVfMMfJNANet9e6mmnAj8eV5T1HQtC9S1l9JMnYtwmbEpVkUQGSVmg2bgB3Q9Zm0qrSKpwlTkt+z7ORWUMmU0NNWJ1PQWULNKzK6eOqL0pvoZktRQGiM3knXLVsAme1IWaswcCgIUvevIWmQUgpczNtnHwFZsaTmq9U8l5pGsRUaIpgOJh6YrHZFLNJ586sypoIIWgqb7LkPccnU52fbZfdRWVppf7PdjSihIiv2J5UQdGCL6iMqbgCOcPwur0MBYdyLwNtK1Eif47tzKluUSqklMoKJFttXANet9eSAmRsZoxQNJS9lnbsSaXVcPslKQ8xPMQzR9TvIe3EsmI7TPlg4EBW57ZqMmH8ng14tg1Rjvr3KUmqHZflfAq1SnDRB3KG0ehuRCIZDOThw+jYrtTH0bGsyejMKOFo2BCNpdHdyNjMGNNh48vRZ0POWtqxJ5XcD1fq8mrqxGK1ZEJNE0vcD5LdKrex3JrJhGp0oRGTqdft1V9oqubD9ktzPoWRQjMbigJEZ3Sxm3ZcpvzW0YylPnBGvWSJ17AKOWlpwVHFhJXBuel1ewlFQ5brTBgXmukmlupWaFidtR+k0d2IP+AnEo3kM0TdUZ+7nPu9pMGQ1XXnTqV8SWWOFaJRhKZd2Kl1mltDtihAdEaXcMe6DiUCSMd8kHgOiEEmLLBeiGdOWppaviSN/wNOr2rUCdsqqEIz46qrY7vSBS+LJmaN7kYiMsLQ9FA+Q9Qdf8C4ydTr9jI4rWMGfigIJ17Iy3wFyrNd76o3rROhSlGA6IwuseNCKC949y6I6PPgap5YcsDQePk8yClxsnsXOMphyZa0h6lCsyAd67LAF/Dhtrszl7dYsV1pYtbzouZzq2GtVvP9+IN+GtwNhkymje5GojLKUFAnoXnieYjM5C1ABoPGBMRkS1GA6Ex1WTVlJWX5201XbFcigU69qsu4jLSZWtWE5Qv4qCqtUtq6aqV7Nyy7MGN2sPr/aLV7TpsDkkjbVrDZswoXjwvNoLWEphE5ICq6P9udO5VqE8svzus0voAxATHZUhQgOiOE0Mdu2n4pIHTLB/EH/dSU1VBakl3XMy1UlCoNh6w2mWatpU0Ngu9NZXLNQNyEZbF71lzSo6xS6XPSvUvzua266jIiC13FEAGy9Hwoq8jrNEbeczYUBYgB6JIj4K6Dpg2KTV4Hcs7I1ogVkwmzTiJUq9RqECBlJWXUlNVYTxsPZnHP7dvg5KswM6Hp8NqyWkpEieWEppHauK7+vakh6NuXc/a5ykxkhrGZsaIJ60xFt8m07RLoeSkrR2cqjFzmg2Ift9zEkm3mffducLihZbOmwz1uj6XuWUqZXX2ktm0gI3BcW/XnElsJ9a56SwnN6fA047Pjhk2matkaXb7n7mcACR25h+9Cgj+zaMI6M1En07xzBNq3KQ633pfzHpPRS16rZaNHZTT7zHuN/g8Vr8trKXPORGiC6ci09nDWpRdASWlsYtOGx+Wx1D0bUWE6EZuw4XXpFMrbvVsJ0NCooKTC6HvOhqIAMYBGdyOhaCj/hkPLL1YyorOwUydD7eNgpMbidSuTaVRGDbtGNoxMjxCWYe2T6dSQZv+HisftsVQYb9Z5L6VuWPI26NL+fHncHkutQOL3bODqWjeLQvezWSkoqSiuQM5w1Ekrb03NWQ3NG7N6wZMxPD1MREYMtZl63V7CMszwtOltWYAcspPj/o9tmq/hcXkYCg5ZJrEup0i7tm3Q97pSWkMDVlt1qQK8wa1/EqGKLkExk37wH8xKQUmFkZn32WKqABFCXC2EeEsIcVQI8fkk+/9OCPGmEGKfEOIJIcTyhH0RIcTe2M8D8z9rJuoXq0v3trZtiglrNveuaEbmgKhYLZkway0tS/8HKPcckZHFKzRBMZMilaRCDXjcHkZmRpiNzOYwQv0p5AokL5N0FgEamfAFfNhtdmrKavI+V76YJkCEECXAncA1wDrgJiHEunmHvQZskVKeA9wH/J+EfUEp5abYz/VYCHUFoovdtP0SiIaySviaj5FZ6CrxZMIpa5h0sp5Ms/R/JJ7bKmYsdTLNqqTHkrcpbW41rnJ1VY50wB/w47A5qC6rNuwaje5GguEgk6HJ3E9y/NmsFZRUqAExIsdKvnpi5grkfOColLJTSjkL/Bq4IfEAKeVTUkpV9X4BWFLgMeaEOlHr8pItuxBESV5+ECPrYKmo92wV+3hW9ZGmhsB3IGvt0Gp5Ef6gn0pHJW6HW/uH7GWKM13j82W1BEo1cdLIyVRduef1bOegoKTCF/QZarLLBjMFSCvQk/Dv3ti2VNwK/GfCv51CiD1CiBeEEO9O9SEhxO2x4/b4/YV50Z12p359BMoqofXcvPwg6gRX76rPfzwpUFvbWkWA+AN+astqtSVO5uD/AOtNpjnn+rRvg4H9iiDNgC6TqY7k1DAsS+LKUa6KghqgsfztuozH6JD8bLCbPQAtCCE+CmwBEgOol0spTwohOoAnhRBvSCkX1D+XUt4F3AWwZcuWgtXe9rq8+i3z27bBc3fAzGROGay+oI86Zx0OW/7aTyrsNqWYnVW08ay0tBT+j1AoRG9vL9PTyfNwpJR8d913qZyu5ODBg/kOOW/eU/UeRJXIOBan08mSJUtwOGLPQ1us70n3LlifUhcDdJhMdcYX9LGyZqWh11Cfo5yFZo4KSir8QT8XNF+gy7nyxUwBchJYmvDvJbFtcxBCXAF8EbhUSjmjbpdSnoz97hRC7AQ2A/o10MiTBneDfrbx9m2w+9tKFc9VV2T98aySy/LA69ZRaObJYGBQu5aWwrzQ29tLZWUlbW1tKU0kJcMlVJRW0FqRbvFcGA6PHMZtd7OkMrWlV0rJ0NAQvb29tLe3Kxtbz1XyEzQIkFpnLXZht9QK5OKW/OpKZUJ9jnLu8ZNDgEYqguEgE7MTlojAAnNNWC8Dq4QQ7UKIUuBDwJxoKiHEZuAHwPVSSl/C9lohRFns7wbg7cCbBRu5Brwub35NpRJZeqFSgC2LhK9EClV4rcHVYB1zjtYs9DT+j+npaerr69Pa1+02u36lvvNASkk4GsZuS68TCiGor6+fu6oqcSgCVIOZ1CZsinJkge85EAowGZo0/Nkud5TjsrtyVwi7dyt+Jnv+dejUOcUKOSBgogCRUoaBTwGPAAeB30opDwghviqEUKOq/i9QAdw7L1x3LbBHCPE68BTwTSmlpQRIg7sBf9CvT8e6UrdSXjxHP0ihSj97XB5LrEAi0QhDwSFtL1kG80Im56zD5rCEAInICFJKTWbKpPfUfgkMvgUTmcOwrZILUqh8CCGE8mznohDGFRR9/B9W6YWuYqoPREr5EPDQvG1fSvg7qb1GSvkccLaxo8sPr+t0x7oapw7x2m3bYNe/wPSYkmCokXA0zND0UEEeOI/bw9C0klhXYisx/HqpGJkZ0Z44mad5wW6zEwjnnqOjF6oQy7QCSUl7TIB274Kzb0x7qMft4fj48dyuoyNGdiKcT4OrITez3YlYfo1e/o8C5L1kQzET3SDydrzNp32b0ilPY+E7leHpYaIyWpAlr8flISqjpifWxTOytQhN1byQY3il3WYnEo0YVsKlpKSETZs2sWHDBq677jpGR0eTHqcKkGgoygc/+EFWrlzJBRdcQHd3t7YLNW2EsipN1Z89LmsUkcypZXGO5FzCpXs32F1K6XwdyOrZLgBFAWIQqoag21J/yflQUpZ1efdC1s2xSoin5nvOMf8jEdVkZJQZy+VysXfvXvbv309dXR133nln0uNC0RAAP//pz6mtreXo0aN85jOf4XOf+5y2C5XYldprGvJBPG4P47PjTIfzrxKdD4UsKphzEcnu3Ur/Dx38H6CYo0ttpVSVVulyvnwpChCD0D2xzuFUHsQsHemFSCJU0TWBMg8028Z1CK9UTUaF8INcdNFFnDypBCoeO3aMq6++mvPOO49t27bFQ3f/9OCfuPnmmwG48cYbeeKJJ7T74dq2wXAnjJ9Ke5hlvueAH2eJk0pHpeHX8rg9BMIBpkJT2j8UGIaBA7qZr+B0cIgVstBhkeSBLEZ0N2GBoinv/KZS+M5Vq+kjhdbSwPzEOs2Jk1n4P77y4AHePDW+YHtURpkOBymzj1AisvP7rGup4svXrdd0bCQS4YknnuDWW28F4Pbbb+f73/8+q1at4sUXX+R/fPp/8KP7f8Spk6dYulSJjrfb7VRXVzM0NERDgwY/gboS694N53wg5WGJrW3ThQwbTSEn08T8l/LqDP3mVY4/B0hd6l+pFCokXyvFFYhBuOwuKh2V+kartKmF77T7QXwBHzZho85Zp984UhCvQmyyCUtz4uTxZ/MOr1QnL2mQDyQYDLJp0yaampoYGBjgyiuvZHJykueee473v//9bNq0iY9//OP09/djL8lTH2w6WwnQyGDGsko730JkoavkZJ7t3q3UGWvVx/8B1umFrlJcgRiIGsqrG63nKQ9k925Yc62mj/iDfuqd9blH52SBo8RBbVmtfvkvOaJJSwsMK+U7dvyjpnOmWilIKTk4fJB6Zz2N5Y3ZDjUjqg8kEAhw1VVXceedd3LLLbdQU1PD3r1748d1jnZiEzZaW1vp6elhyZIlhMNhxsbGqK/XWMLGVqKU2+jenfYw3f17OeIP+llbt7Yg18opA/+46v8o020c/qCfra36rWjypbgCMRDd4+UdTqV6ahZ+EKN7oc9H1wz8HNGkpelUXkIIgV0Yn0zodru54447+Na3voXb7aa9vZ17770XUITY/n37cdgcXH/99fzsZz8D4L777mPHjh3ZmXjatip+kLEFRSHiVJdV47A5TP2epZQFfbazXl0HhqF/v67+j0BI8cEUImxZK0UBYiC6r0BAeSD79ysPqAYKXXhN1wz8HNHUvlfH8hJ2mz0eBWUkmzdv5pxzzuFXv/oV99xzD3fffTcbN25k/fr1PPrQo9htdm699VaGhoZYuXIl3/72t/nmN7+Z3UUS/SApUBPrzFyBTIWmCIaDBXu2q0qrKCsp0x44cOJ5dPd/WKiRlIpmu4YQwp1QWr2IBtQViJRSP0df21ZAKg/omndmPNwf9HOO5xx9rq2BBlcDR0aPFOx68wlHla6IGVcgOpaXsNvszEaNabA0OTm3B8WDDz4Y//vhhx8GlHt+a/gt7DY7TqczvjLJicYNp/0gGz+Y8jCzW9sWOiNbCJFdqZ64/+M83cZgtRwQ0LACEUJcLIR4EzgU+/dGIcS/GT6yM4AGVwOz0VnGZxdG7+TMki2n/SAZCEVDymRawAfO4/YwHBw2rTe6mjiZVktT/R86aYcOm4NwxLxyJqr5TJdqy7YSWL41oyPd6za3nIkZfcGzKhbavTvWrEtH/4fFstBBmwnrO8BVwBCAlPJ14BIjB3WmYEjDIXtZLB8kc8LXUFDp71DIl8zj8hCWYUamtfXY1htNE4vO5bXtNjsRaVw2eiZU85lugRJtW2GkG0Z7Uh5idjZ6IcPTVTSXMwmOQP8buvo/wJx7zoQmH4iUcv6TFDFgLGcchoW1avSDFDKJUMXsbHRN96yj/wMKm0yYjLzrYM1HXZmpgjYJHreHydAkgZA5Vu1CljFR0ez3Oa76P/QpoKjiC/hw2V1UOLLvCWQUWgRIjxDiYkAKIRxCiP+JUj23SAYSE650RfWDHH8u7WFmLPPNbjikSUvTubyEajoqhCM9GbqvQBo3gLMmbfVns3uj+wI+3HY35Q6NSX06oArNYDiY/sDjzyplh1q36Hp9f8BPg6vBMlnooE2AfAL4JEq72ZPApti/i2QgvgLRezJNzAdJgxmln9VrmTmxCETqxEmd/R9gjRVIia0Em9ApqNJmU/5/0phJzU4aVXuhF5J4CZdMUYbduxQFxeHU9fr+YOESJ7WS8YmTUg5KKT8ipWyUUnqllB+VUmZunlwEt0PRkHR/yeJ+kPQCxB/wUyJKCpKFrqJOLGbZxweDg9S70iRO6uz/AGsIEN0TRdu2wuhxGD2RdLfZyYT+gIZQbZ2Jl+pJl/8SHIW+fbr1P0/EDKGZCS1RWD8RQvx4/k8hBncmYFi8fNs2RZNO4wfxBXw0uBr000w1UFZSRnVZtak+kLRams7ltQFKRAlCCENMWFrKuYej4bgZ7dvf/jbr1q3jnHPO4fLLL+f48Rz7dqgCtju5H8TsciZmlPTQ5N878QJ6539A4RMntaJlZvkT8OfYzxNAFTCZ9hMaEUJcLYR4SwhxVAjx+ST7y4QQv4ntf1EI0Zaw7wux7W8JIa7SYzxGYFi8fLwuVmo/iFkai5mdCTPec/duWKZP/oeKEMKw1rZayrmHoqH4CmTz5s3s2bOHffv2ceONN/L3f//3uV3Yu04p2JnCjKUm1pmhKEgpTTVhpVUIu3cp/o8lb9P12oVOnNSKFhPW7xJ+7gE+AOTtHRJClAB3AtcA64CbhBDr5h12KzAipVyJEk78z7HPrkPpob4euBr4t9j5LIdhK5DWcxVNOo0ZyyybaYOrwTTTRlotzQD/h0oheqOnKuf+4Ws/TNfhLgC2b9+O2+0G4MILL6S3tze3i9lssbpYyQWImlhnhgAZnx1nJjJT8GdbLeGS9p67dyu5Wjr7P6zWylYlF8PpKkAPMXg+cFRK2QkghPg1cAOQ2Nv8BuCfYn/fB/yrUEIQbgB+LaWcAbqEEEdj58uuXV8B8Lg88d7oukZPaPCD+AN+zvXqZ6rRitft5eX+lwt+XTVxMqWWlo//4z8/r8T2p6AlMq3kgdjd2s/ZdDZco63USKpy7m0r2rjvsfv4wt99gV075072d999N9dcc4328cynbRsc+hOMHIfa5Qt2m5VMGI8uLPBkmrE3+vQY9O+DSz6r+7XNiKjUQkYBIoSYACQgYr/7AY1tztLSCiTml/QCF6Q6RkoZFkKMAfWx7S/M+2xrivHfDtwOsGzZMh2GnR0et4eZyAwToQn9u4i1bYOnvqZo1u65jvLZyCyjM6PmrUCMEJoZUBMn1V4sC+h+Vnf/h4oQQnvjpixQy7mfPHmStWvXLijnHpVRZiOzyPDca//iF79gz549PP3007lfPN4nfXdSAeJxeTg8cjj38+dIPFTbjGc7XbHQEy8obacNWOFaMYkQNAgQKaXx7b4MREp5F3AXwJYtW/R/wzOQaDfVX4AkJHytvW7OLjMLr3lcHsLRMKMzo9Q6tTW+0oOMpR7y8X9kWCmMB/z4Aj7W1K2hxKafNTVTOfeJ2QlOjJ+gvbo9/pnHH3+cr3/96zz99NOUleVRSsOzFlx1yv/b5o8s2O11e3n2VOpkQ6Mw+9nuHutOvrN7F5SU6u7/AHMSJ7WQ0gcihDg33Y8O1z4JLE3495LYtqTHCCHsQDVKSRUtn7UEhmZmt56X0g9i1jI/8ZqFto+ntRMb6P+AhN7o0hg/SKpy7qFoCCklb76hWH5fe+01Pv7xj/PAAw/g9eY52dhsSjZ1CjNpg6uBqdBUwbPR1cgvM8qaqybppHTvVpIHHS7dr2tG4qQW0jnRv5Xm5190uPbLwCohRLsQohTFKf7AvGMeAG6O/X0j8KRU7AQPAB+KRWm1o/hlXtJhTLpjaGa2vVTRqJO84PHKnSYs883KRk+rpcXbi+pbn0ilELkgycq5b3vbNm7YegN/fvDPAHz2s59lcnIy3q3w+uuvz++ibZfA2AmlNtY8DKu0kAF/wE+loxK3Iwt/k0543B7GZ8eZDk/P3TE9Dn2vG6agWDEHBNKYsKSU2428cMyn8SngEaAE+LGU8oAQ4qvAHinlA8DdwM9jTvJhFCFD7Ljfojjcw8AnpZSWrM9l+EvWthWeXOgHMXuZnziGQuEL+CgRJdSWJTGbGZD/kYhRAiRTOfdTk6cYnx1nTd0aQDFf6Upif5Datjm7EnNBllct9JEYhaZ+LwYRz0YPDs7tB2+g/wPMSZzUgqYoLCHEBpRQ23hsmpTyP/K9uJTyIeChedu+lPD3NPD+FJ/9OvD1fMdgNPFsdKO0cVWjnucH8QV82G12aspqjLluGlQndqFzQfxBP/Wu+uQ+CAPyPxIxqx5WYhKhIXjWgLs+5gf56JxdZmWjm5lQl1iqZ44A6d4FNoch/g9Q7vlsz9mGnDsftGSifxn4XuxnO/B/gDzXxf+1MLT0dUssH2Re4Tu1E6EZhddcdheVjsqCZyn7AynyXlT/x3LjeknbhA0hRMHLmSQmERpCvC7WbpgXZaYqCmaYsMxKqIuXM5n/bB9/Vsn/KNXfrCalZDA4aLkkQtCWiX4jcDnQL6X8GLARxZldRCNet9e4lyyFH8QXNLfsgcdd+Gz0lKaNuP/DOAFiZDZ6OgxfgYCyyh3rWeAHqXRU4ixxFnQFIqU09dlOGiAyMwGn9hpS/wpgIjTBdGTakiYsLQJkWkoZBcJCiCrAx9wIqCIZ8LgNbr7Ttg18B2DqdI3LwcCgqU43M3pmp9RMVf9Hq7FJlQ6bo6ACREppTCHF+aToky6EUJ7tdMUFdWZ0ZpRwNGxaQl1NWQ12YZ+rHJ14AWTkdN6Mzlg1hBfSh/HeKYTYCrwkhKgBfgi8AryKBTO+rUxib3RDSPSDxPAFfaaEOao0uAtb5mI2MsvIzEhyLS3e/0O/9qLJsNvsBfWB6N5IKhWeNeBuSBrtV2hFweyEOpuwUe+qn6sQxv0f5xtyTTMjKjORbgVyGPi/wLuA/wW8CFwJ3BwzZRXRiCG90RNp2ax02Iu94MFwkInZCVM1FsOF5jxUjXDBPcfzP4zRDhMptAkrLkCEwQJEiNP9QeZ9n4U2VVpBG1/QG12tf2WA/wPMjajMREoBIqX8/6SUF6H0Px8Cfgw8DLxHCLGqQOM7IzCkN3oi9lJYetoPotbqMVNjMVxoziOlllYA/4eKw+YgKqNEovpFlKcr566udhJ9ID/96U/xeDxs2rSJTZs28aMf/UifgbRthfGTMNI1Z3Ohe6NbQRtvcDWcvufpcUP9H2Bu4mQmtFTjPS6l/Gcp5WbgJuDdwCHDR3YGEY+XN9JW3LY15gcZtETlzrizsUDmjZSmjQL5P8CYXJB05dzVrPf5JqwPfvCD7N27l71793LbbbfpM5C2hLpYCXjdXgLhAFOhKX2ukwGzTVgwr11Bz4uK/8NABWUwOEiFo8KUxMlMaAnjtQshrhNC3AP8J/AW8F7DR3YGUZB4+fZLlN/Hn81cE6oAaOrepiMpq5V274albzPc/wGnTUlGmbHml3O/8bob+cDlH2DHZTs4dMhgnc5zFpR7FoSLF1pR8AV8VJdVU1Zi/PeZCo/bw+jMKLOR2dP+j6XG+D/A3LyXTKQ0ngohrkRZcVyLUibk18DtUsrCqBpnEAWJl0/wg/iWKwlHZj50qtmuUPZxf9CPXdjnFm8MDMPAG7D9H/I+/z+/9M8cGk4/SUdllGA4SFlJmSbH9pq6NXzufG2FrZOVc//Kt76Cd5mX0SOj/PVf/zVPPvkkAL/73e945plnWL16Nd/5zndYulSHoMm4HySWDxLLL0qsOtBW3Zb/dTKQMtengCRWl2jtflapSVdqXI0qK9xzKtKtQL4APAeslVJeL6X8ZVF45IbL7qKy1ODEuhIHLLsQunfjD/opKynTv/pvFhS6N7ov4KPBPa99rxqVZlB45XzUpE2JfoEDajn3pqYmBgYG5pRz//hffpz3XPoePv7xj9PX1wfAddddR3d3N/v27ePKK6/k5ptvznCFLGjbChOnYLgzvqnQrW2tUBMqLjTHjsOp1wz3r1nhnlORrhbWjkIO5ExHjUoylLat8MRX8Y330OBqMCULXcXtcBc0G90X8C002XXtUlZlOtS/0rJSkFJyaPgQtc5amsqb8r4mpC/n/uAzD+KwOVhWdbrPTX19ffzv2267LfeWtsloi5lJu3dD/Qqg8OVMfAHfnNL1ZqBO5r4Tzxnu/7BqL3QVLYmERXSgIAlXMUenf7STRnejsdfSQCE71vkDSbS07t1KdJpB9a/mo2ajG5ELkqyc+4O/fxC7zY6UktdfqhLGOAAAIABJREFUfx0gvhIBeOCBB1i7dq1+g2hYBeXeOW1uyx3luOyuguT8RGWUweCg6c923ITV/5rh/o/RmVFC0ZAly5hAUYAUjIJMpi2bwVGOPzBgCY2lkFnKC8pbTA0qUWkFCN9NxMhckMRy7j//xc+57+f3ceVFV7J+/Xr++Mc/AnDHHXewfv16Nm7cyB133MFPf/pT/QYw3w/C6TavhVAUhqeHiciI6c92TVkNdpsd38hRw/0f6gp+0ZmwiuiL2ogmKqNz7fR6UuJALr2AgfBRtlrA6eZ1e3mp3/g2LUkTJ+P+j0sMv34iDpuDYDio2/lSlXOfjczyg9/+gJaKljmBA9/4xjf4xje+odv1F9C2FQ7cr/hBYmasQikK8cnUZG1cCIHX2YBvvBPWvMvQa1k5iRCKK5CC4XGfbvNqJFPLLyAooNFufucyr9vLYGCQqIwaep2kiZNdu8BRrqzKCoi6AjE6A79gZUzmowrkrmfimwri38MaWegq3hIn/hKb8Q50EzuLaqEoQAqE4dnoMXyN6wDwTA5lONJ4PC4PYRlmZHrE0OsMBAaU6yW+ZN27lKi0EoMr1c7DbrMTlVHDhaYqQAyvxDuf+pVQ0TgnodDjVlbXRgtNKyTIqnhCIXx2u6H+D7BG5n06TBEgQog6IcRjQogjsd8LWsgJITYJIZ4XQhwQQuwTQnwwYd9PhRBdQoi9sZ9Nhb2D7ClUlz5fhdKV0Dt03NDraCEerWJwJFZ8ma+aNib94D+kS/hutpNivDe6wTWxVEd9LiuQvCb6JH4Qj8tDMBw0PBvdF/AhENS76jMfbDDeqWF8doeh/g9Q7rmmrIbSksIEgmSLWSuQzwNPSClXAU/E/j2fAPCXUsr1wNXAd2NVgVU+K6XcFPvZa/yQ86NQGbv+GUXb9/btN/Q6WihUz+y4bbw8JkDUKKE8Cyg6nU6GhoaymnDVCd3oqrzhaBghBCUiSffFNEgpGRoawul0Zj44FW3bYLIfho4CBSrVg/Lu1LvqC7/qms/MBN6xfqaENF5oBn2WMNmlwiwn+g3AZbG/fwbsBOYE2kspDyf8fUoI4QM8gLFOBINI2clMZ+JLXv9hRROvMD8b3fAVSMCPs8RJpaNS2dC9G0oroDm/hemSJUvo7e3F79cuAMPRML6Aj+myaUNrF41OjzITnUH4ss/1cTqdLFmyJPOBqYjXxdoFDavmmGc7qjtyP28GfAGfNUw5J17EE1YUBH/AT3m1wVnoFjDZpcIsAdIopVQD1vuBtIHdQojzgVLgWMLmrwshvkRsBSOlnEnx2duB2wGWLVuW7JCCUFpSSk1ZTUG08YoSF24p4fhuWP8eQ6+XjnpXPQJhvNCMhfDGEye7d8Gyi6Akv8fb4XDQ3p5d0logFODDv/wwnz7309y69ta8rp+O2x69jWA4yD3X3mPYNVJSvwIqmhRBveW/Fc48G/DplqCZF8d3440tSn0Bn6ElXPwBP6trVxt2/nwxzIQlhHhcCLE/yc8NicdJxT6Q0kYghGgGfg58LNYZEZQyK2uAtwF1zFu9zDv/XVLKLVLKLR6PuZLc8M6ExMoeVDQpGniSBkCFxGFzUOesK8iqK66ZTgzA4OGClS+Zj9vhptxRbngNMH/Ab15CnRDK/2/MD1Iw82yqlsWFpns33nolQdNIs10kGmFwetAa95wCwwSIlPIKKeWGJD9/BAZigkEVEEm/hVgL3T8DX5RSvpBw7j6pMAP8BDA2FEInChHuqJQ98MbrYpmNof3gY8zJQo/7PwqbQJhIIXpkmF5gr20rTA7A4BHKHeW47W5D7zkUCTE8PWy+P2BmEk6+ineZ0v/DyHsemh4iKqOm572kwywn+gOAWuXtZuCP8w8QQpQCvwf+Q0p537x9qvARKP1JzPcYa6AQCVfxmlBtW5VIpMnC9iWfj9GrLinl3GJz3bugrAqaNhp2zUwYLTQDoQAToQlzNdNEPwjG33O846TZk+lxpf5VeccO3Ha3oQqh1XNAwDwB8k3gSiHEEeCK2L8RQmwRQqgt1D6A0g3xliThuvcIId4A3gAagK8Vdvi54XF5GAoO6dqxLpGojJ5e5sf7pJu7CvG6vYYKkMnQJMFwMEGA7NbF/5EPRgvNlO17C0ldB1Q2x1e5Hrex5UyS5vqYQedOKCmDZRca/myr5za79lc6THnLpJRDwOVJtu8Bbov9/QvgFyk+vygrBXvdXiIywsjMiCHtKUdnRglHw8rE0rxJ8YN07TLVke51eRmeHiYUCeEwIKlvTiOp8T4ltPS8W3S/TjYk9oM3oiKyJZLLhFCUlM6dih/E5eGNwTcMu5y6ujF9Mu16GpZdAA6X4QLECt0XM1HMRC8gRvdOmFPqocSuaOIm+0HUezbKqTxHM7WA/wOM7wdvmQJ7bVthygeDh+MFFY3KRo8LTTMn00k/DOyH9ksB4812voAPm7BR56wz7Br5UhQgBcTo3gnxyVTVTNu2wuBbMFmYirjJiOeCGOT7mVNsrnMnuGpN9X/Ex4KBioJVCuypgrp7Fx63h+nINBOhCUMu5Qv4sNvs1JTVZD7YKLpj9b86LgNOmyqNFJr1zvrC1zvLgqIAKSBGZ+yqgim+zI87Os1bhRg9mcY1U2eDIkDaLwWbuY91PKzVIO3UF/DhsruocFQYcn7N1HVAVSt07TrdwjhgzEpTjTozrJK1FjqfVgI0YgmqXpeXUDRkWIHUBS0KLEhRgBQQtYaPUSsQVTDF/SvNG6G00lQBYnQGvj/gp9JRiXv8FIyfjGuHZmL0SlOdTM3sOAnMqYvlUVsYG6QcWaKkR9fTyv3GAjQMX2kma5JmMYoCpICoiXVGaqZ1zrrTzuoSOyw31w9S66zFbrMbN5mqUWedO5UNHZcZcp1saHArk6lh37OVNNO2rRAYxBNU+pYYphwFTBYgI93KT8z/AcbXevMH/OaHLWegKEAKjJGdCZNqLKofZGLAkGtmwiZshibWDajdFzt3Qs1yqDO3XzaAy+6istS4fvBJ+7+bRcwP4hl4EzBWGzc16qzzaeV3x2XxTUYGxcxGZhmZGbGOopCCogApMEZOpkmLzamOThPzQYxMoPQH/HidDUq4csdlhlwjF4xq8yqltFaBvdp2qFqC+8SLVDgqDIm2C4QCTIYmzV2BdD2t1P/ynBXfZKR51jKBEhkoCpACY2ToX9JlfpP5fpBGd6Mhk6maOOmNSpgZs5YAMUhoToQmmI5MW2diSfSDGJRAafpkKqXSgbH9EuV+Y5SWlFJbVmvMPSfmN1mYogApMB63ko2ud7+IUFSpFbRAM1X9IF27dL1eNhi16hqZHiEcDeOZiAmnBPu02XhdXkMiknxTFskBSaRtKwSG8JS4DVGOTM8B8b0JU37oWPh8GZWBr4bkW+p7TkJRgBQYr9uLROo+uQwFh5DI5A9c+yUwdATGenW9plY8bg+ToUkCoYCu5+0P9APQNNQNTedAufmd6lTUFYjeOQLxe7ZCWXOVWOVjTzhsiKJg+mSq+j+SKChet9eQlWb/lAW/5yQUBUiBaXIrD4Q6EehF/IFzJ3ngVsSqxhx7UtdrakXNS9FbOx2YUiaWpoGDljJfgTKxhKNh3XME0n7PZlGzHKqX0jg1zEBgQPd+8Kbfc+dOJeelZumCXUaVMxkIDOCyu6gqrdL93HpSFCAFRtUo1JdCL9TzNZYnqRXkXQuVLXD0CV2vqRWjolXi9zwzbTkBYpSDdSAwgEDEQ4UtgRDQcRlNQycIR8MMTw/revr+qX4qSysN7fCYkvCMUiJnRfLye2qB1HA0rOtl+6f6aXQ3mp/rk4GiACkwRguQpEteIZQXoHMnGFQJOB3qCkT3ew7048BGnYjV/bIQRmWj90/143F5zO8LPp+VV9A0o+SC6P09D0wNmGfKOfEChAKw8oqkuxvLGxWTtM7RZ6becxYUBUiBqSytpNxRbshk6ra7T/cFn8/KHTA9Cidf1fW6WjBKaA5MDeCNSmxLL4BSE7TTNBi1Aumf6rfmxNJxGU0Rxd9jxLNtmvnq6ONgc5wuCzQPdVx9U31J9+dKf6Df/MrDGigKEBNocjcZsgJpKm9KveTt2A4IOFZ4M5bL7qKmrEb/ex4/QdNMMKV2aCaN7kYEQn+hGRhIbqY0G1cNTd6zAWNW16YJzWNPKt09y5LXHWsubwb0vedwNMxgcNCaisI8TBEgQog6IcRjQogjsd+1KY6LJDSTeiBhe7sQ4kUhxFEhxG9i3QsXDU3lTbo70TMued110HquaX6Q5vJm3bW0gfEemiIRWHWlrufVA0eJgwZXg64Ti5Qybhu3IjUrrqQsGqV/tEu3cwbDQUZnRs2ZTMf7lPLtKxe0LoqjjkvPZ9sf8BOV0aIAScPngSeklKuAJ2L/TkZQSrkp9nN9wvZ/Br4jpVwJjAC3GjtcfWkqN2AFEtCgpa28Ak7ugeCIrtfWQmN5o65CMyqjDITGabK5wLtOt/Pqid5Cc3x2nGA4aNmJRay6guZwhH6/fh2m45F2ZtyzGrWYZoVbUVpBpaNS1/dZDVu2qqKQiFkC5AbgZ7G/f4bS11wTsT7oOwC1T3pWn7cCjeWNDE8PMxuZ1eV8oUiIoeBQZjvxistBRk/HtReQ5vJm+if1e8mGp3yEkTTWr56THWwl9FYU1InFqgKE5s00Sht94yd0O2U878UMH8jRx6GiERo3pD2sqaJJV0VhseSAgHkCpFFKqf6P9wOpRK1TCLFHCPGCEEIVEvXAqJRSjZvrBVpTXUgIcXvsHHv8fuO6h2WD+jKo2lW+DAQGkMjMD1zreVBWbYofpKm8iYnQBJOzk7qcr7/rKeW8rRfocj4jUFcgeiUTxsOWraqZ2mw0lTfSH5qAqD65IKZNptEIdD6lKF0ZFJQmd5Nu7zIUBQgAQojHhRD7k/zckHicVN6uVG/YcinlFuDDwHeFECuyHYeU8i4p5RYp5RaPxxp1ZeJRSTqZdNLmgCRSYlfKMRx9UqnvU0D0djb2H48JkPbk8flWoLmimZnIjG7JhIthYmmqP4tBG4RPvabL+dSJueCBA6deU0y9afwfKnqbKvsD/ZQ7yqksTRFRaSEMEyBSyiv+//bOPDqu4kz0v68ltSxLsqxd1mJLxpbkFbywLwEDYR0gwUlgJsRhyMtL5mROZpKZQN5M5uRNXk4gJ8m88OBNkgkJTMIEyAYOsQ3GrI/FC+BFsi1LtrW7JWtXa5e63h91W5asxa3ue3sx9TunT9+uW7e6qu699VV99dVXSqnV03xeAFpEZBGA9T2traNSqsn6PgG8DqwD2oGFIuLf57EQaHKqHE5gt1nrnNxbLLseehrhdJUt/x0odgvNFs9+AHIzltmSnhPYbeLZ0t9CnMRFtYO9vPxL8IlwuvpFW9Lz9HtIT0wnMS7RlvQCpuYVQCzrxdnJS86ja6iLgdEBW/66pa8lekeZZxEpFdZWYIt1vAV44ewIIpIuIonWcRZwJXDYGrG8Bmye7fpoxnYBMhdXD/4JweqXbfnvQPGPQGxpTHtb8PS1kChxpCdOa8AXFeSl2CtAPH0espKyiHPF2ZKeE+RllgLg8e8fHiIRM+Gt2aWtFgPwr+bE+xzNo8yJREqAPAzcKCLVwA3Wb0Rko4j83IqzAtgnIgfQAuNhpdRh69yDwNdEpAY9J/JEWHMfIknxSaQlptn6wAXs6iGtEHLXwLEdtvx3oGQlZeESlz1lPr4LT3wcuUlZUe3qwW61XSysTh739dZ+FAZCV915+jzhV195T0PjXlgWmHm4rZ0jArSojBLizx3FfpRS7cAU5aJSah/wBev4HWDNDNefAC5xMo9OkzffvrUgLf1zbFjKboa3fgT9HXp9SBiId8WTMz/Hnsa0eieexCTyFiwOPS0H8ateTnntU2GVZZSdO2IEGe+Nx1mLVlffHVJ6LX0tbMzdaEfWAqf6ZUBB2S0BRfeX2Y6JdL9FpVFhGWbFThPPlr6WuZk5lt4CaszS84YPW1bgj41AzS5a3EnkRpNH2mkQEW2+bENHIdoXEfpJcaeQkpCCZ14KVG0PKa2+kT56R3rD3xs/tl07H110YUDR/V4H7BiBtA60BmZRGSUYARIh8pLtsx2fs840fx0k54T8gs8VW6xV6t5mdKibVjUSEy9ZbnKuLfe5Y7CDwbFB8lPybciVs+Ql53FqQZ7uyY8Fv3FaRKzORofg+GtQelPA64vs9DrQ7G0GzqjFoh0jQCJEXnIevcO9IW+y1D/ST+dQ59waFpcLSj+uJwpDeMHnSl6KtpcPab+Io9vwJM5nDB+FqYX2Zc4h7FpA6W9YClJmXPIUNeQl5+FxJ8Jgt/ZmGyRNXm1cGdYy174Fw96A1Vd+7DLljUiZQ8AIkAhhlw+doB+40lv0PuL174b0/3Mhb34ew77h4PeLUAqqttNcpHXisfCSLUpexOmB04yEKKib+vR9joURyKLkRXjG+iHOHdIo1/9sh7XMVdshYb7exXMO5Cbn2jYCEcSMQAyzU5iie8/+lyRYgu6ZXnAdxCVCVfissUK2SmqpgO56mvLKgdhpTBVq3A1JsDT1xk7PND8ln86hLvqLr4aqbUEvWm32NuN2uclKCtPmWUrp92HpdZCQNKdLFyUvwtPnCdnrQJO3iZz5OSTERdl+LzNgBEiE8KtfGntD26e80auvn3Nj6k7Wvaxj28O2Kn1RihYgfqE3Z6q2A0JTqjYJjoU5ELvWCDR7m1mYuJDkhGQ7suUo48928aXQeRLajgWVTpO3ifyUfFwSpmaqpUIvsi27ec6XLkpexODYIJ1DoTkqbfY2x0QnwY8RIBEic14m8+LmjQuAYGn2NpMUn0TmvHMveJpC6U3QcSLoF3yu+F+MoEddR/8MhRfTPNxN7vzc6NuVbxr8gj3UkWZTX1NMjLjgzOi6MdvyPFS1Lah0mrxN4W1Mq3YAAqVzFyB+oekfKQZL2MscIkaARAgRIT8l35YHLj85P7gFdeW36e8jW2ePZxOp7lQWJi4MbtTV3QSn9kPZLeM901ggPzkfQWzpKMRKwzLeUfANaFPYozEiQI5shcKLISVnzpeOC80Q7vOIb4SW/paYebbBCJCIUpBSEHrPNJTGdEE+FF0GleHzBFOYUhjcS+bvxZbdGlO9tIS4BPKS80JSVSqlYkqA+FVtTd4mKL8dGvdAz9zUlt5hL91D3eFrTDtOgOcgrLzz3HGnoSBV35tQ7rPfQjFW7jMYARJRClMLafI2hTTxFnJjuvJOaDkE7ceDT2MOFKYWBveSHX4BssoYziihtb81pl6yotQiGnobgr6+fbCdobGhmOmZiojuHPU2wUprF4bDcxvljlsXpobpPvvzt/KO2ePNQFJ8EllJWSGNQGLNhBeMAIkoBSkFeEd0TysYeoZ76B3uDW09xIq/0N+HwzMKKUwtpNnbzJhvLPCLelug9v/Bqk/gsfY+iZXGFEIQmhax2LAUpBToxjS7FHJWweHn53S9v8x+1ZDjHH4B8tfDwuDd4xSmhHaf/cYlsfRsGwESQUI15fXPn4T0wC0sgoKN4RMgKYWMqtG5mbUe2QooWHXXeA8vlhrTotQi2gfbg140GkuLCP341bNK6ftG/btzUmOFtTHtqofmD4JWX/mxo6PgElf4nUeGgBEgEWRcbxrksNe2hmXlnXqCurM2tHQCICjz5crnIbscclbEZGMa6gSrv4MRK4vLQN/ngdEBvWg0CDVWk7eJpPik8LjrD1F95acwtRBPvyfoRaNN3iby5ufFhHWhHyNAIkioZq229cb9L04YRiHjAiTQxrTXA3Vvw6pP6Ot6G4kX7dk3VihKLQKCn2Bt6G0gY15GYO76o4RJQjMINVajt5GClILwuOs//ALkrYWMpSElU5hSiE/5aO4Lbp1TY29j+OZ8bMIIkAiS6k4lLTEtpIYl1Z3KAveC0DKSXqwdLFb+MbR0AiB3fi7xEh94mY/8CVDjvdj63noKUwuJd0VkJ4Kg8AvNYCfS63rqKF5QbGOOnGe8c+Q3U191l/aLFaAaq7G3MTy+zrrqtZVYiOorCH1xcH1vPYtTo3uLgrMxAiTCFKQUBP3A+RsWW3ppqzfrfaDbqkNPaxbiXfEsSlkUeJkr/mCpr7T7ktqeWhZH+T4gZ5OWmEaqOzX4hqWnPubKPEU9u/IuQAU0yh3zjVHfUx8eoXnwOf29ZvPs8QJgfNQVxH3uGe6hY7CDJQuWhJyPcBIRASIiGSKyU0Sqre8pik4RuU5E9k/4DIrIXda5J0Xk5IRzF4W/FPawJHUJ9b31QV1b11Nn3wO3ZjOICw48Y096sxDwWpDOWqh/B9Z8CgCf8tHQ0xBzLxnoMjd45z4C6R/p5/TA6Zgrc1J8EtlJ2dT11OmA7FK9qDCA58vT72HYN+x8mZWCg8/C4sv1KDxEsudn43a5g5rrqu/RbUCs3edIjUAeAnYppZYDu6zfk1BKvaaUukgpdRGwCegHJm7k/Y/+80qp/WHJtQMUpxXT7G1mcHRwTtcNjg7i6fPY1zNNzdNO5A4+B74Q3K0HQGFqYWBC88CzgMDazwDQ2t/K4NggS1Jj6yUDa81PEF4H/A1wrKk2AErSSqjtqT0TcOG92lij9cis1/nL7Hhjemq/duNjPV+h4hIXBakFQakqw1Zmm4mUALkTeMo6fgq46xzxNwPblVKhbZ4RhRQvKEah5vzQNfQ2oFD2DvMvvAe66x138V68oJjuoW46B2dxPKcUHPgNlFytTY0500uLNXUOaAHQ6G1k1Dc6p+vqemOzYQF9n2u7a88slF29GVzx+r7OQtga04PPaZfzq87V/ASOv8xzpb6nHkFiYo+biURKgOQqpfwbYXiAcxk+3wOc/dR9V0QOisi/iUjiTBeKyBdFZJ+I7Dt9+nQIWXaG4rRigMk9tQBw5CUrvw0SkuGgs2qskrQSAE52n5w5UsNu7cn1wnvHg/x1FIuNaUlaCaO+0Tnrx/1C02/JFUsUpxXTM9xzxkNtSjYsu9Ea5c68kLSup25cBeYYY6Nw6HfaoWiSfabCJWkl1PXWzbmjUNtTy6LkRSTGzdiURSWOCRAReUVEKqb5TDJ3ULp7MqMvDxFZBKwBXpoQ/E2gHLgYyAAenOl6pdTPlFIblVIbs7MdfCCDxD+CmGuvxZHG1J2sTXorX4CRuanU5oJfgJzoPjFzpAO/0Rv7+FfKoxtTt8sdE27czyagMk9DXU8dOUk5MWXC62faZ/uie6H3FJx4bcbr/HN7jprwHn8V+lptU1/5WZq2lFHf6JxN82PRUAIcFCBKqRuUUqun+bwAtFiCwS8gWmdJ6tPAH5VS46tzlFKnlGYI+CVwiVPlcJr5CfPJmZ8z5xFIfU89WUlZ9u8PceG9eqdCBz305qfkkxiXOPMIZLgfKv4IK+6AxNTx4LreOhYvWBy+/SFsJKBR1zTU99SzJC32Rlwww+i69GaYtxD2z6zGstU4ZCbefxKSs2H5TbYmO95R6Aq8o6CUoq43DGV2gEi9iVuBLdbxFmA22757OUt9NUH4CHr+pMKBPIaNkgUlcx6BOPaSFV8NGRfAvl/Yn7aFS1wULyieuTGt/IMWYus+Oym4trs2JieTQa/5yUnKmdMIRClFbU9tTDYsoF3Zu13uyc92fCKs/bTuoPS1TblmZGyEJm+Ts/e5pxmO7dDPV7zb1qTHOwo9gXcUOgY76B3ujcn7HCkB8jBwo4hUAzdYvxGRjSLyc38kESkGioA3zrr+aRE5BBwCsoD/FYY8O0ZxWjEne04G7JVXKcWJ7hPO2Mm7XLDxfj2R3nLY/vQtStJKZhYge5+ArDIovmo8aGhsiIbeBpalL3MsT05Tkja3jkL7YDtdQ10sWxibZY5zxbF4weKpjenGB2BsGD781ZRr6nrq8CnfeEPsCB/8CtQYrP+c7UmnulPJTsqe0wjkeJf2hB2L9zkiAkQp1a6Uul4ptdxSdXVY4fuUUl+YEK9WKVWglPKddf0mpdQaSyX2WaWUN9xlsJPiBcX0Dvdqv0EB0DbQRtdQF8vTlzuToQv/Uu+X7uAopCSthCZv01Tz5eYPtWO7jX8NE3Tgtd21jKkxli90qMxhoCSthBPdJwLuKFR36kWdsdiw+JnWKimnHJZcpZ+vsybTq7t0mUvTS53JkG8MPvhPbbIeouuSmShJK5nTCMRf5li8z7GnTD4PWbpQP8j+nsi58D9wjjWmyZnatPHAMzDkjGwuSStBoc4sNPOz9wk9eX7hPZOCY/kl81OSVoJ3xEvbwFTVzXT4n4cLFl7gZLYcpSSthIbeBobGhiafuPgB7Uak5pVJwdWd1cRJnHMjkOqX9b7nG+93Jn3OjK4D7SjUdNWQlphGVlKWY3lyCiNAooCy9DIAjnYcDSj+eM/USXXOxgdguNcxk96laVpoTpoT6O+Ait/D6rshaeGk+Me7jhPvio9JPbGf8Y5Cd2AdhZquGtIT04Pb7z5KKMsoY0yNTe0cld8OKbmw9+eTgmu6aliyYAnuOHvnJsZ593FYUABltzqTPlqA9A73BtxRqOmsYdnCZeFxHGkzRoBEAZlJmWQlZVHVWRVQ/JquGjLnZZIxL8O5TBVdAgUb4J3HZrXZD5aStBLiJX6y0Nz7BIz0w2VfnhK/prOG4gXFJMTFjqvrs/GPGKs6ArvP1V3VLEuPzYbFj79zNKXM8W7YcL8eEZw+c666s9o51Wzzfqh9Cy79Ejj4HPnVb4F0CJVS1HTVxOzI2giQKKEsvYxjnccCiuvoS+ZHBK78ql7Md+RPtifvjnNzwcILzrxkIwOw+yd6oVnuqinxq7uqY/Yl85OZlEnO/JyAG5bjXce5IC121VegF0AmxSdN3zm65L9BfBK8/WNA+/1q9DY6d5/ffQzcqbBhy7njhkB5hnb8Gch9bulvwTvijdln2wiQKKE0o5TjXcfPuRnNmG+ME90nwvPAld+uJxrf/rF2LWJ38hnlHO04qnVLWb4YAAAQ6ElEQVTF+/8L+tvgqr+bEs877KXJ2xSzL9lEVmSsCKhhafQ20jfS53xHwWHiXHEsT18+/agrOUtbQh18Frobx9VcjpS5q0F7dt6wBeal2Z/+BFLdqRSmFHKkY3afX8B4pzFW77MRIFFCWXoZI76Rc64TqO2pZWB0YLyX4yiuOLjib7VV1MmzLalDZ0XmCjoGO2j1NsM7j2qV2ZIrp8Q73K7NiVdlTR2ZxBrlGeWc6D7BwOjArPEq2yuB86PMZellVHVWTT+pfMVX9Pc7j43fZ0ee7bd+qL1NX/ol+9OehhWZgXUUKtoqEIQVGSvCkCv7MQIkSvDris+lxjrUdgiANdlrHM8ToE16U/Nh13dsH4X4G4qqfT/Rrtuv+cdJprt+Ktr1OtFVmbHfmK7IWIFP+cYNIWaisq2SBFcCpQsdMmcNI2XpZfQO93Kq79TUkwsXw5pPw/tPcujUbjLmZZCfbPM+6J21es3Jhi3jjjmdpjyjnIbeBnqHe2eNV9FWwdK0pTHpqgaMAIkaitOKSYpP4uDpg7PGq2irICUhJXw71CXMg2sfhKZ9ULXN1qT9QvPwkd9D4SXazcU0VLRVUJBSQPq8MOyP7TDlmYHpxyvbKynPKI9powE/KzNXAmc6P1O49kHwjVLR+Dars1bbbzTwxve1F+Cr/8HedGchkHkQpRSV7ZUxPco0AiRKiHfFszZrLQdOH5g13qG2Q6zKXBVef1AXfRYyl8Guf7XVIivFncIF7nT2yzBc/y/Tjj5A98ZXZ6227X8jSX5yPhnzMma9zz7l43D74fGGN9YpzyxnXtw89rfOsG1PejHeDVs4MdbH6qRF9v55y2HtmHPjA7DA5rRnYU2W1hDMdp9P9Z2iY7Ajpp9tI0CiiItyLqKqs4q+kb5pzw+ODnKs41j4H7i4eNj0z3D6KLz/S/vS7fWwvtPDgfnJjC25YtoobQNtNPc1j7+QsY6IsCF3A++3vD9jnONdx+kb6TtvypzgSmBV1qqZBQhQufImlAhrjr9jn6pUKdj+DT1pfk34Rh8A6fPSWZq2lA9aPpgxjl/bEMv32QiQKGJdzjp8yjejGmv/6f2MqlHW5awLc87Qe1qXfAxe+VfobbEnzZf/mfUDA3jxzTj3s+fUHgA25m605z+jgPU562nyNuHp80x7fo9Hl/nivIvDmS1HWZezjqMdR2c0HtjXXY0LYe3Jd+zzBF35R73uY9O3YL6Da6ZmYH3uej5s/ZCxGUbtezx7SE5IDo9BjEMYARJFrM1ei0tcM/ZOd5/aTZzEsSF3Q5hzhlYv3fYjGB2Al74Zeno1r8Ch37JhzX0AfNA6fU9tj2cPqQmpMf2SnY3//s10n/d69lKQUkB+is2TyRFkXc46RtXojCqd3ad2szJzJQty1sC2b8Bgd2h/2NcG2x/U+7Bv+HxoaQXJ+pz1eEe84254zmavZy/rc9YT74oPc87swwiQKCLVncrarLW81fTWtOd3n9rN6qzVpLhTwpwzi6xlcM03tLuRA88Gn05fOzz/N5BdzqLrvkVhSiHvNL8zbdQ9nj1syNtAnCsu+P+LMkrTS0l1p/Ju89Stg8d8Y+xr2XdejT5AjyATXAm81Tj12e4f6efQ6UNcuugyuONRvdHTi18LXpWlFPzpqzDYBXf9uzZHjwD+ezjdfW7tb6W2p5ZL8mJ2KyPACJCo42NFH+Nw+2FO90/efrdtoI3K9kouz788QjmzuOrvYfEV8OLfQ9vspqjT4huD578MA51w988hIYlri67lveb36B+ZvOX98a7jNPQ2cGX+1LUhsUycK46rC67mzcY3p6g3Pmj9gO6hbq4quGqGq2OT+QnzuSTvEt5sfHPKuXea32FUjepnO38dXPc/oOJ3etOnYNjzH3D0Ra26msarQbjIS86jPKOc1xqm7r74esPrAFxZENvPthEgUcbVBVcD8Hrj65PCd9Xtwqd8fHzJxyOQqwnExeuGPz4Rnv4UeOe4z/zL34Lql+Dm70Genjy8rug6hn3DU3pqO+t2IgjXL77ertxHDZsWb6JzqJMPWz+cFL6rfheJcYnjz8H5xDWF11DbUztlsezLtS+Tnph+RjV71dfhguv1BPiJ1+f2J8dfhR0PQektcPlX7Ml4CGwq2sT+1v20D7RPCt9Zt5PiBcUx713BCJAoozS9lKVpS3m++vlJ4dtObqMkrSQ6Hri0AvjL56DXA0/fHZgQUQpe/S689zhc8t/h4vFtX1iXu47MeZk8X3OmzD7l488n/sy6nHVkz4++vexD5aqCq0iKT2Lr8TMTxiNjI+w4uYMr86+M2YVls3HjkhuJk7hJz7Z32Mvrja9z/ZLrz8wFuFyw+QltOv7MX0H9e4H9wck3dfzscrj7P3Q6EebGJTeiUPzp+Bl/cp4+D3s9e7lhyQ0x7SgTIiRARORTIlIpIj4RmdG8RkRuFpEqEakRkYcmhJeIyG4r/FkRccj3c/gRETaXbuZg20Eq2vQK7Mq2Sj5o/YC7l98dPQ9c0cXwmV/B6WPwxI3gmWVX4eF+2PoVePP7sO4+PfqYQIIrgbtL7+aNxjdo6GkAtFqjtqeWzaWbnSxFxEhOSOb2pbez7eS28Y3EdtTuoH2wnU+VfSrCuXOG7PnZXFt0Lc/XPD+urvx99e8ZGB3g7uV3T46clA73/VG7fH/qDr2H+kxzIkrpTaJ+vRkWLoHPPQ+JqQ6XJjCWpS9jfc56nql6hlHfKADPHH0Gn/JNLXMMEikRXQF8EpiqELUQkTjgceAWYCVwr4j4V1Y9AvybUmoZ0Ak84Gx2w8tdy+4iPTGdh/c8TP9IP4/sfYS0xLToe+CW3whb/gTDffCzj8GOb0L7hH0fhrzaSeK/Xw4fPq1dlfzFo9NOan6m7DPMi5/H9/Z8j76RPn6474fkJ+dzU/FNYSxQePnsys8y5hvjB3t/QNdgF49++Chl6WVckT/9mpjzgc+v+jydQ508vv9xWvpa+NnBn3Fp3qXTr21KzYMvvAKFG+H5L8HTm6H27TOLWX0+Per41V2w9W9hyeXw+T9DSk54C3UO7l99P03eJp6sfJKT3Sf59ZFfc1PxTRSmFkY6ayEjge6a5cifi7wO/INSat805y4Hvq2Uusn67bcdfRg4DeQppUbPjjcbGzduVPv2TfmrqGTbiW08+NaDuF1uhn3DfO/q73H70tsjna3p6WuHnd/SOxiqMUjOhoQk6G7Sv3NX61FHyTWzJvP0kad5eM/DuF1uRtUoj216jKsLz7+5gIk89uFj/PTgT3G73CgUv7z5l1yYfWGks+Uo33n3Ozx37DncLjfxrnh+c9tvxjfbmpaxUdjzU3jjEW3e607Rnny9rXr/mKR0+NhD2j18FFrrKaX4+htfZ2fdTtwuNynuFJ69/VnykvMinbWAEZH3lVJTtEXRLEA2Azf790gXkfuAS4FvA+9Zow9EpAjYrpSadnm2iHwR+CLA4sWLN9TV1U0XLSrZVb+LV+tf5bqi67hhyQ2Rzs656WqAqu3gOQhjw5BWBMuuh6LLAtZHv3jiRd5rfo9bS27lioLztyfuRynFb4/9lkNth/jk8k9GZpFomBn1jfL0kac52X2Se8rvCXyNz3Cffr4a9mgrvuQsPTopvQXc0T1nNDw2zJOVT+Lp83Dfyvuc27LXIcIuQETkFWA6EftPSqkXrDiv47AAmUgsjUAMBoMhWphJgDi2BFIpFWqXuQmY6Hu50AprBxaKSLxSanRCuMFgMBjCSOTt3GZmL7DcsrhyA/cAW5UeMr0G+M1ztgAvRCiPBoPB8JElUma8nxCRRuBy4M8i8pIVni8i2wCs0cVXgJeAI8BzSqlKK4kHga+JSA2QCTwR7jIYDAbDR52ITqKHGzMHYjAYDHNnpjmQaFZhGQwGgyGKMQLEYDAYDEFhBIjBYDAYgsIIEIPBYDAExUdqEl1ETgPBLkXPAtpszM75iqmnwDF1FRimngLDyXpaopSa4hb7IyVAQkFE9k1nhWCYjKmnwDF1FRimngIjEvVkVFgGg8FgCAojQAwGg8EQFEaABM7PIp2BGMHUU+CYugoMU0+BEfZ6MnMgBoPBYAgKMwIxGAwGQ1AYAWIwGAyGoDACJABE5GYRqRKRGhF5KNL5CTci8gsRaRWRiglhGSKyU0Sqre90K1xE5FGrrg6KyPoJ12yx4leLyJZIlMVJRKRIRF4TkcMiUikiX7XCTV1NQETmicgeETlg1dP/tMJLRGS3VR/PWts4ICKJ1u8a63zxhLS+aYVXicg5t7WORUQkTkQ+FJEXrd/RU09KKfOZ5QPEAceBpYAbOACsjHS+wlwH1wDrgYoJYd8HHrKOHwIesY5vBbYDAlwG7LbCM4AT1ne6dZwe6bLZXE+LgPXWcSpwDFhp6mpKPQmQYh0nALut8j8H3GOF/wT4snX8N8BPrON7gGet45XW+5gIlFjvaVyky+dAfX0N+C/gRet31NSTGYGcm0uAGqXUCaXUMPAMcGeE8xRWlFJvAh1nBd8JPGUdPwXcNSH8P5XmPfTukYuAm4CdSqkOpVQnsBO42fnchw+l1Cml1AfWcS96H5sCTF1Nwiqv1/qZYH0UsAn4nRV+dj356+93wPUiIlb4M0qpIaXUSaAG/b6eN4hIIXAb8HPrtxBF9WQEyLkpABom/G60wj7q5CqlTlnHHiDXOp6pvj5S9WipD9ahe9emrs7CUsvsB1rRAvI40KX0RnIwuczj9WGd70ZvJHfe1xPwv4FvAD7rdyZRVE9GgBhCRulxsrEHtxCRFOD3wN8ppXomnjN1pVFKjSmlLgIK0b3h8ghnKeoQkduBVqXU+5HOy0wYAXJumoCiCb8LrbCPOi2WugXru9UKn6m+PhL1KCIJaOHxtFLqD1awqasZUEp1Aa+ht7deKCLx1qmJZR6vD+t8GtDO+V9PVwJ3iEgtWnW+CfgxUVRPRoCcm73AcsvywY2enNoa4TxFA1sBv3XQFuCFCeGfsyyMLgO6LfXNS8DHRSTdskL6uBV23mDpm58AjiilfjThlKmrCYhItogstI6TgBvR80WvAZutaGfXk7/+NgOvWiO5rcA9lvVRCbAc2BOeUjiPUuqbSqlCpVQxut15VSn1V0RTPUXawiAWPmhrmWNoPe0/RTo/ESj/b4BTwAhaf/oAWre6C6gGXgEyrLgCPG7V1SFg44R0/ho9gVcD3B/pcjlQT1eh1VMHgf3W51ZTV1PqaS3woVVPFcC/WOFLrYatBvgtkGiFz7N+11jnl05I65+s+qsCbol02Ryss2s5Y4UVNfVkXJkYDAaDISiMCstgMBgMQWEEiMFgMBiCwggQg8FgMASFESAGg8FgCAojQAwGg8EQFEaAGAwOICKZIrLf+nhEpMk69orI/410/gwGOzBmvAaDw4jItwGvUuoHkc6LwWAnZgRiMIQREbl2wr4O3xaRp0TkLRGpE5FPisj3ReSQiOyw3KIgIhtE5A0ReV9EXvK7RTEYIo0RIAZDZLkA7ePoDuDXwGtKqTXAAHCbJUT+D7BZKbUB+AXw3Uhl1mCYSPy5oxgMBgfZrpQaEZFD6M3Ldljhh4BioAxYDezUrraIQ7uVMRgijhEgBkNkGQJQSvlEZESdmZT0od9PASqVUpdHKoMGw0wYFZbBEN1UAdkicjlod/EisirCeTIYACNADIaoRultlDcDj4jIAbSH3ysimyuDQWPMeA0Gg8EQFGYEYjAYDIagMALEYDAYDEFhBIjBYDAYgsIIEIPBYDAEhREgBoPBYAgKI0AMBoPBEBRGgBgMBoMhKP4/Rn2H5wyDs1gAAAAASUVORK5CYII=\n",
             "text/plain": [
@@ -415,8 +448,7 @@
           },
           "metadata": {
             "needs_background": "light"
-          },
-          "output_type": "display_data"
+          }
         }
       ],
       "source": [
@@ -451,34 +483,46 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 22,
       "id": "moral-worship",
       "metadata": {
         "id": "moral-worship",
-        "outputId": "859202c4-b770-4327-f4fb-58ac177c89a7"
+        "outputId": "164d96ee-bbdd-4fb9-c6d0-91e6cefb3ed3",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 334
+        }
       },
       "outputs": [
         {
+          "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "<matplotlib.legend.Legend at 0x7eff6b1b8b38>"
+              "<matplotlib.legend.Legend at 0x7f10ac836d50>"
             ]
           },
-          "execution_count": 11,
           "metadata": {},
-          "output_type": "execute_result"
+          "execution_count": 22
         },
         {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/google/colab/_event_manager.py:28: UserWarning: Data has no positive values, and therefore cannot be log-scaled.\n",
+            "  func(*args, **kwargs)\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZUAAAEGCAYAAACtqQjWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3de3xdZZno8d+T+/1+a5O2aWlJs1sQSy0DIsJwK4hcPQOoHDzwsaLi0WF0ZERndJwz4O0oCsrxwqB8HJBRVHAKLaiAXHsDhKZNk7aBJrRJm3vS3POeP961k500adJk7bX25fl+PvuTvVfWXuvJzt77We/7vOtdYoxBKaWUckOC3wEopZSKHZpUlFJKuUaTilJKKddoUlFKKeUaTSpKKaVck+R3AOFQVFRkKisr/Q5DKaWiyvbt248YY4rns42YTCqVlZVs27bN7zCUUiqqiMhb892Gdn8ppZRyjSYVpZRSrtGkopRSyjUxWVNRSik/DA0N0djYSH9/v9+hHFdaWhoVFRUkJye7vm1NKkop5ZLGxkays7OprKxERPwOZ0rGGFpbW2lsbGTp0qWub1+7v5RSyiX9/f0UFhZGbEIBEBEKCwvD1prSpKKUUi6K5IQSFM4YNako5ZH23kE2vnHQ7zCg9glon/fpCL574/AbvH74db/DUJNoUlHKIxse3ManfrmDlm4fi7hDffDwR+D57/oXg0v+9eV/5asvftXvMCLSk08+SVVVFcuXL+euu+7ydN+aVJTySGN7HwDDIz5eGO/IHjAj0FLjXwwuGBgZoL69nn2d+zg6dNTvcCLKyMgIn/70p3niiSeoqanhoYceoqbGu/+3JhWl4knLrvGfUXzV1z1texg2w4yaUfa07/E7nIiyZcsWli9fzrJly0hJSeG6667j97//vWf71yHFSsWTYAtloAu6miC3wt945qimdfzIe2frTk4rOc3HaKb2tcd3UvNOl6vbDCzM4V8+uOq46zQ1NbFo0aKxxxUVFbzyyiuuxnE82lJRKp4010BC0vj9KFXTVkNuai6FaYUTEozyn7ZUlIonLbtg2XlQ/5RttZx8kd8RzUlNaw2BggBJCUkRm1RmalGES3l5OQcOHBh73NjYSHl5uWf715aKUvGivxO6GmHJWZC9YLy+EmWCRfpAYYBAYYB9nfvoG+7zO6yI8Z73vIe6ujr279/P4OAgDz/8MJdffrln+9eWilLxomW3/Vm6CkoCUTsCrK69jmEzTKDQtlRGzSi1bbURWVfxQ1JSEvfccw8XX3wxIyMj3HTTTaxa5V2rSZOKUvGiZaf9WVJtb1ueh5FhSIyur4Fgd1cwqQSXaVIZd+mll3LppZf6sm/t/lIqXrTsgpQsyF1kWyojA9C+3++oTlhNaw05KTmUZ5VTmlFKQVpBxNZV4pEmFaXiRcsu20IRsT8hKrvAalprCBQGEBFEhEBhgJq26Ps7YpUmFaXigTHQvNO2UACKVwISdcX6wZFB6jrqCBQGxpYFCgPs69hH/3BkX8MkXmhSUSoe9LRAX9t4UknJgIKlUddSqWuvY3h0+JikMmJGqG2v9TEyFaRJRal4EEwewW4vsAkmyk6A3NlqBxuEJpVVhXZkk9ZVIoMmFaXiQbCbq2T8y5iSamjbC0PR020ULNJXZI1PL6PF+siiSUWpeNBSA5nFkFU8vqwkAGbUzlwcJWpaa6gurJ5wkSkRobqwWpOK48CBA5x33nkEAgFWrVrF3Xff7en+NakoFQ9aaiZ2fcF4qyVKivVTFemDAgUB9nbs1WI99uTH73znO9TU1PDyyy9z77336tT3oUQkQUT+j4j8QERu9DsepaLO6Kg9m75k0pdx4UmQkDx+UmSEq+s4tkgftKpwFSNmRKfBBxYsWMCaNWsAyM7Oprq6mqamJs/278uptCJyP3AZ0GKMWR2yfD1wN5AI/NQYcxdwBVABtAKNPoSrVHTrfBuGeo9tqSQmQ9HJUdNSCXZvrSo4dsqRYKKpaa3h1OJTPY1rWk/cDofecHebZafAJbO/kmNDQwOvvvoqZ5xxhrtxHIdfLZUHgPWhC0QkEbgXuAQIANeLSACoAl40xtwGfNLjOJWKfmNF+inmfyoNRFVSyU7JpiL72GvAlGWWkZ+ar3WVED09PVxzzTV873vfIycnx7P9+tJSMcY8JyKVkxavA+qNMfsARORhbCvlADDorDMy3TZFZAOwAWDx4sUuR6xUFGt2ureKq479XUk1vPFf0N8Fad598czFziM7CRQEJhTpg8bOrI+kpHICLQq3DQ0Ncc011/CRj3yEq6++2tN9R1JNpRybQIIanWWPAheLyA+A56Z7sjHmx8aYtcaYtcXFxdOtplT8adkFuYunThpRUqw/XpE+KFBoi/UDIwMeRhZ5jDHcfPPNVFdXc9ttt3m+/0hKKlMyxhw1xtxsjPmMMeZev+NRar48vzJ8cM6vqUTJHGBjRfqi4yeVYTPMnrb4Lta/8MILPPjgg/zpT3/itNNO47TTTmPjxo2e7T+S5rxuAhaFPK5wliml5mpkyJ6HMt0VHnMX25mLI7ylcrwifVBosf6U4lM8iSsSnX322Rjj+aHLmEhqqWwFVojIUhFJAa4DHvM5JqVcd2xFIIxa62F06NjhxEEJCXZyyQhvqRyvSB+0IHMBeal5OmOxz3xJKiLyEPASUCUijSJyszFmGLgV2ATsAh4xxkTHAHqlItVUc35NVlJt1/Px6HYmwWvST1WkD4rIYn0c8iWpGGOuN8YsMMYkG2MqjDE/c5ZvNMacbIw5yRjzf/yITalw8/Sru2UXSKI9H2U6JQE42gq9h72L6wQMjQxR1378In1QoDBAfXt93Bfr/RRJ3V9KKbe17ILC5ZCUOv06pcERYJF5hF/XUcfQ6NCsk8qwGaauvc6DyNRUNKko5TFPayrNO4/f9QURP6w49Jr0Mwkt1it/aFJRKlYN9kJ7w/RF+qDMYsgoHD9JMsLUtNaQnZzNouxFM667MHMhuam5mlR8FElDipWKC57VVA7X2r3N1FIRsYknglsqk6e7n46IECjQYn1lZSXZ2dkkJiaSlJTEtm3bPNu3tlSUilXBGknp9Od2jCkJwOHddkbjCDI0MsSe9j2z6voKChQGqOuoY3BkcOaVY9if//xnXnvtNU8TCmhSUcpzntVUWnZBUhrkV868bkk1DPZA54GZ1/VQfUf9rIv0QYHCAMOjWqz3i3Z/KRWrWmrsJJIJiTOvWxIyAix/SXjjOgEnUqQPCq67s3Unq4pm0UoLk29s+Qa723a7us2VBSv54rovzrieiHDRRRchInziE59gw4YNrsZxPJpUlIpVLbtg2XmzW7dkpfOcGqi6JHwxnaCa1hqykrNmVaQPKs8qJyclJ67rKs8//zzl5eW0tLRw4YUXsnLlSs455xxP9q1JRalYdLQNug/OXKQPSsuF3EURV6wPFukTZPY99ZFyZv1sWhThUl5eDkBJSQlXXXUVW7Zs8SypaE1FqVg0dmGu2Xcb2elaIiepDI06RfqCE/gbHPFcrO/t7aW7u3vs/ubNm1m9evUMz3KPtlSUikWzmfNrspJq2PtnO7NxYnJ44joBezv2Mjg6eEL1lKCxYn1HHasK/aur+KG5uZmrrroKgOHhYT784Q+zfv36GZ7lHk0qSsWill22Sytn4eyfUxKwMxq37h2vsfhoLkX6oNAz6+MtqSxbtozXX3/dt/1r95dSsailxiaJWZwwOKYksuYAq2mtITM5k8U5J3558Iqsirgv1vtFk4pSscYYJ6mcQNcX2JmMJSFi6io1rTVUF5xYkT5IRKgurNak4gNNKkp5LOzTtHQfhP7OEyvSAySnQcFJEdFSGRodoratdl5dV4HCAHXtdQyNDLkY2cz8vOribIUzRk0qSsWasSL9idcixi7Y5bP5FOmDAoUBhkaHqOvw7sz6tLQ0WltbIzqxGGNobW0lLS0tLNvXQr1SHgv7NC3Ncxj5FVS6CnY9DoNHISXD3bhOwHyK9EHB69nXtNbMazsnoqKigsbGRg4fjswLngWlpaVRUTH9pZnnQ5OKUrGmZRdklUFGwYk/t6QaMHCkFha+2/XQZms+RfqgiuwKslOyPa2rJCcns3TpUs/2F4m0+0spj4W9Y2QuRfqgYJdZs79dYPMp0gfpNPj+0KSiVCwZHbHXUZnNdPdTyV8Kiam+1lWCRXo3uqwChQH2tO/xvFgfzzSpKOWxsNZU2htguG/uLZXEJDuzsY/Divd17Jt3kT4oWKyv76h3ITI1G5pUlIolc5meZTKfrwLpRpE+SK9Z772oSCoikiki20TkMr9jUWq+wlpTadkFCBTPY5qVkmrofgf62l0L60TsbN1JZnImS3Lmf12XRdmLyE72tlgf73xJKiJyv4i0iMibk5avF5FaEakXkdtDfvVF4BFvo1QqCrXU2Cs9pmTOfRtj07X401rZ1bqLlQUr51WkD9Iz673nV0vlAWDCtJkikgjcC1wCBIDrRSQgIhcCNUCL10EqFQ5hrak018ztpMdQpf7NATY8OkxtuztF+qCxYv2oFuu94EtSMcY8B7RNWrwOqDfG7DPGDAIPA1cA5wJ/A3wY+LjI1IcvIrLB6SLbFuknHikVFsMD0Fo/v3oKQE45pOb40lLZ27GXgZEB15PK4Oggezv2urZNNb1IqqmUAwdCHjcC5caYO4wxnwP+E/iJMWZ0qicbY35sjFlrjFlbXFzsQbhKzU3YaipH6sCMzD+piPh2wS43i/RBWqz3ViQlleMyxjxgjPmD33EoFbGCSWCu56iEKqmG5p12xmMP1bTWkJGUQWVOpWvbXJS9iKzkLE0qHomkpNIELAp5XOEsUyqmhK2m0rITEpLtTMPzVbIK+jug+9D8t3UCatpqXCvSByVIghbrPRRJSWUrsEJElopICnAd8JjPMSnlurAd+7fsgqIVkJQy/20Fu9A8LNYPjw6zp21PWCZ/DBQEqG2r1WK9B/waUvwQ8BJQJSKNInKzMWYYuBXYBOwCHjHG7PQjPqWi0nzm/JpsLKl4V1fZ17mP/pH+8CQVp1i/r2Of69tWE/kyS7Ex5vpplm8ENnocjlLRb6AbOt6GNTe6s73MIsgs8bSlEuyeCsc15UOL9VUFVa5vX42LpO4vpdRctey2P+d7jkqo0oDnSSU9Kd2VM+knW5yzmMzkTHa2audHuGlSUcpjYbkqoBtzfk1WErDJanTKUfyuC053n5iQ6Pq2EySB6oJqdrX6N6dZvNCkolQsaNkFyZmQ5+JRfkm1nfG4o8G9bU5jeHTYtenupxMoDFDbXsvw6HDY9qE0qSgVG1pqoGQlJLj4kfbwgl3hLNIHBQoDDIwM6Jn1YaZJRalY4ObIr6DgTMcejAALZ5E+SM+s94YmFaU85npJpecw9B52t0gPkJplu9M8KNaHs0gftCRnCZnJmZpUwkyTilLR7rDTknC7pQKeXbArnEX6oARJYGXBSmraNKmEkyYVpaJd8Eu/JAxdRyXV0FoHw4Pub9vhRZE+KFAYYE/bHi3Wh5EmFaWiXfNOSC+ArBL3t126CkaHbWIJk/2d+8NepA8KFAboH+lnX6eeWR8umlSUinYtu2w3lYRhqkoPpmsJx3T309FiffhpUlEqmhnjJJUw1FMACldAQlJYi/XBIr2b091PpzKnkoykDE0qYaRJRalo1tkIg93jlwB2W1IKFC4P67kqNa12uvtwFumDxor1mlTCRpOKUtFsbHqWMHYdlYRvDrCR0RHXr0k/k0ChnQZfi/XhoUlFKY+5ep5K8Ms+eKJiOJQEoOMtGOhxfdP7O/fTN9zneVLpH+lnf+d+z/YZTzSpKBXNWnZBTgWk54VvH8F6zeFa1zcdPGckUOBdUgmeta9dYOGhSUWpaNYchulZJhsbAeb+tPHBIv3S3KWub3s6S3KWkJ6UrkklTDSpKOUx49YFhUeG4Uht+JNK/lJISg/LsOKa1hqq8qs8KdIHJSYkUl2g16wPF00qSnnE9bNI2vbByGB4i/RgZz4uWel6sX5kdITdbbs9racEBafBHxkd8XzfsU6TilIecf3SXMEv+XANJw4VhjnAGroaPC/SBwUKA/QN92mxPgw0qSgVrVpqQBKg6OTw76skAD3N0Nvq2ia9PJN+srEz63VySddpUlHKY64NKW6pgYJlkJzu0gaPY6xY796XsB9F+qDKnEot1oeJJhWlPOJ6TSWc07NMFqzbuNgFFizSJyUkubbN2UpMSNQz68Mk4pOKiFwpIj8RkV+JyEV+x6PUXLlaUxnqs4X6cEx3P5XsMkjLc62lMjI6wq62Xb50fQUFCgPsbtutxXqX+ZJUROR+EWkRkTcnLV8vIrUiUi8itwMYY35njPk4cAtwrR/xKhVxDteCGfWupSJip8F3Kan4WaQPChbrG7oafIshFvnVUnkAWB+6QEQSgXuBS4AAcL2IhL7jvuz8Xqmo5kqLZezCXB5+KZdU2/26UBR6+eDLgD9F+qDgWfzbm7f7FkMs8iWpGGOeA9omLV4H1Btj9hljBoGHgSvE+gbwhDFmh9exKhWRWmogMdUW6r1SUg0DXdDVNOdNHOw5yOef/Tx3bbmL5XnLfSnSBy3NXcri7MX828v/xtde+hpt/ZO/ktRcRFJNpRw4EPK40Vn2GeAC4EMicst0TxaRDSKyTUS2HT58OLyRKuW3ll1QfDIkeljknkexvn+4nx+99iMu/93lPHPgGT71rk/xnx/4T1+K9EGJCYk8dNlD3BC4gd/V/Y7LHr2MB2seZGh0yLeYYkEkJZUpGWO+b4w53RhzizHmvuOs92NjzFpjzNri4mIvQ1TKey013nZ9wZyGFRtj2Nywmct/dzk/fP2HvH/R+3n8ysf55GmfJD3Jg6HQM8hJyeEL7/kCv7niN5xacirf3PpNrnnsGl5oesHv0KLWjElFRBJFZLcHsTQBi0IeVzjLlIopZr41ib4O2wXlVZE+KD0fshfO+oJde9r3cPPmm/mHZ/+B7JRs7r/4fr79/m+zIGtBmAM9cctyl/Gj83/Eveffy6gZ5Zanb+Ezf/wMb3W95XdoUWfGtqcxZsQZkbXYGPN2GGPZCqwQkaXYZHId8OEw7k+p6HTYOcbzuqUCTrH++Emlc6CTe169h0f2PEJ2SjZfPuPLXHPyNb52dc2GiHBOxTmcueBMfrnrl9z31/u48vdXckPgBjacsoGslCy/Q4wKs/0v5wM7RWQL0BtcaIy5fC47FZGHgHOBIhFpBP7FGPMzEbkV2AQkAvcbY9yfa1upaOfF1R6nU1INW56H0RGYNLPw8Ogwv97za+557R56Bnu4tupaPn3ap8lNzfU+znlITkzmY6s/xmUnXcbdO+7mP978Dx7f+zifXfNZLj/pchIk4qsGvpptUvmKmzs1xlw/zfKNwEY396VUpJn3gNzmGkjJhtwKN8I5MaWrYGQA2vZD0fKxxVsPbeXOLXdS117HGWVn8MV1X2RF/grv43NRUXoRX3/v17m26lru2nIXX3nhK/xq96+4/YzbeVfxu/wOL2LNKuUaY54FGoBk5/5WQIf3KnUCXJumJTg9i7g+8cvMJl2w652ed7jtmdu4adNNHB06ynfP/S4/uegnUZ9QQq0uWs2DlzzIv5/977QcbeGjGz/Kl/7yJVqOtvgdWkSaVUtFRD4ObAAKgJOwQ33vA84PX2hKxRZXTno0xnZ/VX/Qja2duKIqQOg79Ab/MdjE/W/ejyB8+rRP87FVHyMtKc2fuMJMRPjgSR/k/MXn89M3fsoDOx/g6befZsOpG7ghcAOpial+hxgxZtv99WnsyYmvABhj6kSkJGxRKaWm1tMCfW22G8oH9b3v8OSCxfyu8VGaDwxxSeUl3Lb2Nsoyy3yJx2sZyRn87zX/m6tWXMW3t36bu3fcza/3/JqrV1zN+sr1LM5Z7HeIvpttUhkwxgyK09wWkSTCcM0hpeLBvEYUB68T7+Fw4obOBp5seJJNDZuo76gnIQ3eMzTCNy57gNNLT/csjkiyKHsRd//t3bz0zkvc9/p9/ODVH/CDV39AdUE165eu5+LKiynPKvc7TF/MNqk8KyJfAtJF5ELgU8Dj4QtLqdjjSgXEozm/Grsb2dSwiScbnmR3mx3CvKZkDV8640tceKCGohfvhQJ/WkuR5MyFZ3LmwjM51HuITQ2b2NSwie9u/y7f3f5dTi06lYsrL+aiyovipiUHs08qtwM3A28An8CO0PppuIJSKhbNu2k/1A/7noHMYsgsciGiiUK/GN848gYApxadyhfWfmHiF+Pwo2BGbCxV66ffYBwpyyzjxlU3cuOqG8cS8qaGTXxr27f41rZvsaZkzViCKUp3/38XSWQ2Z/eKyPnAi8aYvvCHNH9r164127Zt8zsMpSY4884/crCzn6dvez/LS07gRDpjYPcfYNMd0PEWvPezcOG/uhLTkb4jbG7YzJMNT/Jqy6sAM3fh9ByG//c+6D4I7/owXPAv9nor6hgNnQ1jLb76jnoSJIG1pWu5uPJiLlhyAQVpBX6HOIGIbDfGrJ3XNmaZVH4OnImdWfgvwHPA88aY9vnsPFw0qahINJ5UzmF5SfbsntSyG578om0VFFfDJXfBsnPnFUdbfxtPv/U0mxo2sa15G6NmlOV5y1lfuZ71S9ezJGfJzBsZ6IbnvgUv/RCSUuGcL8DffNLeV1Oqb68fq001dDWQKImsK1vH+qXrOX/x+RFxkqhnSSVkhwuBDwGfBxYaYyJy3gVNKioSnXXnH3lntkmlrx2euQu2/ARSs+C8O2DtzXOalbi5t5kdLTvY3ryd7c3bqe+oB+x12tcvXc/6yvWclHfSXP4kaN1rW1B7nrDT8F/873Dyen/OoYkSxhhq22t5cv+TPNnwJE09TQhCVUEVp5eezpqSNawpXeNLN5mXLZWPAu8DTgGOAM8DfzHGvDSfnYeLJhUViWbVUhkdgR0/hz9+Hfo74PSPwXlfhszCWe3DGENjdyPbmrexvXk7O1p2cKDbXlEiIymDd5e8mzWlazin4hyq8qsQt77865+GJ/8JjuyBk86H9XfZqfnVcRlj2Nm6k+can2NH8w5eP/w6/SP9gE36p5eePnZbmLUw7PG4kVRme9jzPWAv9oTHPxtjGuazU6XUFBpesF1dh96AJe+1X8wLTj3uU0bNKHs79rKjebwl0tJnz/TOTc3l9JLTubbqWtaWrqWqoCp8kzouvwA++X7bsnrmLvjRmbDuE/D+f4T0vPDsMwaICKuLVrO6aDUAQyND7GzdOday3Nywmd/U/QaABZkLJiSZypxK9w4KXDTr7i8RWQWcA5wNrABqjTE3hDG2OdOWiopEwZbKU39/DitKQ1oqHQfgqa/Azt9CTgVc9HVYddWUXUjDo8PUttVOaIl0DnQCUJJeMuFLZ1neMn8mP+w5DH/6Ouz4BWQUwvlfgXffcMwElGpmI6Mj1HXUjR0wbG/ePnaFyoK0ggn/7xV5K0ic52vsWUtFRHKAxcASoBLIBUbns2Ol4s0xKWKoD174Pjz/XcDA+2+3I7tSMgDoGexhT/sedrftpra9lt1tu6lvr2dwdBCwJ+Cdt+i8sS+ViqyKyDhyzSqGy78Pa2+CJ74Ij38Wtv4MLvkmLDnT7+iiSmJCIisLVrKyYCUfqf4IxhgauhomtEyfeuspANIS0zg5/2SqCqpYWbCSqoIqVuStICM5w9OYZ1tT+Su2jvI88JwxpjHcgc2HtlRUJBprqXzufaxo/RNs/gp0vo2pvoLmcz5H7XD3hAQSrIUA5KXmjX25BAoDnF56OiUZUTBTkjHw5m/gqX+2FxZb/SE7HDo3Ps82D4eDPQfZ1ryNmtaasfdO92A3AIKwJGfJWJKpyrcJpyi9aMoDED9Gf2UBGGN65rPTcNOkoiLRmXf+kZyuXXx72W9p6KihNn8hu4uXUtvXTMdAx9h6i7MXjx1trixYSVV+FSUZJZHRCpmrwV54/nvwwt22G+zs2+CsWyHZ/0sKxxpjDAd7D9oDlLbasQOVpp7xC+kWpBWMJZqV+fbnkpwlJCcmezb6azXwIHaWYgEOAzcaY96cz87DRZOK8lv3YDcNnQ00dDWwv62WhqZXqDlcx+GkYQYTbHJISUhhRf6K8Q93wUpOzj+ZzORMn6MPo/a3YPOXYddjkL0AVl8Dq6+GhWt0GHKYdQ12sadtz1hrpratlrqOOoZHhwFITUxl+w3bPUsqLwJ3GGP+7Dw+F/h3Y8xZ89l5uGhSUV4YGR3hnZ532N+1n/2d+2noahhLJEf6joytl2gMFcPDlA0l0D9Qxnln3cj7V7yXytzKiL/Ebtjsfw5evAf2/glGhyC/0g5OWHU1lJ2iCcYjQyND7OvcR217LbVttfzjun/0LKm8box510zLIoUmFeWWkdERDvcdprG7kcaeRt7qessmkM4G3u5+m6HRobF181JzqUzOpbKvl8q2t1naf5TK5FwWVV1O8in/g7Me7OSdrkE2//05nFw6yzPqY11fO+z6A+x8FPY9a+cUK1xhWy+rroaSlX5HGFe8PE9ln4h8BdsFBvBRYN98dqxUJDDG0DHQQVNPE409jTR1N9HUY2+N3Y280/vOWPcAQJIksShnEZU5lZyz6ByWZlVQ2d1KZcMr5O95CgZ7IKMIAlfaL8bFZ44NpTXyR2efvvypkSk9H9bcYG+9R2y32JuPwrPfhGe/YWdjXnW1fS0L53jWv/LUbJPKTcDXgEexk63+xVmmVEQzxtA91M2h3kO80/POWLIITSJHh49OeE5+aj7lWeVUF1ZzwZILKM8qpyKrgvLschZmLSTZYI+qdz4Ku74HA52Qlme7b1ZfA5Xvm3I6Fe3QmUFmkR2GvPYm6G6Gmt/b1/jP/2ZvZaeOt2DyZzE/mfLFcZOKiKQBtwDLsdPe/4MxZuh4z1HKSz2DPRzqPUTz0WYO9R7i0NFD9nFv89j9vuGJk2unJ6WPJYp1Zesozyofu1VkV0xdKB/qhwMvw7P/F2oes1dfTM2BlR+wX3LLzoWklOPGqg2UE5BdCmdssLfORtj5O5tgnv6qvZWfbl/3lR+w9RitwUSMmVoqPweGsC2TS4Bq4HPhDkqpYLdUy9EWjvQdoeVoy8Tk4dzvGZo4ujRpAXcAABabSURBVF0QitKLKMssY3nect678L2UZZZRmlnKwsyFlGeVU5BWMPPw3IFuOPAKvPWivTVth5FBSM601xBZdbWdmiQ5Nq/JHlFyK+zw47NuhfYGO/PAm4/C5jvsLafcdjMuOctOb1NcpUnGRzMllYAx5hQAEfkZsCX8IalYNmpGaetv40jfEQ4fPczhvsMTfh7pO0JLn00kobWMoMK0Qsoyy6jMreSMBWdQlllmk0ZGKWWZZRRnFJOckHzigfW2wtsv2dtbL8DB18GMgiTCwtNg3Qb7hbXs3LEz3ufKaJtl7vIr4ey/t7fWvXb02NsvQcPz8Oav7ToZhSFJ5iwoPWVOszuruZnplR7r6jLGDPtx8pWIZAI/BAaBZ4wxv/Q8CHVco2aUroEu2vrbaO1vtbc+ewsuCyaOtr42hs2xySI3NZfi9GKK04tZl7uOovQiSjJKKEovsssziinNKCUl8fhdTLPW9c54K+StF+Gwc5nexFSoWAvv+wf7hVSxzk497wI9dnZZ4Un2tu7jdvRD+/6J/9Pdf7DrpWTD4jPs/3PxWVC+Rq/7EkYzJZV3iUiXc1+w16jvcu4bY0zOXHYqIvcDlwEtxpjVIcvXA3cDicBPjTF3AVcDvzbGPC4ivwI0qXhgYGSA9v522vvbxxJDW1/bWMIIXdbWP3WiSJAE8lPzKUwvpDi9mBX5KyhOL56YMDLs49TEMH7IR0ehbZ+tibz1om2JtDfY36VkwaIz4JQP2ZZIGL9wtH0SRiL2ei4Fy+DdH7XLQg8c3n4J/uhcLTMxFSre47RkzrQnXupMyq45blIxxoRrWtEHgHuAXwQXiEgicC9wIdAIbBWRx4AK7CABgJEwxRPTRs0o3YPdNkkMtI8li+D9joEO2vrb6OjvGFs2eURUUEpCCoXphRSmFVKaUUp1QfXY44K0gvH76QXkpeZ5P0vu4FFo2QWH/mqnkD/0BjTvhKFe+/v0Avtlsm6D7SIpO1W7RmJVzkJ7sHDKh+zjo21O96ZzYPGX78BzzldK3mL7Xig7ZfyWu0hrM3Pgy6fJGPOciFROWrwOqDfG7AMQkYeBK7AJpgJ4DZj2G0pENgAbABYvXux+0BFicGSQjoEOOgY66BzopHOg85j7oY/bB9rpHOhkxEydj9OT0slLzSM/LZ/81HwqcyvJS82jIK2AvLS8sZZGMGlkJmdGzhxUPYcnJo9Db0Brna2FgO32KDvFHrmWrbZHp0VVkODDdPAh9DwVn2QU2NFiKz9gHw90Q+NWWz8Lvn92/zdjbcq0XJtoSlePJ5rilTOO8ot3kXSIVg4cCHncCJwBfB+4R0Q+ADw+3ZONMT8Gfgz2jPowxjlvxhh6h3rpGuyic6CTrsEuexvoonOwk66BrrHfdQ5OTByTh8eGSklIIS81j9y0XPJS81iau5R3p72b/NR88tPyJySLglT7Mz0pCib0Gx2Btv3HJpCeQ+Pr5C6yH/pVV45/CeQt8T2BhIqQVKyCUrPhpL+1t6DB3mNbujt+DkNOyz0h2SaW0BZN2Wp7EqcCIiupTMkY0wv8L7/jmGxoZIjuoW66B+2ta7CLnsGeCY+DiSJ4P5hAuge7p205gD1rOyc1h5yUHPJS8yjNKOXk/JPJS82zSSM1l9zU3LH7wZ9piWmR04qYi74OaK2HI3W2xXHEubXtg5EBu05Ckv1Qn3Te+Ie6dLU9Co1wEX2ko6yUTDtQoyJkppKpDmr2/gle/8/xdTJLoGgFFC53fq6wP/OWxF33aiT9tU3AopDHFc4y142aUY4OHaVnyCaBsZ+DPfQM9Yw9nipZdA920z3UfdwWA0CiJJKdkk1uai45KTZBVGRVjCWL0OWTl6UnpUd3cjiekWHoeGti4mitt9c27z08vp4kQsFS++FcccH40WHxSh25o7yVkAhFy+1t9dXjy3tanJrdm+MHQLv/AEdbQ56bbAcPTJVwouBAaC4iKalsBVaIyFJsMrkO+PBcNtR8tJmvv/R1uofGE0UwefQM9tA71DvjuQLBpBB6K84otveTJy7PSck55nFMJ4aZjAxB5wE7zXnHW/YoL9gCadtnZ6UNyii0H7KTLx7/sBWdbM9HSJzD+SZRQGsqMSKrBJafb2+hjraNHyiNHTTVwZ5NE9/76QXjSabwJPuez18CeZU24UTp94cvSUVEHgLOBYpEpBH4F2PMz0TkVmATdkjx/caYnXPZfmtfK0+//TRZyVlkpWSRnZzN4uzF9n5KNlnJ9mdmcubY74M/M5MzyU7Jju+kMJPRUehptgkjmDjaG8bvdzWNF8th4tFa1SXjiaNwecwerU1F301xIqMAMtbBonUTl0/XSq/bDK+1TFw3Jct2neUvcX5WhtxfYrvpIpRfo7+un2b5RmDjfLcfKAzw7LXPzncz8SuYNLqa7LxLHW/bpDGWRN4er3EEZS+wb/glZ036MCyx02gkhGt0evTQBkqcS0waP2GT9RN/1981xefMaeXve2Z8oEBQRtHEz1h+pR2sklthh1Kn+ndphUjq/lJeMMZOMd7VCJ1N44mjq8meLNbZBN3vwOQpUtLy7Ju3pNrOfRU8espbYsf46xxYs6bTtKhjpOXYUWRlq4/9XfAzG+wRCE0677xqLxcw+fOamgu55TbB5JSPJ5vQ+2Fq7WhSiSXDA7aF0d1sh9t2H7KJoqvJSSCN9vHI4MTnJaY4b7gKe4ZxTrnzhnTefHmL9YxjF2j3l5oTEcgqtreKKa6fNTriHBAecH42hnzmm+x5OKGDYILS8pwE4ySf3HJXwtWkEg0Gj44nie5DTuII+dl9yP6+r/3Y5yYkQbbzhilfC9ULx99IwcSRWRS1RUGl4l5CIuQtsrfpDPVD98FjDzCD95u2TRy1Ng+aVPwy2GuHJPYegd4WeyTRc3ji/Z5mexvoOvb5CcmQVWqvO1F4kq1lZJc5y8qc+2U2YWg9IyJop5fyTXKaHaJfsHT6dYb64Gvzm4EbNKm4Z2TIDiU82gpHjzjJwkkYockjeD84F9Vkqbm2mZtZDKUBe7ZvdqlNEKHJIj0/os4WV7OnQ4pVREp2Z3YNTSpTMcZea7z3iJMojthk0XtkPGkcbZv4uL9z6m1Jgj0XI7PEthoWrRu/n1Uy8X5GkRa8Y5h2MKp4EPtJZXjQXvr1aJutOUx7v33i8snF7KCEZJsEMgrtbcG7Jj7OKBx/nFlix6xr95NSKk7EZlI5XAvfXW2TxHTdTGBHPaUX2C/+9HxbmwjezyialCQK7LLUbC1qqznRXi8VD2IzqSQmQ+XZTsLIt0kiNHkE7ydnaIJQSikXxWZSKVgGV93ndxRKTaCHLyoe6PAhpTyi3V8qHmhSUUop5RpNKkp5TM9TUbFMk4pSHtGaiooHmlSU8og2UFQ80KSilFLKNZpUlPKYXk9FxTJNKkp5RGsqKh5oUlHKI9o+UfFAk4pSHtMhxSqWaVJRyiPa/aXigSYVpZRSromKCSVF5ErgA0AO8DNjzGafQ1LqhGmvl4oHYW+piMj9ItIiIm9OWr5eRGpFpF5Ebj/eNowxvzPGfBy4Bbg2nPEqFW6aXFQs86Kl8gBwD/CL4AIRSQTuBS4EGoGtIvIYkAjcOen5NxljWpz7X3aep1TU0ZqKigdhTyrGmOdEpHLS4nVAvTFmH4CIPAxcYYy5E7hs8jZERIC7gCeMMTum2o+IbAA2ACxevNi1+JVSSs2eX4X6cuBAyONGZ9l0PgNcAHxIRG6ZagVjzI+NMWuNMWuLi4vdi1Qpl2i3l4oHUVGoN8Z8H/i+33Eo5QajJ6qoGOZXS6UJWBTyuMJZplTM0pqKigd+JZWtwAoRWSoiKcB1wGM+xaKUUsolXgwpfgh4CagSkUYRudkYMwzcCmwCdgGPGGN2hjsWpfyknV4qHngx+uv6aZZvBDaGe/9KRRpNLiqW6TQtSnlEayoqHmhSUcoj2kJR8UCTilIe0xHFKpZpUlHKI9r9peKBJhWllFKu0aSilEe010vFA00qSnlO04uKXZpUlPKI1lRUPNCkopRSyjWaVJTyiHZ6qXigSUUpj+l5KiqWaVJRyiNaU1HxQJOKUkop12hSUcoj2uul4oEmFaU8pslFxTJNKkp5RGsqKh5oUlFKKeUaTSpKeUS7vVQ80KSilMf0PBUVyzSpKOURramoeKBJRSmllGs0qSjlMaP9XyqGaVJRSinlmqhIKiKSKSLbROQyv2NRSik1vbAmFRG5X0RaROTNScvXi0itiNSLyO2z2NQXgUfCE6VSSim3JIV5+w8A9wC/CC4QkUTgXuBCoBHYKiKPAYnAnZOefxPwLqAGSAtzrEp5QisqKpaFNakYY54TkcpJi9cB9caYfQAi8jBwhTHmTuCY7i0RORfIBAJAn4hsNMaMTrHeBmADwOLFi138K5RSSs1WuFsqUykHDoQ8bgTOmG5lY8wdACLyMeDIVAnFWe/HwI8B1q5dqweDSinlAz+SypwYYx7wOwal5kOPdFQ88GP0VxOwKORxhbNMqbigp6moWOZHUtkKrBCRpSKSAlwHPOZDHEp5SqdpUfEg3EOKHwJeAqpEpFFEbjbGDAO3ApuAXcAjxpid4YxDKaWUN8I9+uv6aZZvBDaGc99KRRrt9VLxICrOqFcqlhhNLyqGaVJRyiNaU1HxQJOKUkop12hSUcpr2vulYpgmFaWUUq7RpKKUUso1mlSUUkq5RpOKUh7TkoqKZZpUlFJKuUaTilJKKddoUlFKKeUaTSpKeUynvlexTJOKUkop12hSUUop5RpNKkoppVyjSUUpj+nU9yqWaVJRSinlGk0qSimlXKNJRSmP6ZBiFcvExOA7XES6gVq/45iFIuCI30HMQjTEGQ0xgsbpNo3TXVXGmOz5bCDJrUgiTK0xZq3fQcxERLZpnO6IhhhB43SbxukuEdk2321o95dSSinXaFJRSinlmlhNKj/2O4BZ0jjdEw0xgsbpNo3TXfOOMyYL9UoppfwRqy0VpZRSPtCkopRSyjVRm1RE5H+IyE4RGRWRtZN+908iUi8itSJy8TTPXyoirzjr/UpEUjyI+Vci8ppzaxCR16ZZr0FE3nDWm/cQvznE+VURaQqJ9dJp1lvvvMb1InK7xzF+S0R2i8hfReS3IpI3zXq+vJYzvTYikuq8H+qd92GlV7GFxLBIRP4sIjXOZ+mzU6xzroh0hrwX/tnrOJ04jvt/FOv7zuv5VxFZ40OMVSGv02si0iUin5u0ji+vp4jcLyItIvJmyLICEXlKROqcn/nTPPdGZ506Eblxxp0ZY6LyBlQDVcAzwNqQ5QHgdSAVWArsBRKneP4jwHXO/fuAT3oc/3eAf57mdw1AkY+v7VeBz8+wTqLz2i4DUpzXPOBhjBcBSc79bwDfiJTXcjavDfAp4D7n/nXAr3z4Py8A1jj3s4E9U8R5LvAHr2M70f8jcCnwBCDA3wCv+BxvInAIWBIJrydwDrAGeDNk2TeB2537t0/1GQIKgH3Oz3znfv7x9hW1LRVjzC5jzFRnzV8BPGyMGTDG7AfqgXWhK4iIAH8L/NpZ9HPgynDGO8X+/w54yKt9hsE6oN4Ys88YMwg8jH3tPWGM2WyMGXYevgxUeLXvWZjNa3MF9n0H9n14vvO+8Iwx5qAxZodzvxvYBZR7GYOLrgB+YayXgTwRWeBjPOcDe40xb/kYwxhjzHNA26TFoe/B6b4DLwaeMsa0GWPagaeA9cfbV9QmleMoBw6EPG7k2A9KIdAR8qU01Trh9D6g2RhTN83vDbBZRLaLyAYP4wp1q9ONcP80zeLZvM5euQl7lDoVP17L2bw2Y+s478NO7PvSF07327uBV6b49Zki8rqIPCEiqzwNbNxM/8dIej+CbX1Od9AYCa8nQKkx5qBz/xBQOsU6J/y6RvQ0LSLyNFA2xa/uMMb83ut4ZmOWMV/P8VspZxtjmkSkBHhKRHY7RxqexAn8CPg69oP8dWxX3U1u7n82ZvNaisgdwDDwy2k2E/bXMtqJSBbwG+BzxpiuSb/ege3C6XFqa78DVngdI1H0f3Tqs5cD/zTFryPl9ZzAGGNExJXzSyI6qRhjLpjD05qARSGPK5xloVqxzeMk5yhxqnXmZKaYRSQJuBo4/TjbaHJ+tojIb7HdKa5+gGb72orIT4A/TPGr2bzO8zKL1/JjwGXA+cbpAJ5iG2F/Lacwm9cmuE6j857Ixb4vPSUiydiE8ktjzKOTfx+aZIwxG0XkhyJSZIzxdHLEWfwfw/5+PAGXADuMMc2TfxEpr6ejWUQWGGMOOl2FLVOs04StAwVVYOvY04rF7q/HgOuc0TVLsUcBW0JXcL6A/gx8yFl0I+BVy+cCYLcxpnGqX4pIpohkB+9jC9JvTrVuuEzqi75qmv1vBVaIHUWXgm3uP+ZFfGBHVwH/CFxujDk6zTp+vZazeW0ew77vwL4P/zRdYgwXp4bzM2CXMeb/TrNOWbDWIyLrsN8Znia/Wf4fHwP+pzMK7G+AzpCuHa9N2xMRCa9niND34HTfgZuAi0Qk3+kGv8hZNj2vRyG4dcN+2TUCA0AzsCnkd3dgR9/UApeELN8ILHTuL8Mmm3rgv4BUj+J+ALhl0rKFwMaQuF53bjuxXT1ev7YPAm8Af3XeeAsmx+k8vhQ7Ymiv13E6/7cDwGvO7b7JMfr5Wk712gD/ik2CAGnO+67eeR8u8+H/fDa2i/OvIa/jpcAtwfcocKvz2r2OHRBxlg9xTvl/nBSnAPc6r/cbhIwI9TjWTGySyA1Z5vvriU1yB4Eh53vzZmwN749AHfA0UOCsuxb4achzb3Lep/XA/5ppXzpNi1JKKdfEYveXUkopn2hSUUop5RpNKkoppVyjSUUppZRrNKkopZRyTUSf/KiUl0RkBDscNehKY0yDT+EoFZV0SLFSDhHpMcZkTfM7wX5eRj0OS6moot1fSk1DRCrFXhPlF9gzuBeJyBdEZKsz2ebXQta9Q0T2iMjzIvKQiHzeWf6MONf7EZEiEWlw7ieKvSZMcFufcJaf6zzn12KvF/PLkDOw3yMiLzqTEW4RkWwReU5ETguJ43kReZdnL5JSk2j3l1Lj0mX8wmn7gb/HTvNzozHmZRG5yHm8DnsG92Micg7Qi52K5TTsZ2oHsH2Gfd2MnUrkPSKSCrwgIpud370bWAW8A7wAvFdEtgC/Aq41xmwVkRygDzvNyseAz4nIyUCaMeb1+b4QSs2VJhWlxvUZY0KP+iuBt4y9PgfYeY8uAl51Hmdhk0w28FvjzEEmIrOZA+0i4FQRCc4/l+tsaxDYYpy54ZwkV4mdGv+gMWYrjE9MKCL/BXxFRL6AnU7jgRP9o5VykyYVpY6vN+S+AHcaY/5f6Aoy6ZKxkwwz3s2cNmlbnzHGTJicT0TOxc5nFzTCcT6nxpijIvIU9oJLf8dxZr9WygtaU1Fq9jYBNznXH0FEyp3rezwHXCki6c5suh8MeU4D41/0H5q0rU86U88jIic7M/BOpxZYICLvcdbPdqbMB/gp8H1gq7FX51PKN9pSUWqWjDGbRaQaeMmpnfcAHzXG7BCRX2Fnnm3BTn0f9G3gEbFXK/zvkOU/xXZr7XAK8Yc5ziWtjTGDInIt8AMRScfWUy4Aeowx20WkC/gPl/5UpeZMhxQr5TIR+Sr2y/7bHu1vIfbCSSt1yLPym3Z/KRXFROR/Yq8rf4cmFBUJtKWilFLKNdpSUUop5RpNKkoppVyjSUUppZRrNKkopZRyjSYVpZRSrvn/+UurlXGAKb8AAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEGCAYAAABLgMOSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAUOUlEQVR4nO3df5BdZX3H8c+nWWQpLBGSoGEX2WSCIQnWGBa0FRmoJoRMAwasBnVEkzFgoVOLWrHUX3U6lSodtKAYhaIUAcUfEBskWIIUKoQECJBITIA4bMQkhnbzQ5EkfvvHOUuuO/vj5smee+5x36+Zndw999xzvnn27P3sc865z+OIEAAA++uPyi4AAFBNBAgAIAkBAgBIQoAAAJIQIACAJC1lF3Agxo4dG52dnWWXAQCVsmrVql9FxLgD3U6lA6Szs1MrV64suwwAqBTbPx+O7XAKCwCQhAABACQhQAAASSp9DQQAyrB79251d3frhRdeKLuUQbW2tqqjo0MHHXRQIdsnQABgP3V3d6utrU2dnZ2yXXY5/YoIbdu2Td3d3ZowYUIh+2iaU1i2J9q+1vatZdcCAIN54YUXNGbMmKYND0myrTFjxhTaSyo0QGxfZ3uL7Sf6LJ9te53tDbYvlaSIeDoiFhZZDwAMl2YOj15F11h0D+R6SbNrF9geJelqSWdKmirpPNtTC64DADDMCg2QiLhX0vN9Fp8saUPe43hR0s2Szq53m7YX2V5pe+XWrVuHsVoAqJYf/vCHmjx5siZNmqTPfvazDd9/GddA2iU9W/N9t6R222NsXyPpdbY/NtCLI2JxRHRFRNe4cQf8SXwAqKS9e/fqoosu0h133KG1a9fqpptu0tq1axtaQ9PchRUR2yRdWHYdAFAFK1as0KRJkzRx4kRJ0vz583Xbbbdp6tTGXREoI0A2STqm5vuOfBkAVM6nl6zR2l9sH9ZtTj36cH1y7rRB19m0aZOOOWbfW2lHR4cefPDBYa1jKGWcwnpI0nG2J9h+maT5km4voQ4AwAEotAdi+yZJp0kaa7tb0icj4lrbF0u6U9IoSddFxJoi6wCAogzVUyhKe3u7nn123+Xk7u5utbe3N7SGQgMkIs4bYPlSSUuL3DcA/CE76aSTtH79ej3zzDNqb2/XzTffrG9+85sNraFpLqIDAOrX0tKiq666SmeccYb27t2rBQsWaNq0xvaGCBAAqKg5c+Zozpw5pe2/acbC2h+259pe3NPTU3YpADBiVTJAImJJRCwaPXp02aUAwIhVyQABAJSPAAEAJCFAAABJCBAAQBICBAAq6Nlnn9Xpp5+uqVOnatq0afrCF77Q8Br4HAgAVFBLS4uuuOIKzZgxQzt27NCJJ56omTNnNnQ0XnogAFBB48eP14wZMyRJbW1tmjJlijZtauzA5vRAAOBA3HGp9MvHh3ebr3yNdGb9Mwxu3LhRjzzyiF7/+tcPbx1DqGQPhE+iA0Bm586dOvfcc3XllVfq8MMPb+i+K9kDiYglkpZ0dXW9v+xaAIxw+9FTGG67d+/Wueeeq3e9610655xzGr7/SvZAAGCkiwgtXLhQU6ZM0SWXXFJKDQQIAFTQ/fffrxtuuEF33323pk+frunTp2vp0sZOs1TJU1gAMNKdcsopiohSa6AHAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACScBsvAFRUZ2en2traNGrUKLW0tGjlypUN3X8lA8T2XElzJ02aVHYpAFCq5cuXa+zYsaXsu5KnsCJiSUQsGj16dNmlAMCIVckeCAA0i8tXXK4nn39yWLd5/JHH66Mnf3TI9Wxr1qxZsq0LLrhAixYtGtY6hkKAAEBF3XfffWpvb9eWLVs0c+ZMHX/88Tr11FMbtn8CBAAOQD09haK0t7dLko466ijNmzdPK1asaGiAVPIaCACMdLt27dKOHTteerxs2TKdcMIJDa2BHggAVNDmzZs1b948SdKePXv0zne+U7Nnz25oDQQIAFTQxIkTtXr16lJr4BQWACAJAQIASEKAAECCsmcDrEfRNRIgALCfWltbtW3btqYOkYjQtm3b1NraWtg+uIgOAPupo6ND3d3d2rp1a9mlDKq1tVUdHR2Fbb+SAcJgigDKdNBBB2nChAlll1G6Sp7CYjBFAChfJQMEAFA+AgQAkIQAAQAkIUAAAEkIEABAEgIEAJCEAAEAJCFAAABJCBAAQBICBACQhAABACQhQAAASQgQAEASAgQAkKSSAWJ7ru3FPT09ZZcCACNWJQOE+UAAoHyVDBAAQPkIEABAEgIEAJCEAAEAJCFAAABJCBAAQBICBACQhAABACQhQAAASQgQAEASAgQAkIQAAQAkIUAAAEkIEABAEgIEAJCEAAEAJCFAAABJKhkgTGkLAOWrZIAwpS0AlK+SAQIAKB8BAgBIQoAAAJIQIACAJAQIACAJAQIASDJkgNgeZfvJRhQDAKiOIQMkIvZKWmf7VQ2oBwBQES11rneEpDW2V0ja1bswIs4qpCoAQNOrN0A+XmgVAIDKqStAIuLHto+VdFxE/Mj2H0saVWxpAIBmVtddWLbfL+lWSV/JF7VL+n5RRQEAml+9t/FeJOmNkrZLUkSsl3RUUUUBAJpfvQHy24h4sfcb2y2SopiSAABVUG+A/Nj230s6xPZMSd+WtKS4sgAAza7eALlU0lZJj0u6QNJSSf9QVFEAgOZX7228p0v6j4j4apHFAACqo94eyHskrbb9gO3P5VPKHlFkYQCA5lbv50DOlyTbR0t6m6SrJR1d7+sBAH946goA2++W9CZJr5H0K0lXSfrvAusCADS5ensQV0p6StI1kpZHxMbCKgIAVEJd10AiYqykBZJaJf2T7RW2byi0MgBAU6t3KJPDJb1K0rGSOiWNlvS74soCADS7ek9h3VfzdVVEdBdX0tBsz5U0d9KkSWWWAQAjmiPqH5HE9mGSFBE7C6toP3R1dcXKlSvLLgMAKsX2qojoOtDt1HsK6wTbj0haI2mt7VW2TzjQnQMAqqveDxIulnRJRBwbEa+S9KF8GQBghKo3QA6NiOW930TEPZIOLaQiAEAl1HsR/WnbH5fUe+vuuyU9XUxJAIAqqLcHskDSOEnflfQdSb2fCwEAjFCD9kBst0q6UNIkZUO5fygidjeiMABAcxuqB/J1SV3KwuNMSZ8rvCIAQCUMdQ1kakS8RpJsXytpRfElAQCqYKgeyEunqyJiT8G1AAAqZKgeyGttb88fW9mc6NvzxxERhxdaHQCgaQ0aIBExqlGFAACqpd7beAEA+D0ECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJJUMENtzbS/u6ekpuxQAGLEqGSARsSQiFo0ePbrsUgBgxKpkgAAAykeAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkLWUX0Mv2oZK+JOlFSfdExI0llwQAGEShPRDb19neYvuJPstn215ne4PtS/PF50i6NSLeL+msIusCABy4ok9hXS9pdu0C26MkXS3pTElTJZ1ne6qkDknP5qvtLbguAMABKjRAIuJeSc/3WXyypA0R8XREvCjpZklnS+pWFiKD1mV7ke2Vtldu3bq1iLIBAHUo4yJ6u/b1NKQsONolfVfSuba/LGnJQC+OiMUR0RURXePGjSu2UgDAgJrmInpE7JL0vrLrAADUp4weyCZJx9R835EvAwBUSBkB8pCk42xPsP0ySfMl3V5CHQCAA1D0bbw3SfqJpMm2u20vjIg9ki6WdKekn0r6VkSsKbIOAMDwK/QaSEScN8DypZKWFrlvAECxGMoEAJCEAAEAJKlkgNiea3txT09P2aUAwIjliCi7hmS2d0haV3YddRgr6VdlF1EH6hw+VahRos7hVpU6J0dE24FupGk+SJhoXUR0lV3EUGyvpM7hU4U6q1CjRJ3DrUp1Dsd2KnkKCwBQPgIEAJCk6gGyuOwC6kSdw6sKdVahRok6h9uIqrPSF9EBAOWpeg8EAFASAgQAkKTpA8T2X9peY/t3trv6PPexfF71dbbPGOD1E2w/mK93Sz4CcNE132L70fxro+1HB1hvo+3H8/WG5ba6/azzU7Y31dQ6Z4D1+pvDvpF1fs72k7Yfs/092y8fYL2Gt+dQbWP74Px42JAfh52NqKtPDcfYXm57bf679Df9rHOa7Z6aY+ETja4zr2PQn6EzX8zb8zHbM0qocXJNOz1qe7vtD/ZZp5T2tH2d7S22n6hZdqTtu2yvz/89YoDXnp+vs972+XXtMCKa+kvSFEmTJd0jqatm+VRJqyUdLGmCpKckjern9d+SND9/fI2kDzS4/iskfWKA5zZKGlti235K0oeHWGdU3rYTJb0sb/OpDa5zlqSW/PHlki5vhvasp20k/ZWka/LH8yXdUsLPebykGfnjNkk/66fO0yT9oNG17e/PUNIcSXdIsqQ3SHqw5HpHSfqlpGOboT0lnSpphqQnapb9i6RL88eX9vf7I+lISU/n/x6RPz5iqP01fQ8kIn4aEf192vxsSTdHxG8j4hlJG5TNt/4S25b055JuzRd9XdJbi6y3n/2/XdJNjdpnAQaaw75hImJZZNMASNIDyiYhawb1tM3Zyo47KTsO35wfFw0TEc9FxMP54x3KplFob2QNw+hsSd+IzAOSXm57fIn1vFnSUxHx8xJreElE3Cvp+T6La4/Bgd4Dz5B0V0Q8HxH/K+kuSbOH2l/TB8ggBppbvdYYSf9X8+bT3zpFepOkzRGxfoDnQ9Iy26tsL2pgXbUuzk8FXDdA17aedm6kBcr+Au1Po9uznrZ5aZ38OOxRdlyWIj+F9jpJD/bz9J/aXm37DtvTGlrYPkP9DJvteJyvgf9AbIb2lKRXRMRz+eNfSnpFP+sktWtTDGVi+0eSXtnPU5dFxG2NrqceddZ8ngbvfZwSEZtsHyXpLttP5n9BNKROSV+W9Bllv7SfUXa6bcFw7r9e9bSn7csk7ZF04wCbKbw9q8z2YZK+I+mDEbG9z9MPKzsNszO/FvZ9Scc1ukZV6GeYX089S9LH+nm6Wdrz90RE2B62z240RYBExFsSXlbP3OrblHVxW/K//oZt/vWharbdIukcSScOso1N+b9bbH9P2SmRYf1lqbdtbX9V0g/6eaohc9jX0Z7vlfQXkt4c+UnbfrZReHv2UU/b9K7TnR8To5Udlw1l+yBl4XFjRHy37/O1gRIRS21/yfbYiGjowIB1/AwbcjzW6UxJD0fE5r5PNEt75jbbHh8Rz+Wn+7b0s84mZddtenUou+48qCqfwrpd0vz8LpcJytJ9Re0K+RvNcklvyxedL6lRPZq3SHoyIrr7e9L2obbbeh8ru1D8RH/rFqXPueN5A+y/9Dnsbc+W9HeSzoqIXw+wThntWU/b3K7suJOy4/DugQKwKPk1l2sl/TQi/nWAdV7Ze23G9snK3hsaGnR1/gxvl/Se/G6sN0jqqTk902gDnmFohvasUXsMDvQeeKekWbaPyE9lz8qXDa7Rdwkk3FUwT9n5uN9K2izpzprnLlN2F8w6SWfWLF8q6ej88URlwbJB0rclHdyguq+XdGGfZUdLWlpT1+r8a42yUzWNbtsbJD0u6bH8IBvft878+znK7tx5qqQ6Nyg7P/to/nVN3zrLas/+2kbSPyoLO0lqzY+7DflxOLGE9jtF2WnKx2racI6kC3uPUUkX5+22WtmNCn9WQp39/gz71GlJV+ft/bhq7sxscK2HKguE0TXLSm9PZYH2nKTd+fvmQmXX3P5L0npJP5J0ZL5ul6Sv1bx2QX6cbpD0vnr2x1AmAIAkVT6FBQAoEQECAEhCgAAAkhAgAIAkBAgAIElTfJAQaDTbe5XdBtrrrRGxsaRygEriNl6MSLZ3RsRhAzxnZb8bv2twWUClcAoLUDbIoLN5Pb6h7NPPx9j+iO2H8sEmP12z7mW2f2b7Pts32f5wvvwe53PW2B5re2P+eJSzOU16t3VBvvy0/DW3Opvv5MaaTy+fZPt/8sH4Vthus32v7ek1ddxn+7UNaySgD05hYaQ6xPsm+npG0t8qGw7n/Ih4wPas/PuTlX36+Xbbp0rapWzIkunKfn8elrRqiH0tVDbkxkm2D5Z0v+1l+XOvkzRN0i8k3S/pjbZXSLpF0jsi4iHbh0v6jbLhSN4r6YO2Xy2pNSJWH2hDAKkIEIxUv4mI2r/mOyX9PLI5JqRsLKBZkh7Jvz9MWaC0Sfpe5GNy2a5nXLBZkv7Edu+YbKPzbb0oaUXk46XlgdapbMj35yLiIWnfwHy2vy3p47Y/omzYiev39z8NDCcCBNhnV81jS/rniPhK7QruM3VpH3u077Rwa59t/XVE/N7gdLZPUzbGW6+9GuR3MiJ+bfsuZRMEvV2DjPQMNALXQID+3SlpQT6Hhmy353NU3CvprbYPyUeOnVvzmo3a96b+tj7b+kA+pLpsvzofbXYg6ySNt31Svn5bPhS8JH1N0hclPRTZzHFAaeiBAP2IiGW2p0j6SX5de6ekd0fEw7ZvUTbK6hZlQ7r3+rykbzmbSe8/a5Z/TdmpqYfzi+RbNcjUyhHxou13SPo324cou/7xFkk7I2KV7e2S/n2Y/qtAMm7jBQ6A7U8pe2P/fIP2d7SyiX6O5zZjlI1TWEBF2H6PsrnMLyM80AzogQAAktADAQAkIUAAAEkIEABAEgIEAJCEAAEAJPl/1VumISOaFmoAAAAASUVORK5CYII=\n",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          },
-          "output_type": "display_data"
+          }
         }
       ],
       "source": [
@@ -533,7 +577,8 @@
     "colab": {
       "name": "00_getting_started.ipynb",
       "provenance": []
-    }
+    },
+    "accelerator": "GPU"
   },
   "nbformat": 4,
   "nbformat_minor": 5

--- a/00_getting_started.ipynb
+++ b/00_getting_started.ipynb
@@ -32,21 +32,474 @@
         "sudo apt-get -qq install exuberant-ctags libopenblas-dev software-properties-common build-essential\n",
         "pip install -q contextlib2 pint simplejson scipy git+https://github.com/ctypesgen/ctypesgen.git\n",
         "if [ ! -d ~/bifrost/.git ]; then\n",
-        "  git clone --branch autoconf https://github.com/ledatelescope/bifrost ~/bifrost\n",
+        "  git clone https://github.com/ledatelescope/bifrost ~/bifrost\n",
         "fi\n",
         "cd ~/bifrost\n",
         "./configure && make -j all && sudo make install"
       ],
       "metadata": {
-        "id": "S-IQgISobCvU"
+        "id": "S-IQgISobCvU",
+        "outputId": "65f3833c-feb8-429a-b0af-1a16db3b56f7",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "id": "S-IQgISobCvU",
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "No bifrost but we're on Google Colab, so will try to install.\n",
+            "Selecting previously unselected package exuberant-ctags.\r\n",
+            "(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 155202 files and directories currently installed.)\r\n",
+            "Preparing to unpack .../exuberant-ctags_1%3a5.9~svn20110310-11_amd64.deb ...\r\n",
+            "Unpacking exuberant-ctags (1:5.9~svn20110310-11) ...\r\n",
+            "Setting up exuberant-ctags (1:5.9~svn20110310-11) ...\r\n",
+            "update-alternatives: using /usr/bin/ctags-exuberant to provide /usr/bin/ctags (ctags) in auto mode\r\n",
+            "update-alternatives: using /usr/bin/ctags-exuberant to provide /usr/bin/etags (etags) in auto mode\r\n",
+            "Processing triggers for man-db (2.8.3-2ubuntu0.1) ...\r\n",
+            "checking build system type... x86_64-unknown-linux-gnu\n",
+            "checking host system type... x86_64-unknown-linux-gnu\n",
+            "checking how to print strings... printf\n",
+            "checking for gcc... gcc\n",
+            "checking whether the C compiler works... yes\n",
+            "checking for C compiler default output file name... a.out\n",
+            "checking for suffix of executables... \n",
+            "checking whether we are cross compiling... no\n",
+            "checking for suffix of object files... o\n",
+            "checking whether the compiler supports GNU C... yes\n",
+            "checking whether gcc accepts -g... yes\n",
+            "checking for gcc option to enable C11 features... none needed\n",
+            "checking for a sed that does not truncate output... /bin/sed\n",
+            "checking for grep that handles long lines and -e... /bin/grep\n",
+            "checking for egrep... /bin/grep -E\n",
+            "checking for fgrep... /bin/grep -F\n",
+            "checking for ld used by gcc... /usr/bin/ld\n",
+            "checking if the linker (/usr/bin/ld) is GNU ld... yes\n",
+            "checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B\n",
+            "checking the name lister (/usr/bin/nm -B) interface... BSD nm\n",
+            "checking whether ln -s works... yes\n",
+            "checking the maximum length of command line arguments... 1572864\n",
+            "checking how to convert x86_64-unknown-linux-gnu file names to x86_64-unknown-linux-gnu format... func_convert_file_noop\n",
+            "checking how to convert x86_64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop\n",
+            "checking for /usr/bin/ld option to reload object files... -r\n",
+            "checking for objdump... objdump\n",
+            "checking how to recognize dependent libraries... pass_all\n",
+            "checking for dlltool... no\n",
+            "checking how to associate runtime and link libraries... printf %s\\n\n",
+            "checking for g++... g++\n",
+            "checking whether the compiler supports GNU C++... yes\n",
+            "checking whether g++ accepts -g... yes\n",
+            "checking for g++ option to enable C++11 features... none needed\n",
+            "checking for ar... ar\n",
+            "checking for archiver @FILE support... @\n",
+            "checking for strip... strip\n",
+            "checking for ranlib... ranlib\n",
+            "checking for gawk... no\n",
+            "checking for mawk... mawk\n",
+            "checking command to parse /usr/bin/nm -B output from gcc object... ok\n",
+            "checking for sysroot... no\n",
+            "checking for a working dd... /bin/dd\n",
+            "checking how to truncate binary pipes... /bin/dd bs=4096 count=1\n",
+            "checking for mt... no\n",
+            "checking if : is a manifest tool... no\n",
+            "checking for stdio.h... yes\n",
+            "checking for stdlib.h... yes\n",
+            "checking for string.h... yes\n",
+            "checking for inttypes.h... yes\n",
+            "checking for stdint.h... yes\n",
+            "checking for strings.h... yes\n",
+            "checking for sys/stat.h... yes\n",
+            "checking for sys/types.h... yes\n",
+            "checking for unistd.h... yes\n",
+            "checking for dlfcn.h... yes\n",
+            "checking for objdir... .libs\n",
+            "checking if gcc supports -fno-rtti -fno-exceptions... no\n",
+            "checking for gcc option to produce PIC... -fPIC -DPIC\n",
+            "checking if gcc PIC flag -fPIC -DPIC works... yes\n",
+            "checking if gcc static flag -static works... yes\n",
+            "checking if gcc supports -c -o file.o... yes\n",
+            "checking if gcc supports -c -o file.o... (cached) yes\n",
+            "checking whether the gcc linker (/usr/bin/ld) supports shared libraries... yes\n",
+            "checking whether -lc should be explicitly linked in... no\n",
+            "checking dynamic linker characteristics... GNU/Linux ld.so\n",
+            "checking how to hardcode library paths into programs... immediate\n",
+            "checking whether stripping libraries is possible... yes\n",
+            "checking if libtool supports shared libraries... yes\n",
+            "checking whether to build shared libraries... yes\n",
+            "checking whether to build static libraries... yes\n",
+            "checking how to run the C++ preprocessor... g++ -E\n",
+            "checking for ld used by g++... /usr/bin/ld\n",
+            "checking if the linker (/usr/bin/ld) is GNU ld... yes\n",
+            "checking whether the g++ linker (/usr/bin/ld) supports shared libraries... yes\n",
+            "checking for g++ option to produce PIC... -fPIC -DPIC\n",
+            "checking if g++ PIC flag -fPIC -DPIC works... yes\n",
+            "checking if g++ static flag -static works... yes\n",
+            "checking if g++ supports -c -o file.o... yes\n",
+            "checking if g++ supports -c -o file.o... (cached) yes\n",
+            "checking whether the g++ linker (/usr/bin/ld) supports shared libraries... yes\n",
+            "checking dynamic linker characteristics... (cached) GNU/Linux ld.so\n",
+            "checking how to hardcode library paths into programs... immediate\n",
+            "checking for gcc... (cached) gcc\n",
+            "checking whether the compiler supports GNU C... (cached) yes\n",
+            "checking whether gcc accepts -g... (cached) yes\n",
+            "checking for gcc option to enable C11 features... (cached) none needed\n",
+            "checking whether the compiler supports GNU C++... (cached) yes\n",
+            "checking whether g++ accepts -g... (cached) yes\n",
+            "checking for g++ option to enable C++11 features... (cached) none needed\n",
+            "checking for gawk... (cached) mawk\n",
+            "checking for a sed that does not truncate output... (cached) /bin/sed\n",
+            "checking for a BSD-compatible install... /usr/bin/install -c\n",
+            "checking whether ln -s works... yes\n",
+            "checking whether make sets $(MAKE)... yes\n",
+            "checking whether ctags executable path has been provided... no\n",
+            "checking for ctags... /usr/bin/ctags\n",
+            "checking whether /usr/bin/ctags is exuberant... yes\n",
+            "checking for inline... inline\n",
+            "checking whether g++ supports C++20 features with -std=c++20... no\n",
+            "checking whether g++ supports C++20 features with +std=c++20... no\n",
+            "checking whether g++ supports C++20 features with -h std=c++20... no\n",
+            "configure: No compiler with C++20 support was found\n",
+            "checking whether g++ supports C++17 features with -std=c++17... yes\n",
+            "checking for C++ std::filesystem support... no\n",
+            "checking for C++ std::string::ends_with support... no\n",
+            "checking for memset... yes\n",
+            "checking for rint... yes\n",
+            "checking for socket... yes\n",
+            "checking for recvmsg... yes\n",
+            "checking for sqrt... yes\n",
+            "checking for strerror... yes\n",
+            "checking for arpa/inet.h... yes\n",
+            "checking for netdb.h... yes\n",
+            "checking for netinet/in.h... yes\n",
+            "checking for sys/file.h... yes\n",
+            "checking for sys/ioctl.h... yes\n",
+            "checking for sys/socket.h... yes\n",
+            "checking for _Bool... no\n",
+            "checking for stdbool.h that conforms to C99... yes\n",
+            "checking for GNU libc compatible malloc... yes\n",
+            "checking for OpenMP flag of C++ compiler... -fopenmp\n",
+            "checking for ptrdiff_t... yes\n",
+            "checking for int16_t... yes\n",
+            "checking for int32_t... yes\n",
+            "checking for int64_t... yes\n",
+            "checking for int8_t... yes\n",
+            "checking for pid_t... yes\n",
+            "checking for size_t... yes\n",
+            "checking for ssize_t... yes\n",
+            "checking for uint16_t... yes\n",
+            "checking for uint32_t... yes\n",
+            "checking for uint64_t... yes\n",
+            "checking for uint8_t... yes\n",
+            "checking for long double with more range or precision than double... yes\n",
+            "checking for numa_node_of_cpu in -lnuma... yes\n",
+            "checking for hwloc_topology_init in -lhwloc... yes\n",
+            "checking for nvcc... /usr/local/cuda/bin/nvcc\n",
+            "checking for nvprune... /usr/local/cuda/bin/nvprune\n",
+            "checking for cuobjdump... /usr/local/cuda/bin/cuobjdump\n",
+            "checking for a working CUDA installation... yes - v11.1\n",
+            "checking for CUDA CXX standard support... C++17\n",
+            "checking for valid CUDA architectures... found: 35 37 50 52 53 60 61 62 70 72 75 80 86\n",
+            "checking which CUDA architectures to target... 70 75\n",
+            "checking for valid requested CUDA architectures... yes\n",
+            "checking for Pascal-style CUDA managed memory... yes\n",
+            "checking for /dev/shm... yes\n",
+            "checking if the compiler accepts '-march=native'... yes\n",
+            "checking whether python executable path has been provided... no\n",
+            "checking for python... /usr/local/bin/python\n",
+            "checking whether /usr/local/bin/python as ctypesgen... yes\n",
+            "checking whether docker executable path has been provided... no\n",
+            "checking for docker... no\n",
+            "checking for doxygen... no\n",
+            "checking for perl... /usr/bin/perl\n",
+            "configure: creating ./config.status\n",
+            "config.status: creating config.mk\n",
+            "config.status: creating Makefile\n",
+            "config.status: creating src/Makefile\n",
+            "config.status: creating python/Makefile\n",
+            "config.status: creating share/bifrost.pc\n",
+            "config.status: creating src/bifrost/config.h\n",
+            "config.status: executing libtool commands\n",
+            "\n",
+            "\n",
+            "configure: cuda: yes - v11.1 - 70 75\n",
+            "configure: numa: yes\n",
+            "configure: hwloc: yes\n",
+            "configure: libvma: no\n",
+            "configure: python bindings: yes\n",
+            "configure: memory alignment: 4096\n",
+            "configure: logging directory: /dev/shm/bifrost\n",
+            "configure: options: native map_cache\n",
+            "\n",
+            "Bifrost is now ready to be compiled.  Please run 'make'\n",
+            "\n",
+            "make -C src all\n",
+            "make[1]: Entering directory '/root/bifrost/src'\n",
+            "Building C++ source file memory.cpp\n",
+            "Building C++ source file affinity.cpp\n",
+            "Building C++ source file testsuite.cpp\n",
+            "Building C++ source file ring_impl.cpp\n",
+            "Building C++ source file cuda.cpp\n",
+            "Building C++ source file fileutils.cpp\n",
+            "Building C++ source file ring.cpp\n",
+            "Building C++ source file common.cpp\n",
+            "Building C++ source file unpack.cpp\n",
+            "Building C++ source file proclog.cpp\n",
+            "Building C++ source file array.cpp\n",
+            "Building C++ source file udp_transmit.cpp\n",
+            "Building C++ source file address.cpp\n",
+            "Building C++ source file quantize.cpp\n",
+            "Building C++ source file udp_socket.cpp\n",
+            "Building CUDA source file transpose.cu\n",
+            "Building C++ source file udp_capture.cpp\n",
+            "Building CUDA source file fft.cu\n",
+            "Building CUDA source file fdmt.cu\n",
+            "Building C++ source file trace.cpp\n",
+            "Building CUDA source file romein_kernels.cu\n",
+            "Building CUDA source file romein.cu\n",
+            "Building CUDA source file gunpack.cu\n",
+            "Building CUDA source file linalg_kernels.cu\n",
+            "Building CUDA source file reduce.cu\n",
+            "Building CUDA source file fir.cu\n",
+            "Building CUDA source file linalg.cu\n",
+            "Building CUDA source file guantize.cu\n",
+            "Generating libbifrost.version\n",
+            "Building JIT version of ArrayIndexer.cuh\n",
+            "Building JIT version of Complex.hpp\n",
+            "Building JIT version of ShapeIndexer.cuh\n",
+            "Building JIT version of IndexArray.cuh\n",
+            "Building JIT version of Vector.hpp\n",
+            "Building JIT version of int_fastdiv.h\n",
+            "Building C++ source file map.cpp\n",
+            "Linking _cuda_device_link.o\n",
+            "Linking libbifrost.so.0.10\n",
+            "Successfully built libbifrost.so.0.10\n",
+            "make[1]: Leaving directory '/root/bifrost/src'\n",
+            "make -C python build\n",
+            "make[1]: Entering directory '/root/bifrost/python'\n",
+            "# Build the libbifrost wrapper\n",
+            "/usr/local/bin/python -c 'from ctypesgen import main as ctypeswrap; ctypeswrap.main()' -lbifrost -I../src ../src/bifrost/config.h ../src/bifrost/ring.h ../src/bifrost/cuda.h ../src/bifrost/fdmt.h ../src/bifrost/transpose.h ../src/bifrost/testsuite.h ../src/bifrost/udp_capture.h ../src/bifrost/memory.h ../src/bifrost/udp_transmit.h ../src/bifrost/fft.h ../src/bifrost/unpack.h ../src/bifrost/udp_socket.h ../src/bifrost/affinity.h ../src/bifrost/address.h ../src/bifrost/map.h ../src/bifrost/proclog.h ../src/bifrost/linalg.h ../src/bifrost/array.h ../src/bifrost/common.h ../src/bifrost/quantize.h ../src/bifrost/fir.h ../src/bifrost/romein.h ../src/bifrost/reduce.h -o bifrost/libbifrost_generated.py\n",
+            "# WAR for 'const char**' being generated as POINTER(POINTER(c_char)) instead of POINTER(c_char_p)\n",
+            "/bin/sed -i.orig -e 's/POINTER(c_char)/c_char_p/g' bifrost/libbifrost_generated.py\n",
+            "# WAR for a buggy WAR in ctypesgen that breaks type checking and auto-byref functionality\n",
+            "/bin/sed -i.orig -e 's/def POINTER/def POINTER_not_used/' bifrost/libbifrost_generated.py\n",
+            "# WAR for a buggy WAR in ctypesgen that breaks string buffer arguments (e.g., as in address.py)\n",
+            "/bin/sed -i.orig -e 's/class String/String = c_char_p\\nclass String_not_used/' bifrost/libbifrost_generated.py\n",
+            "/bin/sed -i.orig -e 's/String.from_param/String_not_used.from_param/g' bifrost/libbifrost_generated.py\n",
+            "/bin/sed -i.orig -e 's/def ReturnString/ReturnString = c_char_p\\ndef ReturnString_not_used/' bifrost/libbifrost_generated.py\n",
+            "/bin/sed -i.orig -e '/errcheck = ReturnString/s/^/#/' bifrost/libbifrost_generated.py\n",
+            "/usr/local/bin/python setup.py build \n",
+            "running build\n",
+            "running build_py\n",
+            "creating build\n",
+            "creating build/lib\n",
+            "creating build/lib/bifrost\n",
+            "copying bifrost/units.py -> build/lib/bifrost\n",
+            "copying bifrost/libbifrost.py -> build/lib/bifrost\n",
+            "copying bifrost/transpose.py -> build/lib/bifrost\n",
+            "copying bifrost/pipeline.py -> build/lib/bifrost\n",
+            "copying bifrost/map.py -> build/lib/bifrost\n",
+            "copying bifrost/memory.py -> build/lib/bifrost\n",
+            "copying bifrost/unpack.py -> build/lib/bifrost\n",
+            "copying bifrost/GPUArray.py -> build/lib/bifrost\n",
+            "copying bifrost/DataType.py -> build/lib/bifrost\n",
+            "copying bifrost/ring.py -> build/lib/bifrost\n",
+            "copying bifrost/udp_socket.py -> build/lib/bifrost\n",
+            "copying bifrost/libbifrost_generated.py -> build/lib/bifrost\n",
+            "copying bifrost/dtype.py -> build/lib/bifrost\n",
+            "copying bifrost/device.py -> build/lib/bifrost\n",
+            "copying bifrost/udp_capture.py -> build/lib/bifrost\n",
+            "copying bifrost/sigproc.py -> build/lib/bifrost\n",
+            "copying bifrost/affinity.py -> build/lib/bifrost\n",
+            "copying bifrost/ring2.py -> build/lib/bifrost\n",
+            "copying bifrost/ndarray.py -> build/lib/bifrost\n",
+            "copying bifrost/romein.py -> build/lib/bifrost\n",
+            "copying bifrost/guppi_raw.py -> build/lib/bifrost\n",
+            "copying bifrost/fir.py -> build/lib/bifrost\n",
+            "copying bifrost/block.py -> build/lib/bifrost\n",
+            "copying bifrost/udp_transmit.py -> build/lib/bifrost\n",
+            "copying bifrost/reduce.py -> build/lib/bifrost\n",
+            "copying bifrost/portaudio.py -> build/lib/bifrost\n",
+            "copying bifrost/psrdada.py -> build/lib/bifrost\n",
+            "copying bifrost/Space.py -> build/lib/bifrost\n",
+            "copying bifrost/address.py -> build/lib/bifrost\n",
+            "copying bifrost/sigproc2.py -> build/lib/bifrost\n",
+            "copying bifrost/temp_storage.py -> build/lib/bifrost\n",
+            "copying bifrost/linalg.py -> build/lib/bifrost\n",
+            "copying bifrost/__init__.py -> build/lib/bifrost\n",
+            "copying bifrost/header_standard.py -> build/lib/bifrost\n",
+            "copying bifrost/fft.py -> build/lib/bifrost\n",
+            "copying bifrost/quantize.py -> build/lib/bifrost\n",
+            "copying bifrost/proclog.py -> build/lib/bifrost\n",
+            "copying bifrost/fdmt.py -> build/lib/bifrost\n",
+            "copying bifrost/core.py -> build/lib/bifrost\n",
+            "copying bifrost/block_chainer.py -> build/lib/bifrost\n",
+            "creating build/lib/bifrost/version\n",
+            "copying bifrost/version/__main__.py -> build/lib/bifrost/version\n",
+            "copying bifrost/version/__init__.py -> build/lib/bifrost/version\n",
+            "creating build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/wav.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/transpose.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/unpack.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/accumulate.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/detect.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/sigproc.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/convert_visibilities.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/binary_io.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/guppi_raw.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/serialize.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/audio.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/reverse.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/correlate.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/reduce.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/psrdada.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/fftshift.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/scrunch.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/__init__.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/fft.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/copy.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/print_header.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/quantize.py -> build/lib/bifrost/blocks\n",
+            "copying bifrost/blocks/fdmt.py -> build/lib/bifrost/blocks\n",
+            "creating build/lib/bifrost/views\n",
+            "copying bifrost/views/basic_views.py -> build/lib/bifrost/views\n",
+            "copying bifrost/views/__init__.py -> build/lib/bifrost/views\n",
+            "creating build/lib/bifrost/telemetry\n",
+            "copying bifrost/telemetry/__main__.py -> build/lib/bifrost/telemetry\n",
+            "copying bifrost/telemetry/__init__.py -> build/lib/bifrost/telemetry\n",
+            "running build_scripts\n",
+            "creating build/scripts-3.7\n",
+            "copying and adjusting ../tools/like_top.py -> build/scripts-3.7\n",
+            "copying and adjusting ../tools/like_bmon.py -> build/scripts-3.7\n",
+            "copying and adjusting ../tools/getsiblings.py -> build/scripts-3.7\n",
+            "copying and adjusting ../tools/setirq.py -> build/scripts-3.7\n",
+            "copying and adjusting ../tools/getirq.py -> build/scripts-3.7\n",
+            "copying and adjusting ../tools/like_pmap.py -> build/scripts-3.7\n",
+            "copying and adjusting ../tools/like_ps.py -> build/scripts-3.7\n",
+            "copying and adjusting ../tools/pipeline2dot.py -> build/scripts-3.7\n",
+            "changing mode of build/scripts-3.7/like_top.py from 644 to 755\n",
+            "changing mode of build/scripts-3.7/like_bmon.py from 644 to 755\n",
+            "changing mode of build/scripts-3.7/getsiblings.py from 644 to 755\n",
+            "changing mode of build/scripts-3.7/setirq.py from 644 to 755\n",
+            "changing mode of build/scripts-3.7/getirq.py from 644 to 755\n",
+            "changing mode of build/scripts-3.7/like_pmap.py from 644 to 755\n",
+            "changing mode of build/scripts-3.7/like_ps.py from 644 to 755\n",
+            "changing mode of build/scripts-3.7/pipeline2dot.py from 644 to 755\n",
+            "make[1]: Leaving directory '/root/bifrost/python'\n",
+            "mkdir -p /usr/local/lib\n",
+            "cp lib/libbifrost.so.0.10 /usr/local/lib/libbifrost.so.0.10\n",
+            "ln -f -s libbifrost.so.0.10 /usr/local/lib/libbifrost.so.0\n",
+            "ln -f -s libbifrost.so.0.10 /usr/local/lib/libbifrost.so\n",
+            "mkdir -p /usr/local/include/bifrost\n",
+            "cp src/bifrost/config.h src/bifrost/ring.h src/bifrost/cuda.h src/bifrost/fdmt.h src/bifrost/transpose.h src/bifrost/testsuite.h src/bifrost/udp_capture.h src/bifrost/memory.h src/bifrost/udp_transmit.h src/bifrost/fft.h src/bifrost/unpack.h src/bifrost/udp_socket.h src/bifrost/affinity.h src/bifrost/address.h src/bifrost/map.h src/bifrost/proclog.h src/bifrost/linalg.h src/bifrost/array.h src/bifrost/common.h src/bifrost/quantize.h src/bifrost/fir.h src/bifrost/romein.h src/bifrost/reduce.h /usr/local/include/bifrost/\n",
+            "mkdir -p /usr/local/share/bifrost\n",
+            "cp share/bifrost.m4 /usr/local/share/bifrost/\n",
+            "mkdir -p /usr/local/lib/pkgconfig\n",
+            "cp share/bifrost.pc /usr/local/lib/pkgconfig/\n",
+            "make -C python install\n",
+            "make[1]: Entering directory '/root/bifrost/python'\n",
+            "/usr/local/bin/python setup.py build \n",
+            "running build\n",
+            "running build_py\n",
+            "running build_scripts\n",
+            "Processing /root/bifrost/python\n",
+            "Requirement already satisfied: numpy>=1.8.1 in /usr/local/lib/python3.7/dist-packages (from bifrost==0.10.0) (1.21.6)\n",
+            "Requirement already satisfied: contextlib2>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from bifrost==0.10.0) (0.5.5)\n",
+            "Requirement already satisfied: pint>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from bifrost==0.10.0) (0.18)\n",
+            "Requirement already satisfied: graphviz>=0.5.0 in /usr/local/lib/python3.7/dist-packages (from bifrost==0.10.0) (0.10.1)\n",
+            "Collecting ctypesgen==1.0.2\n",
+            "  Downloading ctypesgen-1.0.2-py2.py3-none-any.whl (476 kB)\n",
+            "Requirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (from bifrost==0.10.0) (3.2.2)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.7/dist-packages (from pint>=0.7.0->bifrost==0.10.0) (21.3)\n",
+            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from pint>=0.7.0->bifrost==0.10.0) (4.11.3)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->pint>=0.7.0->bifrost==0.10.0) (3.8.0)\n",
+            "Requirement already satisfied: typing-extensions>=3.6.4 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->pint>=0.7.0->bifrost==0.10.0) (4.2.0)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib->bifrost==0.10.0) (0.11.0)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->bifrost==0.10.0) (1.4.2)\n",
+            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->bifrost==0.10.0) (2.8.2)\n",
+            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->bifrost==0.10.0) (3.0.8)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.1->matplotlib->bifrost==0.10.0) (1.15.0)\n",
+            "Building wheels for collected packages: bifrost\n",
+            "  Building wheel for bifrost (setup.py): started\n",
+            "  Building wheel for bifrost (setup.py): finished with status 'done'\n",
+            "  Created wheel for bifrost: filename=bifrost-0.10.0-py3-none-any.whl size=183794 sha256=bf9b54ecd7aabd06caf2e06f84c2dcaac3124374bb596274beb826e27529cd89\n",
+            "  Stored in directory: /tmp/pip-ephem-wheel-cache-ghcz0avk/wheels/35/b7/11/a795b9aa4b1dfc3b2091f793f70becd9333a0b79216d208fd5\n",
+            "Successfully built bifrost\n",
+            "Installing collected packages: ctypesgen, bifrost\n",
+            "  Attempting uninstall: ctypesgen\n",
+            "    Found existing installation: ctypesgen 1.0.3.dev98+g2120dbf\n",
+            "    Uninstalling ctypesgen-1.0.3.dev98+g2120dbf:\n",
+            "      Successfully uninstalled ctypesgen-1.0.3.dev98+g2120dbf\n",
+            "Successfully installed bifrost-0.10.0 ctypesgen-1.0.2\n",
+            "*************************************************************************\n",
+            "By default Bifrost installs with basic Python telemetry enabled in order\n",
+            "to help inform how the software is used for future development.  You can\n",
+            "opt out of telemetry collection using:\n",
+            "python -m bifrost.telemetry --disable\n",
+            "*************************************************************************\n",
+            "\n",
+            "If you have trouble importing Bifrost from Python you may need\n",
+            "to set LD_LIBRARY_PATH to /usr/local/lib or have your\n",
+            "system administrator add this directory to '/etc/ld.so.conf'.\n",
+            "\n",
+            "make[1]: Leaving directory '/root/bifrost/python'\n",
+            "Libraries have been installed in:\n",
+            "  /usr/local/lib\n",
+            "\n",
+            "If you ever happen to want to link against installed libraries\n",
+            "in a given directory, LIBDIR, you must either use libtool, and\n",
+            "specify the full pathname of the library, or use the '-LLIBDIR'\n",
+            "flag during linking and do at least one of the following:\n",
+            "  - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable\n",
+            "    during execution\n",
+            "  - add LIBDIR to the 'LD_RUN_PATH' environment variable\n",
+            "    during linking\n",
+            "  - use the '-Wl,-rpath -Wl,LIBDIR' linker flag\n",
+            "  - have your system administrator add LIBDIR to '/etc/ld.so.conf'\n",
+            "\n",
+            "See any operating system documentation about shared libraries for\n",
+            "more information, such as the ld(1) and ld.so(8) manual pages.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "debconf: unable to initialize frontend: Dialog\n",
+            "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 1.)\n",
+            "debconf: falling back to frontend: Readline\n",
+            "debconf: unable to initialize frontend: Readline\n",
+            "debconf: (This frontend requires a controlling tty.)\n",
+            "debconf: falling back to frontend: Teletype\n",
+            "dpkg-preconfigure: unable to re-open stdin: \n",
+            "Cloning into '/root/bifrost'...\n",
+            "./configure: line 7420: /usr/bin/file: No such file or directory\n",
+            "configure: WARNING: doxygen not found - will not generate any doxygen documentation\n",
+            "configure: WARNING: This version of cuFFT may have unexpected behavior for complex-to-real transforms\n",
+            "transpose.cu: In function ‘BFstatus transpose_simple(const BFarray*, const \n",
+            "   BFarray*, const int*)’:\n",
+            "transpose.cu:319:32: warning: ‘axes_inverted’ may be used uninitialized in \n",
+            "   this function [-Wmaybe-uninitialized]\n",
+            "  func_str += hex_digits[axes[0]];\n",
+            "                          ~~~~~~^\n",
+            "INFO: Status: Preprocessing /tmp/tmp1a8a9abi.h\n",
+            "INFO: Status: gcc -E -U __GNUC__ -dD -I\"../src\" \"-D__extension__=\" \"-D__const=const\" \"-D__asm__(x)=\" \"-D__asm(x)=\" \"-DCTYPESGEN=1\" \"/tmp/tmp1a8a9abi.h\"\n",
+            "INFO: Status: Parsing /tmp/tmp1a8a9abi.h\n",
+            "INFO: Status: Processing description list.\n",
+            "WARNING: Could not load library \"bifrost\". Okay, I'll try to load it at runtime instead. \n",
+            "INFO: Status: Writing to bifrost/libbifrost_generated.py.\n",
+            "INFO: Status: Wrapping complete.\n",
+            "  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.\n",
+            "   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 2,
       "id": "proud-container",
       "metadata": {
         "id": "proud-container"
@@ -68,11 +521,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 3,
       "id": "subject-quebec",
       "metadata": {
         "id": "subject-quebec",
-        "outputId": "ecc41d4f-726a-4c2e-f009-a32825e32838",
+        "outputId": "0649a54f-c2cb-4279-868d-ed95f771e6e2",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -83,10 +536,10 @@
           "name": "stdout",
           "text": [
             "<class 'bifrost.ndarray.ndarray'> float32 (2, 4096) system\n",
-            "[[ 0.0000000e+00  0.0000000e+00 -1.8241284e+25 ...  1.5554413e-43\n",
-            "   1.5554413e-43  1.4012985e-43]\n",
-            " [ 4.4841551e-44  1.1210388e-43  1.6955711e-43 ...  0.0000000e+00\n",
-            "   0.0000000e+00  0.0000000e+00]]\n"
+            "[[9.7624806e-36 0.0000000e+00 1.5581004e-38 ... 1.3563156e-19\n",
+            "  2.8297670e+20 2.6373977e+23]\n",
+            " [2.0704474e-19 7.1220526e+28 1.4251251e-13 ... 7.6813502e+31\n",
+            "  1.8970232e+31 7.2250739e+28]]\n"
           ]
         }
       ],
@@ -119,11 +572,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 4,
       "id": "lightweight-madrid",
       "metadata": {
         "id": "lightweight-madrid",
-        "outputId": "b504c202-8395-4365-ce14-7bebf478dfe3",
+        "outputId": "33842f75-4a1c-4cb5-c82b-0e64eb3c7cf9",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -134,14 +587,14 @@
           "name": "stdout",
           "text": [
             "<class 'bifrost.ndarray.ndarray'> float64 (2, 4096) system\n",
-            "r: [[ 0.17851579 -0.9965826   0.39835836 ...  0.06416343  0.7667563\n",
-            "  -0.53529951]\n",
-            " [ 1.30749412 -1.05996732  1.20367584 ...  0.29484387 -1.37285379\n",
-            "  -0.45451832]]\n",
-            "data: [[ 0.17851579 -0.9965826   0.39835836 ...  0.06416343  0.7667563\n",
-            "  -0.53529951]\n",
-            " [ 1.30749412 -1.05996732  1.20367584 ...  0.29484387 -1.37285379\n",
-            "  -0.45451832]]\n"
+            "r: [[ 0.14467437 -0.9858471  -0.29228502 ...  1.52117552  0.11308428\n",
+            "   1.18072678]\n",
+            " [-1.0376523  -0.79953079  0.29897504 ... -0.09453896 -0.07558208\n",
+            "  -0.11985499]]\n",
+            "data: [[ 0.14467437 -0.9858471  -0.29228502 ...  1.52117552  0.11308428\n",
+            "   1.18072678]\n",
+            " [-1.0376523  -0.79953079  0.29897504 ... -0.09453896 -0.07558208\n",
+            "  -0.11985499]]\n"
           ]
         }
       ],
@@ -166,11 +619,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 5,
       "id": "regional-darkness",
       "metadata": {
         "id": "regional-darkness",
-        "outputId": "729d29ad-1a50-4e47-91df-bf38c5be5348",
+        "outputId": "f0dd5e3a-e301-4276-abd6-c033ee3db68d",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -180,12 +633,12 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "data += 2.0: [[2.17851579 1.0034174  2.39835836 ... 2.06416343 2.7667563  1.46470049]\n",
-            " [3.30749412 0.94003268 3.20367584 ... 2.29484387 0.62714621 1.54548168]]\n",
+            "data += 2.0: [[2.14467437 1.0141529  1.70771498 ... 3.52117552 2.11308428 3.18072678]\n",
+            " [0.9623477  1.20046921 2.29897504 ... 1.90546104 1.92441792 1.88014501]]\n",
             "data[0,:] = 55: [[55.         55.         55.         ... 55.         55.\n",
             "  55.        ]\n",
-            " [ 3.30749412  0.94003268  3.20367584 ...  2.29484387  0.62714621\n",
-            "   1.54548168]]\n"
+            " [ 0.9623477   1.20046921  2.29897504 ...  1.90546104  1.92441792\n",
+            "   1.88014501]]\n"
           ]
         }
       ],
@@ -198,11 +651,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 6,
       "id": "artificial-spider",
       "metadata": {
         "id": "artificial-spider",
-        "outputId": "03abaeb3-6e01-4b4c-f1e8-20caa413366b",
+        "outputId": "68f62d93-399e-4900-bb3e-89786025ef00",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -214,8 +667,8 @@
           "text": [
             "data[:,[1,3,5,7]] = 10: [[55.         55.         55.         ... 55.         55.\n",
             "  55.        ]\n",
-            " [ 3.30749412  0.94003268  3.20367584 ...  2.29484387  0.62714621\n",
-            "   1.54548168]]\n"
+            " [ 0.9623477   1.20046921  2.29897504 ...  1.90546104  1.92441792\n",
+            "   1.88014501]]\n"
           ]
         }
       ],
@@ -236,11 +689,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 7,
       "id": "smaller-organizer",
       "metadata": {
         "id": "smaller-organizer",
-        "outputId": "bdec8c2e-83cc-4ef1-8ce2-5e688215baa0",
+        "outputId": "04a972d2-f24d-43cd-b658-e92085f32071",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -252,8 +705,8 @@
           "text": [
             "<class 'bifrost.ndarray.ndarray'> [[65.         65.         65.         ... 65.         65.\n",
             "  65.        ]\n",
-            " [13.30749412 10.94003268 13.20367584 ... 12.29484387 10.62714621\n",
-            "  11.54548168]]\n"
+            " [10.9623477  11.20046921 12.29897504 ... 11.90546104 11.92441792\n",
+            "  11.88014501]]\n"
           ]
         }
       ],
@@ -292,11 +745,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 8,
       "id": "changing-enhancement",
       "metadata": {
         "id": "changing-enhancement",
-        "outputId": "0f55e47c-78d3-46ac-a5d3-d0237a4d58c7",
+        "outputId": "f9d0a10e-490a-45b8-e286-7f22657ee8a9",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -330,11 +783,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 9,
       "id": "talented-lending",
       "metadata": {
         "id": "talented-lending",
-        "outputId": "aaedd4e9-78b5-4c9b-caa1-d74bef03f55e",
+        "outputId": "28f657a6-aa24-4c82-d3e2-9192d99b330f",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -365,11 +818,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 10,
       "id": "prospective-financing",
       "metadata": {
         "id": "prospective-financing",
-        "outputId": "b45d4064-d869-418d-b432-32b506e232b6",
+        "outputId": "cccab24f-f1e0-489a-9189-5e468fb5d38a",
         "colab": {
           "base_uri": "https://localhost:8080/"
         }
@@ -417,14 +870,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 11,
       "id": "restricted-carrier",
       "metadata": {
         "id": "restricted-carrier",
-        "outputId": "53a29b5e-99ca-4ff7-db75-30705a1863e7",
+        "outputId": "dca9987c-438d-45e9-bdf8-2850f285bf56",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 296
+          "height": 297
         }
       },
       "outputs": [
@@ -432,19 +885,19 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "<matplotlib.legend.Legend at 0x7f10ae361610>"
+              "<matplotlib.legend.Legend at 0x7efe04a81590>"
             ]
           },
           "metadata": {},
-          "execution_count": 21
+          "execution_count": 11
         },
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEGCAYAAABLgMOSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9eXgc1Zno/Tutbqm7tS/d2rxI8oI3sA0OW2zABsKSAFnIQpIZyIUhuZN8M8ncm0lyM5NMcpMvmXsny0eGmYSELJOQDUISSBh2DDa7AWNsbLxIsiVbUrf2pVtSL+f7o7raLamX6u6qrpKnf8+jR3JVddUpd9V53/OuQkpJkSJFihQpki02swdQpEiRIkUWJ0UBUqRIkSJFcqIoQIoUKVKkSE4UBUiRIkWKFMmJogApUqRIkSI5YTd7AIWkoaFBtrW1mT2MIkWKFFlUvPLKK4NSSs/87f+lBEhbWxt79uwxexhFihQpsqgQQhxPtr1owipSpEiRIjlRFCBFihQpUiQnigKkSJEiRYrkRFGAFClSpEiRnCgKkCJFihQpkhOmChAhxI+FED4hxP4U+4UQ4g4hxFEhxD4hxLkJ+24WQhyJ/dxcuFEXKVKkSBEwfwXyU+DqNPuvAVbFfm4H/h1ACFEHfBm4ADgf+LIQotbQkRYpUqRIkTmYmgcipXxGCNGW5pAbgP+QSs35F4QQNUKIZuAy4DEp5TCAEOIxFEH0KyPGece9f8vEpJ+1pRfSV3sRM/YqIy5jGcJylmPBp7FRwgrXpdhEidlDMpxQNMjR4E7KbJW0OS8qyD0LGaF5Yj/eqUOUhSeZKm2gp/o8xpxLDL82wHR0gmPBZ6goaWBZ2fkIIQpyXTMJREboDO6m1rGU1rJNZg/HcGqCJ3CO7eK18Gt89p3fx9vYquv5rZ5I2Ar0JPy7N7Yt1fYFCCFuR1m9sGzZspwG8fLws+x1zrBl4mX+9fBXuD96Gd8J38gIZ6IgieJcejf28mMA7Ox9mumTHwXO4MlFhHAt/z4lzpMAPD76LDP97zPwgpL32Z7hb+33s1T4F+zdHd3AN8M3cUC2GzcEWwB3279hKx0EYHbwMmYH0xkDFj/CPo5r+fewOSYAmBl4F6GRrSaPyhjOEcf4gv2XeMuO8JfNjQSFjat7X+DyRn2fa6sLkLyRUt4F3AWwZcuWnLpn/fzje/j9od/wpRe/xh/WX8pfHHqav6h+A977Q+i4VNfxms09B+/hmy8d4x8v/EcmZif47qvf5V//SvDOjneaPTTD+N5r3+OufSf5zmXfYZ9/Hz858BN+fONtXNx6sf4XCwzD7z8BRx6BlnPhom9C2zZw1cLocTj4IFtf+Hf+FPgS7PgibP07MGBl8NXnv8r9R0b4/pU/5KHOh/gDf+D+Wz7B+vr1ul/LKnzmqc+w+2SIH131C378xo95xvYwD/73T7KksjArvoIQjcKub8FTX0eWN/CxZeciI5P8/tpfsqxGf4XEbB9IJk4CSxP+vSS2LdV2w3j3WR/g/Kbz+aEcJnTbY+CsgV+8D/bfb+RlC0ooGuIn+3/ClsYtvH/1+/nYho+xqnYVP9j3A87UzpWBUIBfHvwl71j+Dq5YfgWf2vwpWspbuOuNu/S/2MQA/ORa6HwKrv0X+Ksn4ewbobIR7KXQsAq2/R186iVY/2544qvw4N8qk4KODAYH+f3R33Pj6hu5sPlCPvu2z1JVVsXdb9yt63WsRNdYF4+feJxbNtzCRs9GvnjhF7Fh4+79Z9A9RyPwx0/CU1+Ds29k74d+yivT/Xzq3L8xRHiA9QXIA8BfxqKxLgTGpJR9wCPAO4QQtTHn+Tti2wxDCMHN629maHqIZ8LDcOujsORt8Lvb4PCjRl66YOzs2clAYICb19+MEAKbsHHL+lvoGuviNd9rZg/PEP7U+ScmQ5P8xbq/AKC0pJSb1tzEKwOvcHTkqH4XCo7Az94Foyfgo/fD+X+VemXhqoX33Q3b/ie8+jN45AugowD/3eHfEY6G+ejajwJQWVrJe1a+hydPPIkv4NPtOlbi14d+TamtlA+d9SEAvG4v7+x4Jw91PkQgFDB5dDogJfzp0/D6L+GyL8B7f8ivuh6g0lHJDStuMOyyZofx/gp4HjhLCNErhLhVCPEJIcQnYoc8BHQCR4EfAn8NEHOe/2/g5djPV1WHupFc3HIxHpeHB489CK4a+Mi90LQB7r0Z+t8w+vKG82j3o9Q569jWui2+7YplV+Cyu3iw80ETR2YcD3c/TEd1Bxs9G+Pb3rXiXQgEjx7XSTGIhODeW2C4Cz7yW2jflvEjCAGX/yNc+El48fvKj0483P0w5zWeR1t1W3zbe1e9l4iM8Pjxx3W7jlWIyiiPH3+cS5ZcQr2rPr79uhXXEQgHeLLnSRNHpxMv/Du8+h+K0nHZ55mOzLCzZyfXtF+D2+E27LKmChAp5U1SymYppUNKuURKebeU8vtSyu/H9ksp5SellCuklGdLKfckfPbHUsqVsZ+fFGK8dpudHct28Nyp55iNzEJZBXz4Xiirgns/BjOThRiGIcxEZnim9xl2LNtBie10BJLb4WZb6zae6XnmjDNjjc2M8erAq1y+7PI5EUgNrgbObTyXx44/ps+Fdn4DOnfCdd+Ftiydtu/4Gpz1Tnj0H+HkK3kPpWe8h6OjR7l82eVztrdXt9NR3XFmTKbz2Offhy/o44rlV8zZfl7jeTS4Gni652mTRqYT3c/Co/8Aa94F278IwIt9LxIMBxd8z3pjdROW5bhkySUEw0H29MdkWWUjvO+HMHQUHv6cuYPLgz39ewiEA+xYumPBvq2tW/EFfRweOWzCyIzjmd5niMgI25duX7Bvx9IdHB09St9kX34XOfEi7P4ObPoobP5o9p+32eDdd0Jlk6KkzE7lNZynep4CSHrP25duZ0//HiZmJ/K6htV4pvcZ7MLOJUsumbPdJmxc3HIxz/c9TyQaMWl0eTIzCX/4BNS2wXu+rzwvKN9zhaOCtzW9zdDLFwVIlpzfdD6ltlKeO/Xc6Y3tl8DWT8Nrv4CuZ8wbXB683P8ydmHnvMbzFux7e+vbAdh9cnehh2UoL/W/RHVZNesbFkYeXdB8QfyYnAkFlZe7eglc/Y3cz+OqhffepURpPfX/5n4elO+5raotaeTRRS0XEZGRM87f9XL/y6xrWEdlaeWCfVtbtzI2M8b+oaTFMKzP41+G0R54979B2en7e6n/Jc5vOh9HicPQyxcFSJY47U42NGxY+JJd+jlFC/jTZyA8Y8rY8mHPwB7WN6xPai/1ur2srFnJnoEzqxnXqwOvstm7GZtY+Bqsql1FTVlNfgLkue/BcCdc/z1w5pkztPxiOPdmeOHf4NTenE4RlVFe9b2aVEkAOMdzDnabnVcG8jeVWYVgOMj+of1sadySdP+FzRcCnLYoLCZ6X4GXfwQX/ndYdmF8sy/go2eih3Mbz03zYX0oCpAcOLfxXN4cepNgOHh6o8MF7/y2Ysp6/k7zBpcDgVCAA4MHUr5kABs9G3nd/zpRqW9IqVn4A35OTJxIec82YWNL45bcJ5bRHtj1bVh3A3RclvM453DlV8BdDw9/PqeorKOjRxmfHU85sbjsLs5uOPuMUhRe979OOBpO+T3XOmtpq2pjrz83oWwaUirReRWNsP1/zdn16sCrAGnfZ70oCpAc2OzdTFiG2T84b9m78nJYfQ3s/q6SMLZIeGPwDcIynFIzBUWATMxO0D3WXbiBGcgrPkXLPtebWkvb5N3EqalTDAYHs7/A4/+k/H7H13IYXQpctUqI5onn4a3/zPrj6soi3fd8XuN5vDn4JtPh6ZyHaSVeHXgVm7Cx2bs55THneM7hdd/riytI5MD90PMi7PiHOaYrUL5nt93NWXVnGT6MogDJATXkM6mt+PIvweyEkg26SDgwdABQXqRUbPIqdYMWnaaWgn3+fZSVlLGmfk3KY9Ss7AODB7I7+cAB2P87xbRQk1v5nJSc+5dQv0qxfUfCWX30Df8beFweWspbUh6zoWEDYRnmrZG38h2pJTgwdICO6g4qSitSHrPJu4mRmRF6JnpSHmMpIiF4/CvQeDZs+siC3fsG93G252zsNuMLjRQFSA5Ul1WztHIph4YPLdzZuA423gQv/RDGTxV+cDnw5tCbtFa0Ul1WnfKYtqo2qkqr2OffV8CRGceh4UOsrl2Nw5baybiufh02YYsLWM3s/CaUVsDF/0+eo0xCiQOu+DIMHoY3fpvVRw8OH2Rt/dq0RRNVofnm0Jt5DdMqHBw6yLr6dWmPOadBUZxe979eiCHlz77fKAEVO/4BbHOLfoaiIY6MHGFdXfp71ouiAMmRNXVrODh0MPnOSz8H0fCi8YUcHDrI2rq1aY8RQrCmbs0ZEcorpeTQ8CHW1KVefYCSA9NR3bHQVJmOvn1w8AFl9eGuy3OkKVjzLmjcoIQHayxzMh2epmusK+M9N7obqXPWnRECxB/w4w/6Mz7bHTUdOGyOxfFsR8KKdaPpHFh91YLdnaOdhKKhjN+zXhQFSI6srVtL72Rv8pj52uVKjaM9P7G8L2RidoITEydYW5/+JQNYXbuaIyNHFm/MfIyTkyeZmJ3Q9JKtq1/HgaED2u3ju7+tJJZe9Nd5jjINQsDWzyirkEN/0vSRIyNHiMiIJkVhbf3aM0KAHBxWFLxMz7bD5mBlzUreGl4EZrsD9yuRfZf+fdJSOOo9pzPN6klRgOSI6qBK+dC9/dMQmoKXDCjKpyOqGS7TxALKqms6Ms3xieNGD8tQsrnntXVrGZ4eZmh6KPOJR47Dm3+ELR9THN5Gsv49UNehaKMahJvWyRRgXd06jo0eYyay+MLRE3lz6E0EQpOicFbdWbw18pa1HelSKpF93nVKdYIkHBo+hMvuYnnl8oIMqShAckSdfJL6QUDxhay+RqlhNGvdYm2qGU7LxKIKzcPDi2Cpn4aDwwcpESWsql2V8diVtSsBJQQ2Iy/dBQg4//Y8R6gBWwm8/W+hby9078p4+KHhQ1SVVqV1oKucVXcWERmha6xLj5GaxsGhgyyvWk65ozzjsWvq1jA8PZxbxF2h6Hoa/AcV35ot+dR9cOggq2tXzylHZCRFAZIjHreHOmdd+miViz6pVGHd/7vCDSxLjo0do85ZR4OrIeOxHdUd2IU9tdBcJBwePkxbVRtOuzPjsStrFAFybPRY+gOnx+GVnykrg+oC9Zc454PKSuelH2Y89K2Rtzir7ixNXQdXVK8ANApNC3Ns7JgmJQEU8yxg7eizF38A7gZY/96ku6WUHBk5UjD/BxQFSF6sqFlB51hn6gPatoJnLbz8Q13LcetJ52gn7dXaegWUlpTSXtO+OJyNaegc62RFzQpNx9Y766kpq+HIyJH0B772cyV8+6JP6jBCjThcSljvoT/DWOp2OFJKuka76Kju0HTa5VXLsQt7ZqFpYWYjs/RM9Gh+tuOra6s+28NdSu7Plo+BI7ni4w/6mQhNaH629aAoQPKgo7qDrtGu1HZTIeD826Dvdei1XnavlJLOsU7NEwvE7nkRmzZmIjP0TvZqnliEEKysWZleG5dSCZhYcj60Gl8+Yg5bbgUZhVdSF6Qemh5iIjSh+Z4dJQ6WVy1f1ALk+PhxojIaX01loqq0igZXg3Wf7Zd/pJgtt/y3lIeoY9f6PetBUYDkQXt1OxOhifQO1nM+CKWVyirEYgxNDzE+O56VAGmvbufU1KlF62A9MX6CqIxmdc8ra1ZybPRYakXh+HMwdATOu1mnUWZB7XI46xp45acpa7B1jiqr5KwUhZqORS1Ajo0pY++oye7ZtqQACQWVFe7a66EqtQ9LtYZk8z3nS1GA5IH6RakvaFLKKmHTTXDg95YL6VVflqxesqp2ojLKifETRg3LUOIvWRb3vKp2FZOhSQYCA8kPePVnSuju+vfoMcTsedutMOVPWd5EvedsNNOVNSvpmehZtCVNuka7EAjaqto0f6a9ShEglovEOvRnmB6D825Je1jXWBfljnI8Lk9hxoX5HQmvFkK8JYQ4KoT4fJL93xFC7I39HBZCjCbsiyTse6CwI1dQX8i0fhCAzX8BkVnLOdNVDTPbFQhgTU1NA11jysSyvEp7mKM6CSW95+CIErp79o1QmjnaxxA6tkNVK+y9J+ludWJpdDdqP2VNBxK5aL/nzrFOWipaNAVKqLRXtzM+O87IzIiBI8uB136ulMRpS9/JUjVHawmU0AvTBIgQogS4E7gGWAfcJISYk38vpfyMlHKTlHIT8D3g/oTdQXWflPL6gg08gUZ3I+WO8swCpPkcpW5NihfcLDrHOrOeWNSJd7FPLC67S/Nn1HtOuurady+Ep5VS62ZhK4GNH4Kjj8P4wgZYnWOdtFe1ZzWxtFcpisLx8cWZ83Ns7FjWzmS1xa+lnu3RE9D5tFLzKkXorkrXWFdB/R9g7grkfOColLJTSjkL/BpI1/39JuBXBRmZRoQQtFe1ZxYgAJs+DKdeA1+K8icmkMvE4na4aS5vpmvcQi9ZFnSNdc3pBa4Fr9uLy+5KnkD52n9A80Zo2aTPAHNl44cVZ/q+Xy/Y1TmmPdJOZWnlUgBOTCw+U2UkGuH42PGsfQGWXF3vjU15mz6c9rDJ2Ul8Ad9/KQHSCiSWv+yNbVuAEGI50A4kNmx2CiH2CCFeEEK8O9VFhBC3x47b4/f79Rj3HNqr27WVOD/7/WCzw95f6j6GXDk+fjzryRQs7GzMQFRG6R7rznpiEUKwtHLpwhWI7xD0v6FM3mbTsBKWXgiv3TMnZHwqNJXTxOJ2uPG6vIvS19U31cdsdDYr/wdAc3kzZSVl1nm2o1HY+wul42mGqs7d491AYSOwYPE40T8E3CelTCzCtFxKuQX4MPBdIUTS9aqU8i4p5RYp5RaPR3/n0tKqpfgCvsxRSRUeWHWVUkkzyzLcRjAbmWVgaiCuaWZDW1Ub3WPd1nM2ZsAX8DEdmc6pzMPyquULzTlv/BaEDTYkT+wqOJs/okSDJYSM9070AmTl81FZWrV0Ua5A1LLs2T7bNmFjedXy+GRsOieeV0xYmz+a+dCYoM9WaOaLmQLkJJD4DS+JbUvGh5hnvpJSnoz97gR2Aqk7xhjI0sqlSCQnJ1IncsXZdBNMDiglCUymd7IXicxJgCyrWkYgHGB42lpRZZlQJ9Oc7rlyGb0TvYSjMeEvJbxxr9JtsMKr3yDzYd27oaQM9t8X36ROpsl6oGdiWeWyRbkC6Z3M73u2TF+Q/b8DhxvWJK97lYg65paKzKVq9MRMAfIysEoI0S6EKEUREguiqYQQa4Ba4PmEbbVCiLLY3w3A2wFTyoeqD6mmh27llUq454H7Mx9rMPlMpksqlMlIfVEXC/lMLMurlhOWYfomY07qnpcU7fDsD+g5xPxwVsGqK+HAHyBWMVn9nnMSIFXLGJoeYio0peswjaZnogeHzYHXnb1gX1K5hJMTJ81v3RwJw5t/gNVXa4ru653sxePyZBUcogemCRApZRj4FPAIcBD4rZTygBDiq0KIxKiqDwG/lnPtJWuBPUKI14GngG9KKa0vQBxOOOtaOPgghGcNHll68tFM1c+ok9NioWeiB5uw0VTRlPVnVRNQ3JH+xr1gd2rSDgvKhvfCZL+S3Ihyz9Vl1VSVVmV9qmWVit19sa1Ceid6aa1ozamg4NLKpcxGZ/EFfAaMLAu6nobAEGx4n6bDeyZ6clKM8sVUH4iU8iEp5Wop5Qop5ddj274kpXwg4Zh/klJ+ft7nnpNSni2l3Bj7fXehx65SW1ZLuaNc+7J3w3uVpKDOp4wdWAZ6J3px2V3UO+uz/mxrRWv8HIuJ3olemsub03YhTMWyKmUyPT5+XGkpeuB+JQPcmf3EbCirr1bMHrFVbu9kb3zFmC3qPS82P0jPRE9OihEkrK7Nfrb3369YK1Zeoenw3onenO85HxaLE92yqBE6mgVIx3Zw1igPiImoL1kuSUdOuxOvy2sdW7FG8plM6531uO1uZWLpeiamHd6o8wh1oLRcESJv/hEiYXonenPWTNUVyGL6nqWUeWnj8dW1mebZ8IxipVjzrpSFExOZiczgC/hyfrbzoShAdCArAWIvhbXvUsoThMwrE9Ez0cPSityXvEsqlyw+H0geWpoQgpaKFk5OnlRebke5Zu2w4Gx4HwSGCHc+yanJUznfs9vhpsHVsKiSCUdmRpgKTeUsQJormrEJm7lC8+gTMDOm2Xx1cvIkEllcgSxWllQu4eTkSe2tXte/Vyn9ffRxYweWgqiM5qWZQkyAmL3Mz4Kp0BTD08N5vWStFa2cmjypCP/V79CkHZrCyiugrIqBN35DWIbz0kyXVCjP9mIh1xBeFYfNQXN5s7nP9oHfK31eOi7VdHg+ATH5UhQgOrC0cimhaEi74639UnDVKWYGE/AFfMxGZ/MWIJryXyxCPtFIKi0VLZwa74EpH6y9Tq+h6Y/DCauvoue4Ei6ez/fcXNHMqclTeo3McPIVIKAITdNW15EQHH5EaVlbos1Xl09ATL4UBYgOZBWJBVBiVxywRx5RHpgCo4fGsqRiiZL/ski003xCeFVaK1qZiAQZs5fBqnfoNTRjWPNOeqNKK+V8V10DUwPaV9cmoz7baqBHLpi6uu7erZivsojuyycgJl+KAkQHWsuVh/XUVBaa2lnXKtFYx581aFSpUSfTfCYWdSJeLGas+AokD3NOa6yf+Kn2C5Uy/VZm5RX0OMqwI7IqljmflooWwjKMP6h/GSAj6J3oxevyZlWFdz5LKpcwPD1sTv7LoT8rUXQrtmv+iBq2XMgqvCpFAaIDjeXKCxpPMtPCih1gd8GhhwwaVWr6JvsQCJrKs8+HUFlsuSA9Ez1UllZSXVad8zlapicBONVqcuFELZRV0lvTTGtEUiJyf81bYkJzsaw0+6b68s7GNu3ZllIRICt2KO2KNdI7aU4ILxQFiC6UlpTicXnom8pCgJS6lQfl0J8L3i+9b6qPBlcDpSWlOZ+j3llPqa00u3s2kVOTp/IOc2zteQWA3ppmPYZkOH3OclpmgzBwIOdzqJPxYvGD9E310Vye3/ejWhQK/myfeg0mTinhuxqRUjEj52Oyy4eiANGJ5vLm7ExYAGuuhfFepWd6AdHjJRNC0FzRvGgESN9UX14rLoCqtx6hAsGpmdHMB1uAPjlLcziiKCk5oj4ni0GARGWU/qn+nCoNJNJcodxzwZ/tQ38GUQKrr9L8kfHZcYLhYN7vc64UBYhONFc0Z2fCAiXhS9jgrcKasfqn+uMvST40lTctGgHSP9Wf30s23IkYPExLWd2imExnI7MMTg/T5G6GQ3/K+TxOu5N6Z332ypEJDE8PE4qG8p5M65x1OGwOcwTI8ovBXaf5I+oYiwJkkdNS3kL/VH92RdjKG2DZRXlpiNkipdRlBQLKQ9s/2a/DqIxlYnaCydBkfvd8+FEAWmtWLooEyoEppX97c/O50L9PKfyYIy0VLYtCaKoKXL7Ptk3YaCpvKuyzPXQM/Aezrq3WP6WMsShAFjlN5U3MRmezL3F+1rUwsB9Gug0Z13yGp4eZiczkbc4B5aH1B/2ETAhFzgb1Jcvrno88AvWraK1bxanJU5bvhdIfiE0s7TuUDYcfyflci0WAqKskvZSjgq5A3vpP5fdZ12b1sfgKRAeLQi4UBYhOqM7GnMxYAEce03lEydFTY2kub0YiGQgM5H0uI1FfspwFyMykEp+/+iqay5sJhAOMzYzpOEL9iU8sLVugtj2v56ulvIW+qT7zS5xnIP5sL0bz7JFHwbMGarNr/NU31YfdZqfOqd3spSdFAaITcWdjtrbi+hVQ21awsibqS6FH4xnTnI1ZkrfQ7HoaIrOw6h1xIWR5oRlTZBrLG5Wkx65nIBTM6VwtFS2EoiEGg4N6DlF3+qb6KHeUU+nIP0cnvrqOFmB1PTOplN9fdWXWH+2f7KfJ3YQtj1DtfCgKEJ2IT6bZrkCEUF7wzqcLUlxRT6ebeg51grYqfVN92IWdBldDbic4/DCUVsKyi+ICZDHcc52zjrKSWNZ8OAjduSWtLpZQ3r5JxbenR0JdS0ULURnFHyhAAmXX0xAN5VTdoG+qzzTzFRQFiG5UlVZR4ajITRtXX/Dju/Uf2Dz6pvpw2V05NRiaj5rhvBhWII3ljTk1GEJKxfyzYjvYSxeNAJkTddb2diVp9cijOZ1LPY/Vv2c9QrVV1PMU5J6PPAalFbD0wqw/2h/IM7owT0wVIEKIq4UQbwkhjgohPp9k/y1CCL8QYm/s57aEfTcLIY7Efm4u7MiT01TelFu4Y9tWpbvdEePNWHpqaU67kzqn9cNa+6b6ci/n0b8PJvrivqp6Zz12Ybe+CSsx0s7hgvZLlECAHJz/cbPdlPXvWc2cz5eCCU1VQem4TGn1kAXhaBhfwKeb0MwF0wSIEKIEuBO4BlgH3CSEWJfk0N9IKTfFfn4U+2wd8GXgAuB84MtCiNoCDT0lLRUt2ZuwQHnB27blrCFmg14hvCrN5c2LQxvPdZkfC99V7dMlthI8bo+l71lKqSTUJU4sq65UIv2GjmV9vgpHBW6729JCMxAKMDozqps5p2ArTd9BJZk4B/+HP+AnKqP/ZVcg5wNHpZSdUspZ4NfADRo/exXwmJRyWEo5AjwGXG3QODWTUza6yqorYfhYTi94NuhtM22paLG0aSMSjTAwNZD7S3bkEWg5Fyq88U1N5U3xMFkrMj47TiAcmHvP6gSVg5IihKCxvNHSAkT9PvTSxl12F7VltbkphNlwNBYdtzJ7AZJ3dKEOmClAWoHE+ue9sW3zeZ8QYp8Q4j4hhFqLW+tnEULcLoTYI4TY4/cb6xBrKm9iYnaCQCiQ/YfV7nYGRmNNh6cZnh7WVWNRwx2tmhcxGBwkLMO53XNwBE6+sqDzYJO7ydIrkKThrLVt0HBWzqvcRnejpU1YatKfEc+2oRx5DLzroTr7WlZmZ6GD9Z3oDwJtUspzUFYZP8v2BFLKu6SUW6SUWzwej+4DTES1s2tuLJVI/QqoX2moGUvVIPU2YQXDQcZnx3U7p57kpZl2PQMyCisvn7O5sVyZTK0qNFNOLKuuVNoHzExmfc5Gd6OlV11GTKaGJxNOj0pdz3kAACAASURBVMOJ53MyX4FOCbJ5YqYAOQkkdvdZEtsWR0o5JKVUW979CDhP62fNQBUgOS/1V16pJKzlGK+fCSOWvFaPSsrrno89qYTvtp43Z7NadWBkZkSPIepOynteeYWSz5JDD5rG8kZlNRcN6zFE3emb6sMmbHjc+imJTeUGrzQ7d0I0nLMA6Zvqo6q0inJHub7jygIzBcjLwCohRLsQohT4EPBA4gFCiER14nrgYOzvR4B3CCFqY87zd8S2mYrXrdjJc1qBgKLphqcVrcQAVBNEk1s/AaLes1Xt4zmbNqRUBEj7JQtai6r/f1YWmg6bY2F28rKLlGi/Y09lfc6m8iaiMmrZZMKBwAANzgYcNm1tYLXgdXuZDE3mZpLWwrEnFAVl6QU5fTzvAqE6YJoAkVKGgU+hTPwHgd9KKQ8IIb4qhLg+dtjfCCEOCCFeB/4GuCX22WHgf6MIoZeBr8a2mUrek+nyi8HmyOkF14LaVU5PLS3vVZfBxLOTS7PMTh7uVAoQJukMpzYQs6pPoH+qn0Z348LsZIdTESKd2T9f6vdsVaHpD/h1fa6hAMrRsaegfZvm3ufz0TPvJVdM9YFIKR+SUq6WUq6QUn49tu1LUsoHYn9/QUq5Xkq5UUq5XUp5KOGzP5ZSroz9/MSse0jE7XBTWVqZ+8RSWq5oIzm84FrwBXxUllbm1e5zPvWuegQi91WXwfiD/txyQI49qfxesWPBrrjZzqI+AX/AH5/8FrBiO/gPwXh20YJWVxT8Qf0FSF4+zUwMd8HocSX/I0fSfs8FwupO9EVHozvPcMcVl0H/GzClv6nAH/Djden7wDlsDupd9ZYVIL6AL7eJ5dhTULMM6joW7Kpz1mG32a2rjQfTTCwdsRVV586szmn1ZEIjnm11pWnIs63+/3do732eSCgSYmRmRHehmS1FAaIzje7G/B64jpjGm+ULrgVfMMfJNANet9e6mmnAj8eV5T1HQtC9S1l9JMnYtwmbEpVkUQGSVmg2bgB3Q9Zm0qrSKpwlTkt+z7ORWUMmU0NNWJ1PQWULNKzK6eOqL0pvoZktRQGiM3knXLVsAme1IWaswcCgIUvevIWmQUgpczNtnHwFZsaTmq9U8l5pGsRUaIpgOJh6YrHZFLNJ586sypoIIWgqb7LkPccnU52fbZfdRWVppf7PdjSihIiv2J5UQdGCL6iMqbgCOcPwur0MBYdyLwNtK1Eif47tzKluUSqklMoKJFttXANet9eSAmRsZoxQNJS9lnbsSaXVcPslKQ8xPMQzR9TvIe3EsmI7TPlg4EBW57ZqMmH8ng14tg1Rjvr3KUmqHZflfAq1SnDRB3KG0ehuRCIZDOThw+jYrtTH0bGsyejMKOFo2BCNpdHdyNjMGNNh48vRZ0POWtqxJ5XcD1fq8mrqxGK1ZEJNE0vcD5LdKrex3JrJhGp0oRGTqdft1V9oqubD9ktzPoWRQjMbigJEZ3Sxm3ZcpvzW0YylPnBGvWSJ17AKOWlpwVHFhJXBuel1ewlFQ5brTBgXmukmlupWaFidtR+k0d2IP+AnEo3kM0TdUZ+7nPu9pMGQ1XXnTqV8SWWOFaJRhKZd2Kl1mltDtihAdEaXcMe6DiUCSMd8kHgOiEEmLLBeiGdOWppaviSN/wNOr2rUCdsqqEIz46qrY7vSBS+LJmaN7kYiMsLQ9FA+Q9Qdf8C4ydTr9jI4rWMGfigIJ17Iy3wFyrNd76o3rROhSlGA6IwuseNCKC949y6I6PPgap5YcsDQePk8yClxsnsXOMphyZa0h6lCsyAd67LAF/Dhtrszl7dYsV1pYtbzouZzq2GtVvP9+IN+GtwNhkymje5GojLKUFAnoXnieYjM5C1ABoPGBMRkS1GA6Ex1WTVlJWX5201XbFcigU69qsu4jLSZWtWE5Qv4qCqtUtq6aqV7Nyy7MGN2sPr/aLV7TpsDkkjbVrDZswoXjwvNoLWEphE5ICq6P9udO5VqE8svzus0voAxATHZUhQgOiOE0Mdu2n4pIHTLB/EH/dSU1VBakl3XMy1UlCoNh6w2mWatpU0Ngu9NZXLNQNyEZbF71lzSo6xS6XPSvUvzua266jIiC13FEAGy9Hwoq8jrNEbeczYUBYgB6JIj4K6Dpg2KTV4Hcs7I1ogVkwmzTiJUq9RqECBlJWXUlNVYTxsPZnHP7dvg5KswM6Hp8NqyWkpEieWEppHauK7+vakh6NuXc/a5ykxkhrGZsaIJ60xFt8m07RLoeSkrR2cqjFzmg2Ift9zEkm3mffducLihZbOmwz1uj6XuWUqZXX2ktm0gI3BcW/XnElsJ9a56SwnN6fA047Pjhk2matkaXb7n7mcACR25h+9Cgj+zaMI6M1En07xzBNq3KQ633pfzHpPRS16rZaNHZTT7zHuN/g8Vr8trKXPORGiC6ci09nDWpRdASWlsYtOGx+Wx1D0bUWE6EZuw4XXpFMrbvVsJ0NCooKTC6HvOhqIAMYBGdyOhaCj/hkPLL1YyorOwUydD7eNgpMbidSuTaVRGDbtGNoxMjxCWYe2T6dSQZv+HisftsVQYb9Z5L6VuWPI26NL+fHncHkutQOL3bODqWjeLQvezWSkoqSiuQM5w1Ekrb03NWQ3NG7N6wZMxPD1MREYMtZl63V7CMszwtOltWYAcspPj/o9tmq/hcXkYCg5ZJrEup0i7tm3Q97pSWkMDVlt1qQK8wa1/EqGKLkExk37wH8xKQUmFkZn32WKqABFCXC2EeEsIcVQI8fkk+/9OCPGmEGKfEOIJIcTyhH0RIcTe2M8D8z9rJuoXq0v3trZtiglrNveuaEbmgKhYLZkway0tS/8HKPcckZHFKzRBMZMilaRCDXjcHkZmRpiNzOYwQv0p5AokL5N0FgEamfAFfNhtdmrKavI+V76YJkCEECXAncA1wDrgJiHEunmHvQZskVKeA9wH/J+EfUEp5abYz/VYCHUFoovdtP0SiIaySviaj5FZ6CrxZMIpa5h0sp5Ms/R/JJ7bKmYsdTLNqqTHkrcpbW41rnJ1VY50wB/w47A5qC6rNuwaje5GguEgk6HJ3E9y/NmsFZRUqAExIsdKvnpi5grkfOColLJTSjkL/Bq4IfEAKeVTUkpV9X4BWFLgMeaEOlHr8pItuxBESV5+ECPrYKmo92wV+3hW9ZGmhsB3IGvt0Gp5Ef6gn0pHJW6HW/uH7GWKM13j82W1BEo1cdLIyVRduef1bOegoKTCF/QZarLLBjMFSCvQk/Dv3ti2VNwK/GfCv51CiD1CiBeEEO9O9SEhxO2x4/b4/YV50Z12p359BMoqofXcvPwg6gRX76rPfzwpUFvbWkWA+AN+astqtSVO5uD/AOtNpjnn+rRvg4H9iiDNgC6TqY7k1DAsS+LKUa6KghqgsfztuozH6JD8bLCbPQAtCCE+CmwBEgOol0spTwohOoAnhRBvSCkX1D+XUt4F3AWwZcuWgtXe9rq8+i3z27bBc3fAzGROGay+oI86Zx0OW/7aTyrsNqWYnVW08ay0tBT+j1AoRG9vL9PTyfNwpJR8d913qZyu5ODBg/kOOW/eU/UeRJXIOBan08mSJUtwOGLPQ1us70n3LlifUhcDdJhMdcYX9LGyZqWh11Cfo5yFZo4KSir8QT8XNF+gy7nyxUwBchJYmvDvJbFtcxBCXAF8EbhUSjmjbpdSnoz97hRC7AQ2A/o10MiTBneDfrbx9m2w+9tKFc9VV2T98aySy/LA69ZRaObJYGBQu5aWwrzQ29tLZWUlbW1tKU0kJcMlVJRW0FqRbvFcGA6PHMZtd7OkMrWlV0rJ0NAQvb29tLe3Kxtbz1XyEzQIkFpnLXZht9QK5OKW/OpKZUJ9jnLu8ZNDgEYqguEgE7MTlojAAnNNWC8Dq4QQ7UKIUuBDwJxoKiHEZuAHwPVSSl/C9lohRFns7wbg7cCbBRu5Brwub35NpRJZeqFSgC2LhK9EClV4rcHVYB1zjtYs9DT+j+npaerr69Pa1+02u36lvvNASkk4GsZuS68TCiGor6+fu6oqcSgCVIOZ1CZsinJkge85EAowGZo0/Nkud5TjsrtyVwi7dyt+Jnv+dejUOcUKOSBgogCRUoaBTwGPAAeB30opDwghviqEUKOq/i9QAdw7L1x3LbBHCPE68BTwTSmlpQRIg7sBf9CvT8e6UrdSXjxHP0ihSj97XB5LrEAi0QhDwSFtL1kG80Im56zD5rCEAInICFJKTWbKpPfUfgkMvgUTmcOwrZILUqh8CCGE8mznohDGFRR9/B9W6YWuYqoPREr5EPDQvG1fSvg7qb1GSvkccLaxo8sPr+t0x7oapw7x2m3bYNe/wPSYkmCokXA0zND0UEEeOI/bw9C0klhXYisx/HqpGJkZ0Z44mad5wW6zEwjnnqOjF6oQy7QCSUl7TIB274Kzb0x7qMft4fj48dyuoyNGdiKcT4OrITez3YlYfo1e/o8C5L1kQzET3SDydrzNp32b0ilPY+E7leHpYaIyWpAlr8flISqjpifWxTOytQhN1byQY3il3WYnEo0YVsKlpKSETZs2sWHDBq677jpGR0eTHqcKkGgoygc/+EFWrlzJBRdcQHd3t7YLNW2EsipN1Z89LmsUkcypZXGO5FzCpXs32F1K6XwdyOrZLgBFAWIQqoag21J/yflQUpZ1efdC1s2xSoin5nvOMf8jEdVkZJQZy+VysXfvXvbv309dXR133nln0uNC0RAAP//pz6mtreXo0aN85jOf4XOf+5y2C5XYldprGvJBPG4P47PjTIfzrxKdD4UsKphzEcnu3Ur/Dx38H6CYo0ttpVSVVulyvnwpChCD0D2xzuFUHsQsHemFSCJU0TWBMg8028Z1CK9UTUaF8INcdNFFnDypBCoeO3aMq6++mvPOO49t27bFQ3f/9OCfuPnmmwG48cYbeeKJJ7T74dq2wXAnjJ9Ke5hlvueAH2eJk0pHpeHX8rg9BMIBpkJT2j8UGIaBA7qZr+B0cIgVstBhkeSBLEZ0N2GBoinv/KZS+M5Vq+kjhdbSwPzEOs2Jk1n4P77y4AHePDW+YHtURpkOBymzj1AisvP7rGup4svXrdd0bCQS4YknnuDWW28F4Pbbb+f73/8+q1at4sUXX+R/fPp/8KP7f8Spk6dYulSJjrfb7VRXVzM0NERDgwY/gboS694N53wg5WGJrW3ThQwbTSEn08T8l/LqDP3mVY4/B0hd6l+pFCokXyvFFYhBuOwuKh2V+kartKmF77T7QXwBHzZho85Zp984UhCvQmyyCUtz4uTxZ/MOr1QnL2mQDyQYDLJp0yaampoYGBjgyiuvZHJykueee473v//9bNq0iY9//OP09/djL8lTH2w6WwnQyGDGsko730JkoavkZJ7t3q3UGWvVx/8B1umFrlJcgRiIGsqrG63nKQ9k925Yc62mj/iDfuqd9blH52SBo8RBbVmtfvkvOaJJSwsMK+U7dvyjpnOmWilIKTk4fJB6Zz2N5Y3ZDjUjqg8kEAhw1VVXceedd3LLLbdQU1PD3r1748d1jnZiEzZaW1vp6elhyZIlhMNhxsbGqK/XWMLGVqKU2+jenfYw3f17OeIP+llbt7Yg18opA/+46v8o020c/qCfra36rWjypbgCMRDd4+UdTqV6ahZ+EKN7oc9H1wz8HNGkpelUXkIIgV0Yn0zodru54447+Na3voXb7aa9vZ17770XUITY/n37cdgcXH/99fzsZz8D4L777mPHjh3ZmXjatip+kLEFRSHiVJdV47A5TP2epZQFfbazXl0HhqF/v67+j0BI8cEUImxZK0UBYiC6r0BAeSD79ysPqAYKXXhN1wz8HNHUvlfH8hJ2mz0eBWUkmzdv5pxzzuFXv/oV99xzD3fffTcbN25k/fr1PPrQo9htdm699VaGhoZYuXIl3/72t/nmN7+Z3UUS/SApUBPrzFyBTIWmCIaDBXu2q0qrKCsp0x44cOJ5dPd/WKiRlIpmu4YQwp1QWr2IBtQViJRSP0df21ZAKg/omndmPNwf9HOO5xx9rq2BBlcDR0aPFOx68wlHla6IGVcgOpaXsNvszEaNabA0OTm3B8WDDz4Y//vhhx8GlHt+a/gt7DY7TqczvjLJicYNp/0gGz+Y8jCzW9sWOiNbCJFdqZ64/+M83cZgtRwQ0LACEUJcLIR4EzgU+/dGIcS/GT6yM4AGVwOz0VnGZxdG7+TMki2n/SAZCEVDymRawAfO4/YwHBw2rTe6mjiZVktT/R86aYcOm4NwxLxyJqr5TJdqy7YSWL41oyPd6za3nIkZfcGzKhbavTvWrEtH/4fFstBBmwnrO8BVwBCAlPJ14BIjB3WmYEjDIXtZLB8kc8LXUFDp71DIl8zj8hCWYUamtfXY1htNE4vO5bXtNjsRaVw2eiZU85lugRJtW2GkG0Z7Uh5idjZ6IcPTVTSXMwmOQP8buvo/wJx7zoQmH4iUcv6TFDFgLGcchoW1avSDFDKJUMXsbHRN96yj/wMKm0yYjLzrYM1HXZmpgjYJHreHydAkgZA5Vu1CljFR0ez3Oa76P/QpoKjiC/hw2V1UOLLvCWQUWgRIjxDiYkAKIRxCiP+JUj23SAYSE650RfWDHH8u7WFmLPPNbjikSUvTubyEajoqhCM9GbqvQBo3gLMmbfVns3uj+wI+3HY35Q6NSX06oArNYDiY/sDjzyplh1q36Hp9f8BPg6vBMlnooE2AfAL4JEq72ZPApti/i2QgvgLRezJNzAdJgxmln9VrmTmxCETqxEmd/R9gjRVIia0Em9ApqNJmU/5/0phJzU4aVXuhF5J4CZdMUYbduxQFxeHU9fr+YOESJ7WS8YmTUg5KKT8ipWyUUnqllB+VUmZunlwEt0PRkHR/yeJ+kPQCxB/wUyJKCpKFrqJOLGbZxweDg9S70iRO6uz/AGsIEN0TRdu2wuhxGD2RdLfZyYT+gIZQbZ2Jl+pJl/8SHIW+fbr1P0/EDKGZCS1RWD8RQvx4/k8hBncmYFi8fNs2RZNO4wfxBXw0uBr000w1UFZSRnVZtak+kLRams7ltQFKRAlCCENMWFrKuYej4bgZ7dvf/jbr1q3jnHPO4fLLL+f48Rz7dqgCtju5H8TsciZmlPTQ5N878QJ6539A4RMntaJlZvkT8OfYzxNAFTCZ9hMaEUJcLYR4SwhxVAjx+ST7y4QQv4ntf1EI0Zaw7wux7W8JIa7SYzxGYFi8fLwuVmo/iFkai5mdCTPec/duWKZP/oeKEMKw1rZayrmHoqH4CmTz5s3s2bOHffv2ceONN/L3f//3uV3Yu04p2JnCjKUm1pmhKEgpTTVhpVUIu3cp/o8lb9P12oVOnNSKFhPW7xJ+7gE+AOTtHRJClAB3AtcA64CbhBDr5h12KzAipVyJEk78z7HPrkPpob4euBr4t9j5LIdhK5DWcxVNOo0ZyyybaYOrwTTTRlotzQD/h0oheqOnKuf+4Ws/TNfhLgC2b9+O2+0G4MILL6S3tze3i9lssbpYyQWImlhnhgAZnx1nJjJT8GdbLeGS9p67dyu5Wjr7P6zWylYlF8PpKkAPMXg+cFRK2QkghPg1cAOQ2Nv8BuCfYn/fB/yrUEIQbgB+LaWcAbqEEEdj58uuXV8B8Lg88d7oukZPaPCD+AN+zvXqZ6rRitft5eX+lwt+XTVxMqWWlo//4z8/r8T2p6AlMq3kgdjd2s/ZdDZco63USKpy7m0r2rjvsfv4wt99gV075072d999N9dcc4328cynbRsc+hOMHIfa5Qt2m5VMGI8uLPBkmrE3+vQY9O+DSz6r+7XNiKjUQkYBIoSYACQgYr/7AY1tztLSCiTml/QCF6Q6RkoZFkKMAfWx7S/M+2xrivHfDtwOsGzZMh2GnR0et4eZyAwToQn9u4i1bYOnvqZo1u65jvLZyCyjM6PmrUCMEJoZUBMn1V4sC+h+Vnf/h4oQQnvjpixQy7mfPHmStWvXLijnHpVRZiOzyPDca//iF79gz549PP3007lfPN4nfXdSAeJxeTg8cjj38+dIPFTbjGc7XbHQEy8obacNWOFaMYkQNAgQKaXx7b4MREp5F3AXwJYtW/R/wzOQaDfVX4AkJHytvW7OLjMLr3lcHsLRMKMzo9Q6tTW+0oOMpR7y8X9kWCmMB/z4Aj7W1K2hxKafNTVTOfeJ2QlOjJ+gvbo9/pnHH3+cr3/96zz99NOUleVRSsOzFlx1yv/b5o8s2O11e3n2VOpkQ6Mw+9nuHutOvrN7F5SU6u7/AHMSJ7WQ0gcihDg33Y8O1z4JLE3495LYtqTHCCHsQDVKSRUtn7UEhmZmt56X0g9i1jI/8ZqFto+ntRMb6P+AhN7o0hg/SKpy7qFoCCklb76hWH5fe+01Pv7xj/PAAw/g9eY52dhsSjZ1CjNpg6uBqdBUwbPR1cgvM8qaqybppHTvVpIHHS7dr2tG4qQW0jnRv5Xm5190uPbLwCohRLsQohTFKf7AvGMeAG6O/X0j8KRU7AQPAB+KRWm1o/hlXtJhTLpjaGa2vVTRqJO84PHKnSYs883KRk+rpcXbi+pbn0ilELkgycq5b3vbNm7YegN/fvDPAHz2s59lcnIy3q3w+uuvz++ibZfA2AmlNtY8DKu0kAF/wE+loxK3Iwt/k0543B7GZ8eZDk/P3TE9Dn2vG6agWDEHBNKYsKSU2428cMyn8SngEaAE+LGU8oAQ4qvAHinlA8DdwM9jTvJhFCFD7Ljfojjcw8AnpZSWrM9l+EvWthWeXOgHMXuZnziGQuEL+CgRJdSWJTGbGZD/kYhRAiRTOfdTk6cYnx1nTd0aQDFf6Upif5Datjm7EnNBllct9JEYhaZ+LwYRz0YPDs7tB2+g/wPMSZzUgqYoLCHEBpRQ23hsmpTyP/K9uJTyIeChedu+lPD3NPD+FJ/9OvD1fMdgNPFsdKO0cVWjnucH8QV82G12aspqjLluGlQndqFzQfxBP/Wu+uQ+CAPyPxIxqx5WYhKhIXjWgLs+5gf56JxdZmWjm5lQl1iqZ44A6d4FNoch/g9Q7vlsz9mGnDsftGSifxn4XuxnO/B/gDzXxf+1MLT0dUssH2Re4Tu1E6EZhddcdheVjsqCZyn7AynyXlT/x3LjeknbhA0hRMHLmSQmERpCvC7WbpgXZaYqCmaYsMxKqIuXM5n/bB9/Vsn/KNXfrCalZDA4aLkkQtCWiX4jcDnQL6X8GLARxZldRCNet9e4lyyFH8QXNLfsgcdd+Gz0lKaNuP/DOAFiZDZ6OgxfgYCyyh3rWeAHqXRU4ixxFnQFIqU09dlOGiAyMwGn9hpS/wpgIjTBdGTakiYsLQJkWkoZBcJCiCrAx9wIqCIZ8LgNbr7Ttg18B2DqdI3LwcCgqU43M3pmp9RMVf9Hq7FJlQ6bo6ACREppTCHF+aToky6EUJ7tdMUFdWZ0ZpRwNGxaQl1NWQ12YZ+rHJ14AWTkdN6Mzlg1hBfSh/HeKYTYCrwkhKgBfgi8AryKBTO+rUxib3RDSPSDxPAFfaaEOao0uAtb5mI2MsvIzEhyLS3e/0O/9qLJsNvsBfWB6N5IKhWeNeBuSBrtV2hFweyEOpuwUe+qn6sQxv0f5xtyTTMjKjORbgVyGPi/wLuA/wW8CFwJ3BwzZRXRiCG90RNp2ax02Iu94MFwkInZCVM1FsOF5jxUjXDBPcfzP4zRDhMptAkrLkCEwQJEiNP9QeZ9n4U2VVpBG1/QG12tf2WA/wPMjajMREoBIqX8/6SUF6H0Px8Cfgw8DLxHCLGqQOM7IzCkN3oi9lJYetoPotbqMVNjMVxoziOlllYA/4eKw+YgKqNEovpFlKcr566udhJ9ID/96U/xeDxs2rSJTZs28aMf/UifgbRthfGTMNI1Z3Ohe6NbQRtvcDWcvufpcUP9H2Bu4mQmtFTjPS6l/Gcp5WbgJuDdwCHDR3YGEY+XN9JW3LY15gcZtETlzrizsUDmjZSmjQL5P8CYXJB05dzVrPf5JqwPfvCD7N27l71793LbbbfpM5C2hLpYCXjdXgLhAFOhKX2ukwGzTVgwr11Bz4uK/8NABWUwOEiFo8KUxMlMaAnjtQshrhNC3AP8J/AW8F7DR3YGUZB4+fZLlN/Hn81cE6oAaOrepiMpq5V274albzPc/wGnTUlGmbHml3O/8bob+cDlH2DHZTs4dMhgnc5zFpR7FoSLF1pR8AV8VJdVU1Zi/PeZCo/bw+jMKLOR2dP+j6XG+D/A3LyXTKQ0ngohrkRZcVyLUibk18DtUsrCqBpnEAWJl0/wg/iWKwlHZj50qtmuUPZxf9CPXdjnFm8MDMPAG7D9H/I+/z+/9M8cGk4/SUdllGA4SFlJmSbH9pq6NXzufG2FrZOVc//Kt76Cd5mX0SOj/PVf/zVPPvkkAL/73e945plnWL16Nd/5zndYulSHoMm4HySWDxLLL0qsOtBW3Zb/dTKQMtengCRWl2jtflapSVdqXI0qK9xzKtKtQL4APAeslVJeL6X8ZVF45IbL7qKy1ODEuhIHLLsQunfjD/opKynTv/pvFhS6N7ov4KPBPa99rxqVZlB45XzUpE2JfoEDajn3pqYmBgYG5pRz//hffpz3XPoePv7xj9PX1wfAddddR3d3N/v27ePKK6/k5ptvznCFLGjbChOnYLgzvqnQrW2tUBMqLjTHjsOp1wz3r1nhnlORrhbWjkIO5ExHjUoylLat8MRX8Y330OBqMCULXcXtcBc0G90X8C002XXtUlZlOtS/0rJSkFJyaPgQtc5amsqb8r4mpC/n/uAzD+KwOVhWdbrPTX19ffzv2267LfeWtsloi5lJu3dD/Qqg8OVMfAHfnNL1ZqBO5r4Tzxnu/7BqL3QVLYmERXSgIAlXMUenf7STRnejsdfSQCE71vkDSbS07t1KdJpB9a/mo2ajG5ELkqyc+4O/fxC7zY6UktdfqhLGOAAAIABJREFUfx0gvhIBeOCBB1i7dq1+g2hYBeXeOW1uyx3luOyuguT8RGWUweCg6c923ITV/5rh/o/RmVFC0ZAly5hAUYAUjIJMpi2bwVGOPzBgCY2lkFnKC8pbTA0qUWkFCN9NxMhckMRy7j//xc+57+f3ceVFV7J+/Xr++Mc/AnDHHXewfv16Nm7cyB133MFPf/pT/QYw3w/C6TavhVAUhqeHiciI6c92TVkNdpsd38hRw/0f6gp+0ZmwiuiL2ogmKqNz7fR6UuJALr2AgfBRtlrA6eZ1e3mp3/g2LUkTJ+P+j0sMv34iDpuDYDio2/lSlXOfjczyg9/+gJaKljmBA9/4xjf4xje+odv1F9C2FQ7cr/hBYmasQikK8cnUZG1cCIHX2YBvvBPWvMvQa1k5iRCKK5CC4XGfbvNqJFPLLyAooNFufucyr9vLYGCQqIwaep2kiZNdu8BRrqzKCoi6AjE6A79gZUzmowrkrmfimwri38MaWegq3hIn/hKb8Q50EzuLaqEoQAqE4dnoMXyN6wDwTA5lONJ4PC4PYRlmZHrE0OsMBAaU6yW+ZN27lKi0EoMr1c7DbrMTlVHDhaYqQAyvxDuf+pVQ0TgnodDjVlbXRgtNKyTIqnhCIXx2u6H+D7BG5n06TBEgQog6IcRjQogjsd8LWsgJITYJIZ4XQhwQQuwTQnwwYd9PhRBdQoi9sZ9Nhb2D7ClUlz5fhdKV0Dt03NDraCEerWJwJFZ8ma+aNib94D+kS/hutpNivDe6wTWxVEd9LiuQvCb6JH4Qj8tDMBw0PBvdF/AhENS76jMfbDDeqWF8doeh/g9Q7rmmrIbSksIEgmSLWSuQzwNPSClXAU/E/j2fAPCXUsr1wNXAd2NVgVU+K6XcFPvZa/yQ86NQGbv+GUXb9/btN/Q6WihUz+y4bbw8JkDUKKE8Cyg6nU6GhoaymnDVCd3oqrzhaBghBCUiSffFNEgpGRoawul0Zj44FW3bYLIfho4CBSrVg/Lu1LvqC7/qms/MBN6xfqaENF5oBn2WMNmlwiwn+g3AZbG/fwbsBOYE2kspDyf8fUoI4QM8gLFOBINI2clMZ+JLXv9hRROvMD8b3fAVSMCPs8RJpaNS2dC9G0oroDm/hemSJUvo7e3F79cuAMPRML6Aj+myaUNrF41OjzITnUH4ss/1cTqdLFmyJPOBqYjXxdoFDavmmGc7qjtyP28GfAGfNUw5J17EE1YUBH/AT3m1wVnoFjDZpcIsAdIopVQD1vuBtIHdQojzgVLgWMLmrwshvkRsBSOlnEnx2duB2wGWLVuW7JCCUFpSSk1ZTUG08YoSF24p4fhuWP8eQ6+XjnpXPQJhvNCMhfDGEye7d8Gyi6Akv8fb4XDQ3p5d0logFODDv/wwnz7309y69ta8rp+O2x69jWA4yD3X3mPYNVJSvwIqmhRBveW/Fc48G/DplqCZF8d3440tSn0Bn6ElXPwBP6trVxt2/nwxzIQlhHhcCLE/yc8NicdJxT6Q0kYghGgGfg58LNYZEZQyK2uAtwF1zFu9zDv/XVLKLVLKLR6PuZLc8M6ExMoeVDQpGniSBkCFxGFzUOesK8iqK66ZTgzA4OGClS+Zj9vhptxRbngNMH/Ab15CnRDK/2/MD1Iw82yqlsWFpns33nolQdNIs10kGmFwetAa95wCwwSIlPIKKeWGJD9/BAZigkEVEEm/hVgL3T8DX5RSvpBw7j6pMAP8BDA2FEInChHuqJQ98MbrYpmNof3gY8zJQo/7PwqbQJhIIXpkmF5gr20rTA7A4BHKHeW47W5D7zkUCTE8PWy+P2BmEk6+ineZ0v/DyHsemh4iKqOm572kwywn+gOAWuXtZuCP8w8QQpQCvwf+Q0p537x9qvARKP1JzPcYa6AQCVfxmlBtW5VIpMnC9iWfj9GrLinl3GJz3bugrAqaNhp2zUwYLTQDoQAToQlzNdNEPwjG33O846TZk+lxpf5VeccO3Ha3oQqh1XNAwDwB8k3gSiHEEeCK2L8RQmwRQqgt1D6A0g3xliThuvcIId4A3gAagK8Vdvi54XF5GAoO6dqxLpGojJ5e5sf7pJu7CvG6vYYKkMnQJMFwMEGA7NbF/5EPRgvNlO17C0ldB1Q2x1e5Hrex5UyS5vqYQedOKCmDZRca/myr5za79lc6THnLpJRDwOVJtu8Bbov9/QvgFyk+vygrBXvdXiIywsjMiCHtKUdnRglHw8rE0rxJ8YN07TLVke51eRmeHiYUCeEwIKlvTiOp8T4ltPS8W3S/TjYk9oM3oiKyJZLLhFCUlM6dih/E5eGNwTcMu5y6ujF9Mu16GpZdAA6X4QLECt0XM1HMRC8gRvdOmFPqocSuaOIm+0HUezbKqTxHM7WA/wOM7wdvmQJ7bVthygeDh+MFFY3KRo8LTTMn00k/DOyH9ksB4812voAPm7BR56wz7Br5UhQgBcTo3gnxyVTVTNu2wuBbMFmYirjJiOeCGOT7mVNsrnMnuGpN9X/Ex4KBioJVCuypgrp7Fx63h+nINBOhCUMu5Qv4sNvs1JTVZD7YKLpj9b86LgNOmyqNFJr1zvrC1zvLgqIAKSBGZ+yqgim+zI87Os1bhRg9mcY1U2eDIkDaLwWbuY91PKzVIO3UF/DhsruocFQYcn7N1HVAVSt07TrdwjhgzEpTjTozrJK1FjqfVgI0YgmqXpeXUDRkWIHUBS0KLEhRgBQQtYaPUSsQVTDF/SvNG6G00lQBYnQGvj/gp9JRiXv8FIyfjGuHZmL0SlOdTM3sOAnMqYvlUVsYG6QcWaKkR9fTyv3GAjQMX2kma5JmMYoCpICoiXVGaqZ1zrrTzuoSOyw31w9S66zFbrMbN5mqUWedO5UNHZcZcp1saHArk6lh37OVNNO2rRAYxBNU+pYYphwFTBYgI93KT8z/AcbXevMH/OaHLWegKEAKjJGdCZNqLKofZGLAkGtmwiZshibWDajdFzt3Qs1yqDO3XzaAy+6istS4fvBJ+7+bRcwP4hl4EzBWGzc16qzzaeV3x2XxTUYGxcxGZhmZGbGOopCCogApMEZOpkmLzamOThPzQYxMoPQH/HidDUq4csdlhlwjF4xq8yqltFaBvdp2qFqC+8SLVDgqDIm2C4QCTIYmzV2BdD2t1P/ynBXfZKR51jKBEhkoCpACY2ToX9JlfpP5fpBGd6Mhk6maOOmNSpgZs5YAMUhoToQmmI5MW2diSfSDGJRAafpkKqXSgbH9EuV+Y5SWlFJbVmvMPSfmN1mYogApMB63ko2ud7+IUFSpFbRAM1X9IF27dL1eNhi16hqZHiEcDeOZiAmnBPu02XhdXkMiknxTFskBSaRtKwSG8JS4DVGOTM8B8b0JU37oWPh8GZWBr4bkW+p7TkJRgBQYr9uLROo+uQwFh5DI5A9c+yUwdATGenW9plY8bg+ToUkCoYCu5+0P9APQNNQNTedAufmd6lTUFYjeOQLxe7ZCWXOVWOVjTzhsiKJg+mSq+j+SKChet9eQlWb/lAW/5yQUBUiBaXIrD4Q6EehF/IFzJ3ngVsSqxhx7UtdrakXNS9FbOx2YUiaWpoGDljJfgTKxhKNh3XME0n7PZlGzHKqX0jg1zEBgQPd+8Kbfc+dOJeelZumCXUaVMxkIDOCyu6gqrdL93HpSFCAFRtUo1JdCL9TzNZYnqRXkXQuVLXD0CV2vqRWjolXi9zwzbTkBYpSDdSAwgEDEQ4UtgRDQcRlNQycIR8MMTw/revr+qX4qSysN7fCYkvCMUiJnRfLye2qB1HA0rOtl+6f6aXQ3mp/rk4GiACkwRguQpEteIZQXoHMnGFQJOB3qCkT3ew7048BGnYjV/bIQRmWj90/143F5zO8LPp+VV9A0o+SC6P09D0wNmGfKOfEChAKw8oqkuxvLGxWTtM7RZ6becxYUBUiBqSytpNxRbshk6ra7T/cFn8/KHTA9Cidf1fW6WjBKaA5MDeCNSmxLL4BSE7TTNBi1Aumf6rfmxNJxGU0Rxd9jxLNtmvnq6ONgc5wuCzQPdVx9U31J9+dKf6Df/MrDGigKEBNocjcZsgJpKm9KveTt2A4IOFZ4M5bL7qKmrEb/ex4/QdNMMKV2aCaN7kYEQn+hGRhIbqY0G1cNTd6zAWNW16YJzWNPKt09y5LXHWsubwb0vedwNMxgcNCaisI8TBEgQog6IcRjQogjsd+1KY6LJDSTeiBhe7sQ4kUhxFEhxG9i3QsXDU3lTbo70TMued110HquaX6Q5vJm3bW0gfEemiIRWHWlrufVA0eJgwZXg64Ti5Qybhu3IjUrrqQsGqV/tEu3cwbDQUZnRs2ZTMf7lPLtKxe0LoqjjkvPZ9sf8BOV0aIAScPngSeklKuAJ2L/TkZQSrkp9nN9wvZ/Br4jpVwJjAC3GjtcfWkqN2AFEtCgpa28Ak7ugeCIrtfWQmN5o65CMyqjDITGabK5wLtOt/Pqid5Cc3x2nGA4aNmJRay6guZwhH6/fh2m45F2ZtyzGrWYZoVbUVpBpaNS1/dZDVu2qqKQiFkC5AbgZ7G/f4bS11wTsT7oOwC1T3pWn7cCjeWNDE8PMxuZ1eV8oUiIoeBQZjvxistBRk/HtReQ5vJm+if1e8mGp3yEkTTWr56THWwl9FYU1InFqgKE5s00Sht94yd0O2U878UMH8jRx6GiERo3pD2sqaJJV0VhseSAgHkCpFFKqf6P9wOpRK1TCLFHCPGCEEIVEvXAqJRSjZvrBVpTXUgIcXvsHHv8fuO6h2WD+jKo2lW+DAQGkMjMD1zreVBWbYofpKm8iYnQBJOzk7qcr7/rKeW8rRfocj4jUFcgeiUTxsOWraqZ2mw0lTfSH5qAqD65IKZNptEIdD6lKF0ZFJQmd5Nu7zIUBQgAQojHhRD7k/zckHicVN6uVG/YcinlFuDDwHeFECuyHYeU8i4p5RYp5RaPxxp1ZeJRSTqZdNLmgCRSYlfKMRx9UqnvU0D0djb2H48JkPbk8flWoLmimZnIjG7JhIthYmmqP4tBG4RPvabL+dSJueCBA6deU0y9afwfKnqbKvsD/ZQ7yqksTRFRaSEMEyBSyiv+//bOPDqu4kz0v68ltSxLsqxd1mJLxpbkFbywLwEDYR0gwUlgJsRhyMtL5mROZpKZQN5M5uRNXk4gJ8m88OBNkgkJTMIEyAYOsQ3GrI/FC+BFsi1LtrW7JWtXa5e63h91W5asxa3ue3sx9TunT9+uW7e6qu699VV99dVXSqnV03xeAFpEZBGA9T2traNSqsn6PgG8DqwD2oGFIuLf57EQaHKqHE5gt1nrnNxbLLseehrhdJUt/x0odgvNFs9+AHIzltmSnhPYbeLZ0t9CnMRFtYO9vPxL8IlwuvpFW9Lz9HtIT0wnMS7RlvQCpuYVQCzrxdnJS86ja6iLgdEBW/66pa8lekeZZxEpFdZWYIt1vAV44ewIIpIuIonWcRZwJXDYGrG8Bmye7fpoxnYBMhdXD/4JweqXbfnvQPGPQGxpTHtb8PS1kChxpCdOa8AXFeSl2CtAPH0espKyiHPF2ZKeE+RllgLg8e8fHiIRM+Gt2aWtFgPwr+bE+xzNo8yJREqAPAzcKCLVwA3Wb0Rko4j83IqzAtgnIgfQAuNhpdRh69yDwNdEpAY9J/JEWHMfIknxSaQlptn6wAXs6iGtEHLXwLEdtvx3oGQlZeESlz1lPr4LT3wcuUlZUe3qwW61XSysTh739dZ+FAZCV915+jzhV195T0PjXlgWmHm4rZ0jArSojBLizx3FfpRS7cAU5aJSah/wBev4HWDNDNefAC5xMo9OkzffvrUgLf1zbFjKboa3fgT9HXp9SBiId8WTMz/Hnsa0eieexCTyFiwOPS0H8ateTnntU2GVZZSdO2IEGe+Nx1mLVlffHVJ6LX0tbMzdaEfWAqf6ZUBB2S0BRfeX2Y6JdL9FpVFhGWbFThPPlr6WuZk5lt4CaszS84YPW1bgj41AzS5a3EnkRpNH2mkQEW2+bENHIdoXEfpJcaeQkpCCZ14KVG0PKa2+kT56R3rD3xs/tl07H110YUDR/V4H7BiBtA60BmZRGSUYARIh8pLtsx2fs840fx0k54T8gs8VW6xV6t5mdKibVjUSEy9ZbnKuLfe5Y7CDwbFB8lPybciVs+Ql53FqQZ7uyY8Fv3FaRKzORofg+GtQelPA64vs9DrQ7G0GzqjFoh0jQCJEXnIevcO9IW+y1D/ST+dQ59waFpcLSj+uJwpDeMHnSl6KtpcPab+Io9vwJM5nDB+FqYX2Zc4h7FpA6W9YClJmXPIUNeQl5+FxJ8Jgt/ZmGyRNXm1cGdYy174Fw96A1Vd+7DLljUiZQ8AIkAhhlw+doB+40lv0PuL174b0/3Mhb34ew77h4PeLUAqqttNcpHXisfCSLUpexOmB04yEKKib+vR9joURyKLkRXjG+iHOHdIo1/9sh7XMVdshYb7exXMO5Cbn2jYCEcSMQAyzU5iie8/+lyRYgu6ZXnAdxCVCVfissUK2SmqpgO56mvLKgdhpTBVq3A1JsDT1xk7PND8ln86hLvqLr4aqbUEvWm32NuN2uclKCtPmWUrp92HpdZCQNKdLFyUvwtPnCdnrQJO3iZz5OSTERdl+LzNgBEiE8KtfGntD26e80auvn3Nj6k7Wvaxj28O2Kn1RihYgfqE3Z6q2A0JTqjYJjoU5ELvWCDR7m1mYuJDkhGQ7suUo48928aXQeRLajgWVTpO3ifyUfFwSpmaqpUIvsi27ec6XLkpexODYIJ1DoTkqbfY2x0QnwY8RIBEic14m8+LmjQuAYGn2NpMUn0TmvHMveJpC6U3QcSLoF3yu+F+MoEddR/8MhRfTPNxN7vzc6NuVbxr8gj3UkWZTX1NMjLjgzOi6MdvyPFS1Lah0mrxN4W1Mq3YAAqVzFyB+oekfKQZL2MscIkaARAgRIT8l35YHLj85P7gFdeW36e8jW2ePZxOp7lQWJi4MbtTV3QSn9kPZLeM901ggPzkfQWzpKMRKwzLeUfANaFPYozEiQI5shcKLISVnzpeOC80Q7vOIb4SW/paYebbBCJCIUpBSEHrPNJTGdEE+FF0GleHzBFOYUhjcS+bvxZbdGlO9tIS4BPKS80JSVSqlYkqA+FVtTd4mKL8dGvdAz9zUlt5hL91D3eFrTDtOgOcgrLzz3HGnoSBV35tQ7rPfQjFW7jMYARJRClMLafI2hTTxFnJjuvJOaDkE7ceDT2MOFKYWBveSHX4BssoYziihtb81pl6yotQiGnobgr6+fbCdobGhmOmZiojuHPU2wUprF4bDcxvljlsXpobpPvvzt/KO2ePNQFJ8EllJWSGNQGLNhBeMAIkoBSkFeEd0TysYeoZ76B3uDW09xIq/0N+HwzMKKUwtpNnbzJhvLPCLelug9v/Bqk/gsfY+iZXGFEIQmhax2LAUpBToxjS7FHJWweHn53S9v8x+1ZDjHH4B8tfDwuDd4xSmhHaf/cYlsfRsGwESQUI15fXPn4T0wC0sgoKN4RMgKYWMqtG5mbUe2QooWHXXeA8vlhrTotQi2gfbg140GkuLCP341bNK6ftG/btzUmOFtTHtqofmD4JWX/mxo6PgElf4nUeGgBEgEWRcbxrksNe2hmXlnXqCurM2tHQCICjz5crnIbscclbEZGMa6gSrv4MRK4vLQN/ngdEBvWg0CDVWk7eJpPik8LjrD1F95acwtRBPvyfoRaNN3iby5ufFhHWhHyNAIkioZq229cb9L04YRiHjAiTQxrTXA3Vvw6pP6Ot6G4kX7dk3VihKLQKCn2Bt6G0gY15GYO76o4RJQjMINVajt5GClILwuOs//ALkrYWMpSElU5hSiE/5aO4Lbp1TY29j+OZ8bMIIkAiS6k4lLTEtpIYl1Z3KAveC0DKSXqwdLFb+MbR0AiB3fi7xEh94mY/8CVDjvdj63noKUwuJd0VkJ4Kg8AvNYCfS63rqKF5QbGOOnGe8c+Q3U191l/aLFaAaq7G3MTy+zrrqtZVYiOorCH1xcH1vPYtTo3uLgrMxAiTCFKQUBP3A+RsWW3ppqzfrfaDbqkNPaxbiXfEsSlkUeJkr/mCpr7T7ktqeWhZH+T4gZ5OWmEaqOzX4hqWnPubKPEU9u/IuQAU0yh3zjVHfUx8eoXnwOf29ZvPs8QJgfNQVxH3uGe6hY7CDJQuWhJyPcBIRASIiGSKyU0Sqre8pik4RuU5E9k/4DIrIXda5J0Xk5IRzF4W/FPawJHUJ9b31QV1b11Nn3wO3ZjOICw48Y096sxDwWpDOWqh/B9Z8CgCf8tHQ0xBzLxnoMjd45z4C6R/p5/TA6Zgrc1J8EtlJ2dT11OmA7FK9qDCA58vT72HYN+x8mZWCg8/C4sv1KDxEsudn43a5g5rrqu/RbUCs3edIjUAeAnYppZYDu6zfk1BKvaaUukgpdRGwCegHJm7k/Y/+80qp/WHJtQMUpxXT7G1mcHRwTtcNjg7i6fPY1zNNzdNO5A4+B74Q3K0HQGFqYWBC88CzgMDazwDQ2t/K4NggS1Jj6yUDa81PEF4H/A1wrKk2AErSSqjtqT0TcOG92lij9cis1/nL7Hhjemq/duNjPV+h4hIXBakFQakqw1Zmm4mUALkTeMo6fgq46xzxNwPblVKhbZ4RhRQvKEah5vzQNfQ2oFD2DvMvvAe66x138V68oJjuoW46B2dxPKcUHPgNlFytTY0500uLNXUOaAHQ6G1k1Dc6p+vqemOzYQF9n2u7a88slF29GVzx+r7OQtga04PPaZfzq87V/ASOv8xzpb6nHkFiYo+biURKgOQqpfwbYXiAcxk+3wOc/dR9V0QOisi/iUjiTBeKyBdFZJ+I7Dt9+nQIWXaG4rRigMk9tQBw5CUrvw0SkuGgs2qskrQSAE52n5w5UsNu7cn1wnvHg/x1FIuNaUlaCaO+0Tnrx/1C02/JFUsUpxXTM9xzxkNtSjYsu9Ea5c68kLSup25cBeYYY6Nw6HfaoWiSfabCJWkl1PXWzbmjUNtTy6LkRSTGzdiURSWOCRAReUVEKqb5TDJ3ULp7MqMvDxFZBKwBXpoQ/E2gHLgYyAAenOl6pdTPlFIblVIbs7MdfCCDxD+CmGuvxZHG1J2sTXorX4CRuanU5oJfgJzoPjFzpAO/0Rv7+FfKoxtTt8sdE27czyagMk9DXU8dOUk5MWXC62faZ/uie6H3FJx4bcbr/HN7jprwHn8V+lptU1/5WZq2lFHf6JxN82PRUAIcFCBKqRuUUqun+bwAtFiCwS8gWmdJ6tPAH5VS46tzlFKnlGYI+CVwiVPlcJr5CfPJmZ8z5xFIfU89WUlZ9u8PceG9eqdCBz305qfkkxiXOPMIZLgfKv4IK+6AxNTx4LreOhYvWBy+/SFsJKBR1zTU99SzJC32Rlwww+i69GaYtxD2z6zGstU4ZCbefxKSs2H5TbYmO95R6Aq8o6CUoq43DGV2gEi9iVuBLdbxFmA22757OUt9NUH4CHr+pMKBPIaNkgUlcx6BOPaSFV8NGRfAvl/Yn7aFS1wULyieuTGt/IMWYus+Oym4trs2JieTQa/5yUnKmdMIRClFbU9tTDYsoF3Zu13uyc92fCKs/bTuoPS1TblmZGyEJm+Ts/e5pxmO7dDPV7zb1qTHOwo9gXcUOgY76B3ujcn7HCkB8jBwo4hUAzdYvxGRjSLyc38kESkGioA3zrr+aRE5BBwCsoD/FYY8O0ZxWjEne04G7JVXKcWJ7hPO2Mm7XLDxfj2R3nLY/vQtStJKZhYge5+ArDIovmo8aGhsiIbeBpalL3MsT05Tkja3jkL7YDtdQ10sWxibZY5zxbF4weKpjenGB2BsGD781ZRr6nrq8CnfeEPsCB/8CtQYrP+c7UmnulPJTsqe0wjkeJf2hB2L9zkiAkQp1a6Uul4ptdxSdXVY4fuUUl+YEK9WKVWglPKddf0mpdQaSyX2WaWUN9xlsJPiBcX0Dvdqv0EB0DbQRtdQF8vTlzuToQv/Uu+X7uAopCSthCZv01Tz5eYPtWO7jX8NE3Tgtd21jKkxli90qMxhoCSthBPdJwLuKFR36kWdsdiw+JnWKimnHJZcpZ+vsybTq7t0mUvTS53JkG8MPvhPbbIeouuSmShJK5nTCMRf5li8z7GnTD4PWbpQP8j+nsi58D9wjjWmyZnatPHAMzDkjGwuSStBoc4sNPOz9wk9eX7hPZOCY/kl81OSVoJ3xEvbwFTVzXT4n4cLFl7gZLYcpSSthIbeBobGhiafuPgB7Uak5pVJwdWd1cRJnHMjkOqX9b7nG+93Jn3OjK4D7SjUdNWQlphGVlKWY3lyCiNAooCy9DIAjnYcDSj+eM/USXXOxgdguNcxk96laVpoTpoT6O+Ait/D6rshaeGk+Me7jhPvio9JPbGf8Y5Cd2AdhZquGtIT04Pb7z5KKMsoY0yNTe0cld8OKbmw9+eTgmu6aliyYAnuOHvnJsZ593FYUABltzqTPlqA9A73BtxRqOmsYdnCZeFxHGkzRoBEAZlJmWQlZVHVWRVQ/JquGjLnZZIxL8O5TBVdAgUb4J3HZrXZD5aStBLiJX6y0Nz7BIz0w2VfnhK/prOG4gXFJMTFjqvrs/GPGKs6ArvP1V3VLEuPzYbFj79zNKXM8W7YcL8eEZw+c666s9o51Wzzfqh9Cy79Ejj4HPnVb4F0CJVS1HTVxOzI2giQKKEsvYxjnccCiuvoS+ZHBK78ql7Md+RPtifvjnNzwcILzrxkIwOw+yd6oVnuqinxq7uqY/Yl85OZlEnO/JyAG5bjXce5IC121VegF0AmxSdN3zm65L9BfBK8/WNA+/1q9DY6d5/ffQzcqbBhy7njhkB5hnb8Gch9bulvwTvijdln2wiQKKE0o5TjXcfPuRnNmG+ME90nwvPAld+uJxrf/rF2LWJ38hnlHO04qnVLWb4YAAAQ6ElEQVTF+/8L+tvgqr+bEs877KXJ2xSzL9lEVmSsCKhhafQ20jfS53xHwWHiXHEsT18+/agrOUtbQh18Frobx9VcjpS5q0F7dt6wBeal2Z/+BFLdqRSmFHKkY3afX8B4pzFW77MRIFFCWXoZI76Rc64TqO2pZWB0YLyX4yiuOLjib7VV1MmzLalDZ0XmCjoGO2j1NsM7j2qV2ZIrp8Q73K7NiVdlTR2ZxBrlGeWc6D7BwOjArPEq2yuB86PMZellVHVWTT+pfMVX9Pc7j43fZ0ee7bd+qL1NX/ol+9OehhWZgXUUKtoqEIQVGSvCkCv7MQIkSvDris+lxjrUdgiANdlrHM8ToE16U/Nh13dsH4X4G4qqfT/Rrtuv+cdJprt+Ktr1OtFVmbHfmK7IWIFP+cYNIWaisq2SBFcCpQsdMmcNI2XpZfQO93Kq79TUkwsXw5pPw/tPcujUbjLmZZCfbPM+6J21es3Jhi3jjjmdpjyjnIbeBnqHe2eNV9FWwdK0pTHpqgaMAIkaitOKSYpP4uDpg7PGq2irICUhJXw71CXMg2sfhKZ9ULXN1qT9QvPwkd9D4SXazcU0VLRVUJBSQPq8MOyP7TDlmYHpxyvbKynPKI9powE/KzNXAmc6P1O49kHwjVLR+Dars1bbbzTwxve1F+Cr/8HedGchkHkQpRSV7ZUxPco0AiRKiHfFszZrLQdOH5g13qG2Q6zKXBVef1AXfRYyl8Guf7XVIivFncIF7nT2yzBc/y/Tjj5A98ZXZ6227X8jSX5yPhnzMma9zz7l43D74fGGN9YpzyxnXtw89rfOsG1PejHeDVs4MdbH6qRF9v55y2HtmHPjA7DA5rRnYU2W1hDMdp9P9Z2iY7Ajpp9tI0CiiItyLqKqs4q+kb5pzw+ODnKs41j4H7i4eNj0z3D6KLz/S/vS7fWwvtPDgfnJjC25YtoobQNtNPc1j7+QsY6IsCF3A++3vD9jnONdx+kb6TtvypzgSmBV1qqZBQhQufImlAhrjr9jn6pUKdj+DT1pfk34Rh8A6fPSWZq2lA9aPpgxjl/bEMv32QiQKGJdzjp8yjejGmv/6f2MqlHW5awLc87Qe1qXfAxe+VfobbEnzZf/mfUDA3jxzTj3s+fUHgA25m605z+jgPU562nyNuHp80x7fo9Hl/nivIvDmS1HWZezjqMdR2c0HtjXXY0LYe3Jd+zzBF35R73uY9O3YL6Da6ZmYH3uej5s/ZCxGUbtezx7SE5IDo9BjEMYARJFrM1ei0tcM/ZOd5/aTZzEsSF3Q5hzhlYv3fYjGB2Al74Zeno1r8Ch37JhzX0AfNA6fU9tj2cPqQmpMf2SnY3//s10n/d69lKQUkB+is2TyRFkXc46RtXojCqd3ad2szJzJQty1sC2b8Bgd2h/2NcG2x/U+7Bv+HxoaQXJ+pz1eEe84254zmavZy/rc9YT74oPc87swwiQKCLVncrarLW81fTWtOd3n9rN6qzVpLhTwpwzi6xlcM03tLuRA88Gn05fOzz/N5BdzqLrvkVhSiHvNL8zbdQ9nj1syNtAnCsu+P+LMkrTS0l1p/Ju89Stg8d8Y+xr2XdejT5AjyATXAm81Tj12e4f6efQ6UNcuugyuONRvdHTi18LXpWlFPzpqzDYBXf9uzZHjwD+ezjdfW7tb6W2p5ZL8mJ2KyPACJCo42NFH+Nw+2FO90/efrdtoI3K9kouz788QjmzuOrvYfEV8OLfQ9vspqjT4huD578MA51w988hIYlri67lveb36B+ZvOX98a7jNPQ2cGX+1LUhsUycK46rC67mzcY3p6g3Pmj9gO6hbq4quGqGq2OT+QnzuSTvEt5sfHPKuXea32FUjepnO38dXPc/oOJ3etOnYNjzH3D0Ra26msarQbjIS86jPKOc1xqm7r74esPrAFxZENvPthEgUcbVBVcD8Hrj65PCd9Xtwqd8fHzJxyOQqwnExeuGPz4Rnv4UeOe4z/zL34Lql+Dm70Genjy8rug6hn3DU3pqO+t2IgjXL77ertxHDZsWb6JzqJMPWz+cFL6rfheJcYnjz8H5xDWF11DbUztlsezLtS+Tnph+RjV71dfhguv1BPiJ1+f2J8dfhR0PQektcPlX7Ml4CGwq2sT+1v20D7RPCt9Zt5PiBcUx713BCJAoozS9lKVpS3m++vlJ4dtObqMkrSQ6Hri0AvjL56DXA0/fHZgQUQpe/S689zhc8t/h4vFtX1iXu47MeZk8X3OmzD7l488n/sy6nHVkz4++vexD5aqCq0iKT2Lr8TMTxiNjI+w4uYMr86+M2YVls3HjkhuJk7hJz7Z32Mvrja9z/ZLrz8wFuFyw+QltOv7MX0H9e4H9wck3dfzscrj7P3Q6EebGJTeiUPzp+Bl/cp4+D3s9e7lhyQ0x7SgTIiRARORTIlIpIj4RmdG8RkRuFpEqEakRkYcmhJeIyG4r/FkRccj3c/gRETaXbuZg20Eq2vQK7Mq2Sj5o/YC7l98dPQ9c0cXwmV/B6WPwxI3gmWVX4eF+2PoVePP7sO4+PfqYQIIrgbtL7+aNxjdo6GkAtFqjtqeWzaWbnSxFxEhOSOb2pbez7eS28Y3EdtTuoH2wnU+VfSrCuXOG7PnZXFt0Lc/XPD+urvx99e8ZGB3g7uV3T46clA73/VG7fH/qDr2H+kxzIkrpTaJ+vRkWLoHPPQ+JqQ6XJjCWpS9jfc56nql6hlHfKADPHH0Gn/JNLXMMEikRXQF8EpiqELUQkTjgceAWYCVwr4j4V1Y9AvybUmoZ0Ak84Gx2w8tdy+4iPTGdh/c8TP9IP4/sfYS0xLToe+CW3whb/gTDffCzj8GOb0L7hH0fhrzaSeK/Xw4fPq1dlfzFo9NOan6m7DPMi5/H9/Z8j76RPn6474fkJ+dzU/FNYSxQePnsys8y5hvjB3t/QNdgF49++Chl6WVckT/9mpjzgc+v+jydQ508vv9xWvpa+NnBn3Fp3qXTr21KzYMvvAKFG+H5L8HTm6H27TOLWX0+Per41V2w9W9hyeXw+T9DSk54C3UO7l99P03eJp6sfJKT3Sf59ZFfc1PxTRSmFkY6ayEjge6a5cifi7wO/INSat805y4Hvq2Uusn67bcdfRg4DeQppUbPjjcbGzduVPv2TfmrqGTbiW08+NaDuF1uhn3DfO/q73H70tsjna3p6WuHnd/SOxiqMUjOhoQk6G7Sv3NX61FHyTWzJvP0kad5eM/DuF1uRtUoj216jKsLz7+5gIk89uFj/PTgT3G73CgUv7z5l1yYfWGks+Uo33n3Ozx37DncLjfxrnh+c9tvxjfbmpaxUdjzU3jjEW3e607Rnny9rXr/mKR0+NhD2j18FFrrKaX4+htfZ2fdTtwuNynuFJ69/VnykvMinbWAEZH3lVJTtEXRLEA2Azf790gXkfuAS4FvA+9Zow9EpAjYrpSadnm2iHwR+CLA4sWLN9TV1U0XLSrZVb+LV+tf5bqi67hhyQ2Rzs656WqAqu3gOQhjw5BWBMuuh6LLAtZHv3jiRd5rfo9bS27lioLztyfuRynFb4/9lkNth/jk8k9GZpFomBn1jfL0kac52X2Se8rvCXyNz3Cffr4a9mgrvuQsPTopvQXc0T1nNDw2zJOVT+Lp83Dfyvuc27LXIcIuQETkFWA6EftPSqkXrDiv47AAmUgsjUAMBoMhWphJgDi2BFIpFWqXuQmY6Hu50AprBxaKSLxSanRCuMFgMBjCSOTt3GZmL7DcsrhyA/cAW5UeMr0G+M1ztgAvRCiPBoPB8JElUma8nxCRRuBy4M8i8pIVni8i2wCs0cVXgJeAI8BzSqlKK4kHga+JSA2QCTwR7jIYDAbDR52ITqKHGzMHYjAYDHNnpjmQaFZhGQwGgyGKMQLEYDAYDEFhBIjBYDAYgsIIEIPBYDAExUdqEl1ETgPBLkXPAtpszM75iqmnwDF1FRimngLDyXpaopSa4hb7IyVAQkFE9k1nhWCYjKmnwDF1FRimngIjEvVkVFgGg8FgCAojQAwGg8EQFEaABM7PIp2BGMHUU+CYugoMU0+BEfZ6MnMgBoPBYAgKMwIxGAwGQ1AYAWIwGAyGoDACJABE5GYRqRKRGhF5KNL5CTci8gsRaRWRiglhGSKyU0Sqre90K1xE5FGrrg6KyPoJ12yx4leLyJZIlMVJRKRIRF4TkcMiUikiX7XCTV1NQETmicgeETlg1dP/tMJLRGS3VR/PWts4ICKJ1u8a63zxhLS+aYVXicg5t7WORUQkTkQ+FJEXrd/RU09KKfOZ5QPEAceBpYAbOACsjHS+wlwH1wDrgYoJYd8HHrKOHwIesY5vBbYDAlwG7LbCM4AT1ne6dZwe6bLZXE+LgPXWcSpwDFhp6mpKPQmQYh0nALut8j8H3GOF/wT4snX8N8BPrON7gGet45XW+5gIlFjvaVyky+dAfX0N+C/gRet31NSTGYGcm0uAGqXUCaXUMPAMcGeE8xRWlFJvAh1nBd8JPGUdPwXcNSH8P5XmPfTukYuAm4CdSqkOpVQnsBO42fnchw+l1Cml1AfWcS96H5sCTF1Nwiqv1/qZYH0UsAn4nRV+dj356+93wPUiIlb4M0qpIaXUSaAG/b6eN4hIIXAb8HPrtxBF9WQEyLkpABom/G60wj7q5CqlTlnHHiDXOp6pvj5S9WipD9ahe9emrs7CUsvsB1rRAvI40KX0RnIwuczj9WGd70ZvJHfe1xPwv4FvAD7rdyZRVE9GgBhCRulxsrEHtxCRFOD3wN8ppXomnjN1pVFKjSmlLgIK0b3h8ghnKeoQkduBVqXU+5HOy0wYAXJumoCiCb8LrbCPOi2WugXru9UKn6m+PhL1KCIJaOHxtFLqD1awqasZUEp1Aa+ht7deKCLx1qmJZR6vD+t8GtDO+V9PVwJ3iEgtWnW+CfgxUVRPRoCcm73AcsvywY2enNoa4TxFA1sBv3XQFuCFCeGfsyyMLgO6LfXNS8DHRSTdskL6uBV23mDpm58AjiilfjThlKmrCYhItogstI6TgBvR80WvAZutaGfXk7/+NgOvWiO5rcA9lvVRCbAc2BOeUjiPUuqbSqlCpVQxut15VSn1V0RTPUXawiAWPmhrmWNoPe0/RTo/ESj/b4BTwAhaf/oAWre6C6gGXgEyrLgCPG7V1SFg44R0/ho9gVcD3B/pcjlQT1eh1VMHgf3W51ZTV1PqaS3woVVPFcC/WOFLrYatBvgtkGiFz7N+11jnl05I65+s+qsCbol02Ryss2s5Y4UVNfVkXJkYDAaDISiMCstgMBgMQWEEiMFgMBiCwggQg8FgMASFESAGg8FgCAojQAwGg8EQFEaAGAwOICKZIrLf+nhEpMk69orI/410/gwGOzBmvAaDw4jItwGvUuoHkc6LwWAnZgRiMIQREbl2wr4O3xaRp0TkLRGpE5FPisj3ReSQiOyw3KIgIhtE5A0ReV9EXvK7RTEYIo0RIAZDZLkA7ePoDuDXwGtKqTXAAHCbJUT+D7BZKbUB+AXw3Uhl1mCYSPy5oxgMBgfZrpQaEZFD6M3Ldljhh4BioAxYDezUrraIQ7uVMRgijhEgBkNkGQJQSvlEZESdmZT0od9PASqVUpdHKoMGw0wYFZbBEN1UAdkicjlod/EisirCeTIYACNADIaoRultlDcDj4jIAbSH3ysimyuDQWPMeA0Gg8EQFGYEYjAYDIagMALEYDAYDEFhBIjBYDAYgsIIEIPBYDAEhREgBoPBYAgKI0AMBoPBEBRGgBgMBoMhKP4/Rn2H5wyDs1gAAAAASUVORK5CYII=\n",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
-            ]
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEGCAYAAABLgMOSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9eXxb5Z3o/X1kyZbkfZG8ZbGdhWyQAClbEyBhKdACXehC2xnoC0N7p31n2rm303bmTjvT277t3DtdXjrMtLR0mZZuUNoCZdgJSdgDhCwkZLGd2Iltyfsi2dby3D+OjpBtLUfSOTrHGX0/H3/sHJ3lOdE5z+/3/FYhpaRIkSJFihTJFpvZAyhSpEiRIouTogApUqRIkSI5URQgRYoUKVIkJ4oCpEiRIkWK5ERRgBQpUqRIkZywmz2AQtLQ0CDb2trMHkaRIkWKLCpeffXVQSmlZ/72/1ICpK2tjT179pg9jCJFihRZVAghTiTbXjRhFSlSpEiRnCgKkCJFihQpkhNFAVKkSJEiRXKiKECKFClSpEhOFAVIkSJFihTJCVMFiBDix0IInxDiQIrPhRDiTiHEMSHEPiHEeQmf3SKEOBr7uaVwoy5SpEiRImD+CuSnwDVpPr8WWBX7uQP4dwAhRB3wFeBC4ALgK0KIWkNHWqRIkSJF5mBqHoiUcqcQoi3NLjcC/yGVmvMvCiFqhBDNwOXAE1LKYQAhxBMoguhXRozzzvv+molJP2tLL6Kv9mJm7FVGXMYyhOUsx4PPYqOEFa7LsIkSs4dkOKFokGPBHZTZKmlzXlyQexYyQvPEAbxThykLTzJV2kBP9fmMOZcYfm2A6egEx4M7qShpYFnZBQghCnJdMwlERugM7qbWsZTWsk1mD8dwaoIncY7t4vXwa3z+3T/A29iq6/mtnkjYCvQk/Ls3ti3V9gUIIe5AWb2wbNmynAbxyvBz7HXOsHniFf71yD/xQPRyvhO+iRHOREESxbn0HuzlxwHY0fss06c+DpzBk4sI4Vr+fUqcpwB4cvQ5Zvo/YOAFJR+w7eSv7Q+wVPgXfLo7uoFvhm/moGw3bgi2AO62f8NWOgjA7ODlzA6mMwYsfoR9HNfy72FzTAAwM/AeQiNbTB6VMZwtOvmS/Zc0lh3hz5sbCQob1/S+yBWN+j7XVhcgeSOlvBu4G2Dz5s05dc/6+Sf38PvDv+HLL32NP6y/jD87/Cx/Vr0f3v9D6LhM1/Gazb2H7uWbLx/nHy76ByZmJ/jua9/lX/9C8O6Od5s9NMP43uvf4+59p/jO5d9hn38fPzn4E3580+1c0nqJ/hcLDMPvPwVHH4OW8+Dib0LbVnDVwugJOPQQW178dx4OfBm2/z1s+RswYGXw1Re+ygNHR/j+VT/kkc5H+AN/4IFbP8X6+vW6X8sqfO6Zz7H7VIgfvesX/Hj/j9lpe5SH/tunWVJZmBVfQYhGYfe34OmvI8s9fGLZecjIJL+/7pcsq9FfITHbB5KJU8DShH8viW1Ltd0w3nvWh7ig6QJ+KIcJ3f4EOGvgFx+AAw8YedmCEoqG+MmBn7C5cTMfXP1BPrHhE6yqXcUP9v2AM7VzZSAU4JeHfsnVy6/myuVX8plzP0NLeQt3779b/4tNDMBProPOZ+C6f4G/eBrOvgkqG8FeCg2rYOvfwGdehvXvhae+Cg/9tTIp6MhgcJDfH/s9N62+iYuaL+Lz7/g8VWVV3LP/Hl2vYyW6xrp48uST3LrhVjZ6NvL3F/09Nmzcc+AMuudoBP74aXj6a3D2B9n7kZ/w6nQ/nznvrwwRHmB9AfIg8OexaKyLgDEpZR/wGHC1EKI25jy/OrbNMIQQ3LL+Foamh9gZHobbHocl74Df3Q5HHjfy0gVjR88OBgID3LL+FoQQ2ISNW9ffStdYF6/7Xjd7eIbwcOfDTIYm+bN1fwZAaUkpN6+5mVcHXuXYyDH9LhQcgZ+9B0ZPwscfgAv+IvXKwlULH7gHtv4PeO1n8NiXQEcB/rsjvyMcDfPxtR8HoLK0kvetfB9Pn3waX8Cn23WsxK8P/5pSWykfOesjAHjdXt7d8W4e6XyEQChg8uh0QEp4+LPwxi/h8r+D99/Nr7oepNJRyY0rbjTssmaH8f4KeAE4SwjRK4S4TQjxKSHEp2K7PAJ0AseAHwJ/CRBznv8v4JXYz1dVh7qRXNJyCR6Xh4eOPwSuGvjYfdC0Ae67Bfr3G315w3m8+3HqnHVsbd0a33blsitx2V081PmQiSMzjke7H6WjuoONno3xbe9Z8R4EgsdP6KQYREJw360w3AUf+y20b814CELAFf8AF30aXvq+8qMTj3Y/yvmN59NW3Rbf9v5V7yciIzx54kndrmMVojLKkyee5NIll1Lvqo9vv37F9QTCAZ7uedrE0enEi/8Gr/2HonRc/gWmIzPs6NnBte3X4na4DbusqQJESnmzlLJZSumQUi6RUt4jpfy+lPL7sc+llPLTUsoVUsqzpZR7Eo79sZRyZeznJ4UYr91mZ/uy7Tx/+nlmI7NQVgEfvQ/KquC+T8DMZCGGYQgzkRl29u5k+7LtlNjejkByO9xsbd3Kzp6dZ5wZa2xmjNcGXuOKZVfMiUBqcDVwXuN5PHHiCX0utOMb0LkDrv8utGXptL36a3DWu+Hxf4BTr+Y9lJ7xHo6NHuOKZVfM2d5e3U5HdceZMZnOY59/H76gjyuXXzln+/mN59PgauDZnmdNGplOdD+nPB9r3gPb/ycAL/W9RDAcXPA9643VTViW49IllxIMB9nTH5NllY3wgR/C0DF49AvmDi4P9vTvIRAOsH3p9gWfbWndgi/o48jIERNGZhw7e3cSkRG2Ld224LPtS7dzbPQYfZN9+V3k5Euw+zuw6eNw7sezP95mg/feBZXNipIyO5XXcJ7peQYg6T1vW7qNPf17mJidyOsaVmNn707sws6lSy6ds90mbFzScgkv9L1AJBoxaXR5MjMJf/gU1LbBe/89bhZ9pucZKhwVvKPpHYZevihAsuSCpgsotZXy/Onn397Yfils+Sy8/gvo2mne4PLglf5XsAs75zeev+Czd7a+E4Ddp3YXeliG8nL/y1SXVbO+YWHk0YXNF8b3yZlQUHm5q5fANd/I/TyuWnj/D5QorWf+v9zPg/I9t1W1JY08urjlYiIycsb5u17pf4V1DeuoLK1c8NmW1i2MzYxxYChpMQzr8+Q/wmgPvPffwPl2WsHL/S9zQdMFOEochl6+KECyxGl3sqFhw8KX7LIvKFrAw5+D8IwpY8uHPQN7WN+wPqm91Ov2srJmJXsGzqxmXK8NvMa53nOxiYWvwaraVdSU1eQnQJ7/Hgx3wg3fm/Ny58TyS+D8WxVb9+m9OZ0iKqO85nstqZIAcI7nHOw2O68O5G8qswrBcJADQwfY3Lg56ecXNV8E8LZFYTHRuwde+SFc+ClYdlF8sy/go2eih/Maz0tzsD4UBUgOnNd4Hm8OvUkwHHx7o8MF7/62Ysp64S7zBpcDgVCAg4MHU75kABs9G3nD/wZRqW9IqVn4A35OTpxMec82YWNz4+bcJ5bRHtj1bVh3I3RcnvM453DlP4K7Hh79Yk5RWcdGjzE+O55yYnHZXZzdcPYZpSi84X+DcDSc8nuuddbSVtXGXn9uQtk0pITH/g4qGuN+D5XXBl4DSPs+60VRgOTAud5zCcswBwbnLXtXXgGrr4Xd31USxhYJ+wf3E5bhlJopKAJkYnaC7rHuwg3MQF71KVr2ed7UWtom7yZOT51mMDiY/QWe/Efl99Vfy2F0KXDVwuVfgpMvwFv/mfXh6soi3fd8fuP5vDn4JtPh6ZyHaSVeG3gNm7BxrvfclPuc4zmHN3xvLK4gkYO/h56XFOFRVjHno1cHXsVtd3NW3VmGD6MoQHJADflMaiu+4sswOwG7vlXgUeXOwaGDgPIipWKTV6kbtOg0tRTs8++jrKSMNfVrUu6jZmUfHDyY3ckHDsKB38FF/w1qciufk5Lz/hzqV8GTX4FIOKtD9/v343F5aClvSbnPhoYNhGWYt0beynekluDg0EE6qjuoKK1Iuc8m7yZGZkbomehJuY+liIQUBaVxA2z62IKP9w3u42zP2dhtxhcaKQqQHKguq2Zp5VIODx9e+GHjOth4M7z8Qxg/XfjB5cCbQ2/SWtFKdVl1yn3aqtqoKq1in39fAUdmHIeHD7O6djUOW2on47r6ddiELS5gNbPjm1BaAZf8v3mOMgklDrjyKzB4BPb/NqtDDw0fYm392rRFE1Wh+ebQm3kN0yocGjrEuvp1afc5p0FRnN7wv1GIIeXPG79WAiqu+DLY5hb9DEVDHB05yrq69PesF0UBkiNr6tZwaOhQ8g8v+wJEw4vGF3Jo6BBr69am3UcIwZq6NWdEKK+UksPDh1lTl3r1AUoOTEd1x0JTZTr69sGhB5XVh7suz5GmYM17FO1z93c0lzmZDk/TNdaV8Z4b3Y3UOevOCAHiD/jxB/0Zn+2Omg4cNsfieLYjYdj9bWjeCKuuXvBx52gnoWgo4/esF0UBkiNr69bSO9mbPGa+drlS42jPTyzvC5mYneDkxEnW1qd/yQBW167m6MjRxRszH+PU5CkmZic0vWTr6tdxcOigdvv47m8riaUX/2Weo0yDELDlc8oq5PDDmg45OnKUiIxoUhTW1q89IwTIoWFFwcv0bDtsDlbWrOSt4UVgtjv4gBLZd+nnk5bCUe85nWlWT4oCJEdUB1XKh+6dn4XQFLxsQFE+HVHNcJkmFlBWXdORaU5MnDB6WIaSzT2vrVvL8PQwQ9NDmU88cgLe/CNs/oTi8DaS9e+Dug7F16ZBuGmdTAHW1a3j+OhxZiKLLxw9kTeH3kQgNCkKZ9WdxVsjb1nbkS6l8n171ynVCZJwePgwLruL5ZXLCzKkogDJEXXySeoHAcUXsvpapYbRrHWLtalmOC0Tiyo0jwwvgqV+Gg4NH6JElLCqdlXGfVfWrgSUENiMvHw3IOCCO/IcoQZsJfDOv4a+vdC9K+Puh4cPU1ValdaBrnJW3VlEZISusS49Rmoah4YOsbxqOeWO8oz7rqlbw/D0cG4Rd4Wicwf4Dyu+NVvyqfvQ0CFW166eU47ISIoCJEc8bg91zrr00SoXf1qpwnrgd4UbWJYcHztOnbOOBldDxn07qjuwC3tqoblIODJ8hLaqNpx2Z8Z9V9YoAuT46PH0O06Pw6s/U1YG1QXqL3HOh5WVzss/zLjrWyNvcVbdWZq6Dq6oXgFoFJoW5vjYcU1KAijmWcDa0Wcv/QDcDbAheVMoKSVHR44WzP8BRQGSFytqVtA51pl6h7Yt4FmrZItadGncOdpJe7W2XgGlJaW017QvDmdjGjrHOllRs0LTvvXOemrKajg6cjT9jq//XAnfvvjTOoxQIw6XEtZ7+E8wlrodjpSSrtEuOqo7NJ12edVy7MKeWWhamNnILD0TPZqf7fjq2qrP9nAXHHlUMY/ay5Lu4g/6mQhNaH629aAoQPKgo7qDrtGu1HZTIeCC26HvDaXsgMWQUtI51ql5YoHYPS9i08ZMZIbeyV7NE4sQgpU1K9Nr41IqARNLLoBW48tHzGHzbSCj8GrqgtRD00NMhCY037OjxMHyquWLWoCcGD9BVEbjq6lMVJVW0eBqsO6z/cqPFLPl5v8n5S7q2LV+z3pQFCB50F7dzkRoIr2D9ZwPQ2mlsgqxGEPTQ4zPjmclQNqr2zk9dXrROlhPjp8kKqNZ3fPKmpUcHz2eWlE48TwMHYXzb9FplFlQuxzOuhZe/WnKGmydo8oqOStFoaZjUQuQ42PK2Dtqsnu2LSlAQkFlhbv2BqhK7cNSrSHZfM/5UhQgeaB+UeoLmpSySth0s1J6wGIhverLktVLVtVOVEY5OX7SqGEZSvwly+KeV9WuYjI0yUBgIPkOr/1MCd1d/z49hpg977gNpvwpy5uo95yNZrqyZiU9Ez2LtqRJ12gXAkFbVZvmY9qrFAFiuUisQw/D9JhSTDMNXWNdlDvK8bg8hRkX5nckvEYI8ZYQ4pgQ4otJPv+OEGJv7OeIEGI04bNIwmcPFnbkCuoLmdYPAnDun0Fk1nLOdFXDzHYFAlhTU9NA15gysSyv0h7mqE5CSe85OKKE7p59E5RmjvYxhI5tUNUKe+9N+rE6sTS6G7WfsqYDiVy033PnWCctFS2aAiVU2qvbGZ8dZ2RmxMCR5cDeXyglcdrSd7JUzdFaAiX0wjQBIoQoAe4CrgXWATcLIebk30spPyel3CSl3AR8D3gg4eOg+pmU8oaCDTyBRncj5Y7yzAKk+RxoPDvlC24WnWOdWU8s6sS72CcWl92l+Rj1npOuuvbdB+FpOM8E85WKrQQ2fgSOPQnjCxtgdY510l7VntXE0l6lKAonxhdnzs/xseNZO5PVFr+WerZHT0Lns0rNqxShuypdY10F9X+AuSuQC4BjUspOKeUs8GsgXff3m4FfFWRkGhFC0F7VnlmAAGz6KJx+HXwpyp+YQC4Ti9vhprm8ma5xC71kWdA11jWnF7gWvG4vLrsreQLl6/+hlJVo2aTPAHNl40cVZ/q+Xy/4qHNMe6SdytLKpQCcnFh8pspINMKJsRNZ+wIsubreG5vyNn007W6Ts5P4Ar7/UgKkFUgsf9kb27YAIcRyoB1IbNjsFELsEUK8KIR4b6qLCCHuiO23x+/36zHuObRXt2srcX72B8Fmh72/1H0MuXJi/ETWkylY2NmYgaiM0j3WnfXEIoRgaeXShSsQ32Ho369M3mbTsBKWXgSv3zsnZHwqNJXTxOJ2uPG6vIvS19U31cdsdDYr/wdAc3kzZSVl1nm2o1HFfNVxWcaqzt3j3UBhI7Bg8TjRPwLcL6VMLMK0XEq5Gfgo8F0hRNL1qpTybinlZinlZo9Hf+fS0qql+AK+zFFJFR5Y9S7Y95usy3AbwWxkloGpgbimmQ1tVW10j3Vbz9mYAV/Ax3RkOqcyD8urli805+z/LQgbbHi/TiPMk3M/pkSDJYSM9070AmTl81FZWrV0Ua5A1LLs2T7bNmFjedXy+GRsOidfUExYSUq2L9g1JuizFZr5YqYAOQUkfsNLYtuS8RHmma+klKdivzuBHUDqjjEGsrRyKRLJqYnUiVxxNt0MkwPQ9azxA8tA72QvEpmTAFlWtYxAOMDwtLWiyjKhTqY53XPlMnoneglHY8JfSth/n9JtsMKr3yDzYd17oaQMDtwf36ROpsl6oGdiWeWyRbkC6Z3M73u2TF+QA78DhxvWJK97lYg65paKzKVq9MRMAfIKsEoI0S6EKEUREguiqYQQa4Ba4IWEbbVCiLLY3w3AOwFTyoeqD6mmh27lVUq458EHMu9rMPlMpksqlMlIfVEXC/lMLMurlhOWYfomY07qnpcV7fDsD+k5xPxwVsGqq+DgHyBWMVn9nnMSIFXLGJoeYio0peswjaZnogeHzYHXnb1gX1K5hFMTp8xv3RwJw5t/gNXXaIru653sxePyZBUcogemCRApZRj4DPAYcAj4rZTyoBDiq0KIxKiqjwC/lnPtJWuBPUKIN4BngG9KKa0vQBxOOOs6OPQQhGcNHll68tFM1WPUyWmx0DPRg03YaKpoyvpY1QQUd6Tvvw/sTk3aYUHZ8H6Y7FeSG1HuubqsmqrSqqxPtaxSsbsvtlVI70QvrRWtORUUXFq5lNnoLL6Az4CRZUHXsxAYSln3aj49Ez05KUb5YqoPREr5iJRytZRyhZTy67FtX5ZSPpiwzz9KKb8477jnpZRnSyk3xn7fU+ixq9SW1VLuKNe+7N3wfiUpqPMZYweWgd6JXlx2F/XO+qyPba1ojZ9jMdE70UtzeXPaLoSpWFalTKYnxk8oLUUPPqBkgDuzn5gNZfU1itkjtsrtneyNrxizRb3nxeYH6ZnoyUkxgoTVtdnP9oEHFGvFyis17d470ZvzPefDYnGiWxY1QkezAOnYBs4a5QExEfUlyyXpyGl34nV5rWMr1kg+k2m9sx633a1MLF07Y9rhTTqPUAdKyxUh8uYfIRKmd6I3Z81UXYEspu9ZSpmXNh5fXZtpng3PKFaKNe9RrBYZmInM4Av4cn6286EoQHQgKwFiL4W171EqqIbMKxPRM9HD0orcl7xLKpcsPh9IHlqaEIKWihZOTZ5SXm5HuWbtsOBs+AAEhgh3Ps3pydM537Pb4abB1bCokglHZkaYCk3lLECaK5qxCZu5QvPYUzAzptl8dWryFBJZXIEsVpZULuHU5CntrV7Xv18p/X3sSWMHloKojOalmUJMgJi9zM+CqdAUw9PDeb1krRWtnJ48pQj/1Vdr0g5NYeWVUFbFwP7fEJbhvDTTJRXKs71YyDWEV8Vhc9Bc3mzus33w90qfl47LNO2eT0BMvhQFiA4srVxKKBrS7nhrvwxcdYqZwQR8AR+z0dm8BYim/BeLkE80kkpLRQunx3tgygdrr9draPrjcMLqd9FzQgkXz+d7bq5o5vTkab1GZjj5ChBQhKZpq+tICI48prSsLdHmq8snICZfigJEB7KKxAIosSsO2KOPKQ9MgdFDY1lSsUTJf1kk2mk+IbwqrRWtTESCjNnLYNXVeg3NGNa8m96o0ko531XXwNSA9tW1yajPthrokQumrq67dyvmqyyi+/IJiMmXogDRgdZy5WE9PZWFpnbWdUo01onnDBpVatTJNJ+JRZ2IF4sZK74CycOc0xrrJ366/SKlTL+VWXklPY4y7IisimXOp6WihbAM4w/qXwbICHonevG6vFlV4Z3PksolDE8Pm5P/cvhPShTdim2aD1HDlgtZhVelKEB0oLFceUHjSWZaWLEd7C44/IhBo0pN32QfAkFTefb5ECqLLRekZ6KHytJKqsuqcz5Hy/QkAKdbTS6cqIWySnprmmmNSEpE7q95S0xoLpaVZt9UX97Z2KY921IqAmTFdqVdsUZ6J80J4YWiANGF0pJSPC4PfVNZCJBSt/KgHP5Twful90310eBqoLSkNOdz1DvrKbWVZnfPJnJ68nTeYY6tPa8C0FvTrMeQDKfPWU7LbBAGDuZ8DnUyXix+kL6pPprL8/t+VItCwZ/t06/DxGklfFcjUipm5HxMdvlQFCA60VzenJ0JC2DNdTDeq/RMLyB6vGRCCJormheNAOmb6strxQVQ9dZjVCA4PTOaeWcL0CdnaQ5HFCUlR9TnZDEIkKiM0j/Vn1OlgUSaK5R7LvizffhPIEpg9bs0HzI+O04wHMz7fc6VogDRieaK5uxMWKAkfAkbvFVYM1b/VH/8JcmHpvKmRSNA+qf683vJhjsRg0doKatbFJPpbGSWwelhmtzNcPjhnM/jtDupd9ZnrxyZwPD0MKFoKO/JtM5Zh8PmMEeALL8E3HWaD1HHWBQgi5yW8hb6p/qzK8JW3gDLLs5LQ8wWKaUuKxBQHtr+yX4dRmUsE7MTTIYm87vnI48D0FqzclEkUA5MKf3bm5vPg/59SuHHHGmpaFkUQlNV4PJ9tm3CRlN5U2Gf7aHj4D+UdW21/illjEUBsshpKm9iNjqbfYnzs66DgQMw0m3IuOYzPD3MTGQmb3MOKA+tP+gnZEIocjaoL1le93z0MahfRWvdKk5PnrZ8L5T+QGxiad+ubDjyWM7nWiwCRF0l6aUcFXQF8tZ/Kr/Pui6rw+IrEB0sCrlQFCA6oTobczJjARx9QucRJUdPjaW5vBmJZCAwkPe5jER9yXIWIDOTSnz+6nfRXN5MIBxgbGZMxxHqT3xiadkMte15PV8t5S30TfWZX+I8A/FnezGaZ48+Dp41UJtd46++qT7sNjt1Tu1mLz0pChCdiDsbs7UV16+A2raClTVRXwo9Gs+Y5mzMkryFZtezEJmFVVfHhZDlhWZMkWksb1SSHrt2QiiY07laKloIRUMMBgf1HKLu9E31Ue4op9KRf45OfHUdLcDqemZSKb+/6qqsD+2f7KfJ3YQtj1DtfCgKEJ2IT6bZrkCEUF7wzmcLUlxRT6ebeg51grYqfVN92IWdBldDbic48iiUVsKyi+MCZDHcc52zjrKSWNZ8OAjduSWtLpZQ3r5JxbenR0JdS0ULURnFHyhAAmXXsxAN5VTdoG+qzzTzFRQFiG5UlVZR4ajITRtXX/ATu/Uf2Dz6pvpw2V05NRiaj5rhvBhWII3ljTk1GEJKxfyzYhvYSxeNAJkTddb2TiVp9ejjOZ1LPY/Vv2c9QrVV1PMU5J6PPgGlFbD0oqwP7Q/kGV2YJ6YKECHENUKIt4QQx4QQX0zy+a1CCL8QYm/s5/aEz24RQhyN/dxS2JEnp6m8Kbdwx7YtSne7o8absfTU0px2J3VO64e19k315V7Oo38fTPTFfVX1znrswm59E1ZipJ3DBe2XKoEAOTj/42a7Kevfs5o5ny8FE5qqgtJxudLqIQvC0TC+gE83oZkLpgkQIUQJcBdwLbAOuFkIsS7Jrr+RUm6K/fwodmwd8BXgQuAC4CtCiNoCDT0lLRUt2ZuwQHnB27bmrCFmg14hvCrN5c2LQxvPdZkfC99V7dMlthI8bo+l71lKqSTUJU4sq65SIv2Gjmd9vgpHBW6729JCMxAKMDozqps5p2ArTd8hJZk4B/+HP+AnKqP/ZVcgFwDHpJSdUspZ4NfAjRqPfRfwhJRyWEo5AjwBXGPQODWTUza6yqqrYPh4Ti94NuhtM22paLG0aSMSjTAwNZD7S3b0MWg5Dyq88U1N5U3xMFkrMj47TiAcmHvP6gSVg5IihKCxvNHSAkT9PvTSxl12F7VltbkphNlwLBYdtzJ7AZJ3dKEOmClAWoHE+ue9sW3z+YAQYp8Q4n4hhFqLW+uxCCHuEELsEULs8fuNdYg1lTcxMTtBIBTI/mC1u52B0VjT4WmGp4d11VjUcEer5kUMBgcJy3Bu9xwcgVOvLug82ORusvQKJGk4a20bNJyV8yq30d1oaROWmvRnxLNtKEefAO96qM6+lpXZWehgfSf6Q0CblPIclFXGz7I9gZTybinlZinlZo/Ho/sAE1Ht7JobSyVSvwLqVxpqxlI1SL1NWMFwkPHZcd3OqSd5aaZdO0FGYeUVczY3liuTqVWFZsqJZdVVSvuAmcmsz9nobrT0qsuIydTwZMLpcfcb0RAAACAASURBVDj5Qk7mK9ApQTZPzBQgp4DE7j5LYtviSCmHpJRqy7sfAedrPdYMVAGS81J/5VVKwlqO8fqZMGLJa/WopLzu+fjTSvhu6/lzNqtVB0ZmRvQYou6kvOeVVyr5LDn0oGksb1RWc9GwHkPUnb6pPmzChsetn5LYVG7wSrNzB0TDOQuQvqk+qkqrKHeU6zuuLDBTgLwCrBJCtAshSoGPAA8m7iCESFQnbgAOxf5+DLhaCFEbc55fHdtmKl63YifPaQUCiqYbnla0EgNQTRBNbv0EiHrPVrWP52zakFIRIO2XLmgtqv7/WVloOmyOhdnJyy5Wov2OP5P1OZvKm4jKqGWTCQcCAzQ4G3DYtLWB1YLX7WUyNJmbSVoLx59SFJSlF+Z0eN4FQnXANAEipQwDn0GZ+A8Bv5VSHhRCfFUIcUNst78SQhwUQrwB/BVwa+zYYeB/oQihV4CvxraZSt6T6fJLwObI6QXXgtpVTk8tLe9Vl8HEs5NLs8xOHu5UChAm6QynNhCzqk+gf6qfRnfjwuxkh1MRIp3ZP1/q92xVoekP+HV9rqEAytHxZ6B9q+be5/PRM+8lV0z1gUgpH5FSrpZSrpBSfj227ctSygdjf39JSrleSrlRSrlNSnk44dgfSylXxn5+YtY9JOJ2uKksrcx9YiktV7SRHF5wLfgCPipLK/Nq9zmfelc9ApH7qstg/EF/bjkgx59Wfq/YvuCjuNnOoj4Bf8Afn/wWsGIb+A/DeHbRglZXFPxB/QVIXj7NTAx3wegJJf8jR9J+zwXC6k70RUejO89wxxWXQ/9+mNLfVOAP+PG69H3gHDYH9a56ywoQX8CX28Ry/BmoWQZ1HQs+qnPWYbfZrauNB9NMLB2xFVXnjqzOafVkQiOebXWlacizrf7/d2jvfZ5IKBJiZGZEd6GZLUUBojON7sb8HriOmMab5QuuBV8wx8k0A16317qaacCPx5XlPUdC0L1LWX0kydi3CZsSlWRRAZJWaDZuAHdD1mbSqtIqnCVOS37Ps5FZQyZTQ01Ync9AZQs0rMrpcNUXpbfQzJaiANGZvBOuWjaBs9oQM9ZgYNCQJW/eQtMgpJS5mTZOvQoz40nNVyp5rzQNYio0RTAcTD2x2GyK2aRzR1ZlTYQQNJU3WfKe45Opzs+2y+6isrRS/2c7GlFCxFdsS6qgaMEXVMZUXIGcYXjdXoaCQ7mXgbaVKJE/x3fkVLcoFVJKZQWSrTauAa/ba0kBMjYzRigayl5LO/600mq4/dKUuxge4pkj6veQdmJZsQ2mfDBwMKtzWzWZMH7PBjzbhihH/fuUJNWOy3M+hVoluOgDOcNodDcikQwG8vBhdGxT6uPoWNZkdGaUcDRsiMbS6G5kbGaM6bDx5eizIWct7fjTSu6HK3V5NXVisVoyoaaJJe4HyW6V21huzWRCNbrQiMnU6/bqLzRV82H7ZTmfwkihmQ1FAaIzuthNOy5XfutoxlIfOKNessRrWIWctLTgqGLCyuDc9Lq9hKIhy3UmjAvNdBNLdSs0rM7aD9LobsQf8BOJRvIZou6oz13O/V7SYMjqunOHUr6kMscK0ShC0y7s1DrNrSFbFCA6o0u4Y12HEgGkYz5IPAfEIBMWWC/EMyctTS1fksb/AW+vatQJ2yqoQjPjqqtjm9IFL4smZo3uRiIywtD0UD5D1B1/wLjJ1Ov2MjitYwZ+KAgnX8zLfAXKs13vqjetE6FKUYDojC6x40IoL3j3Lojo8+BqnlhywNB4+TzIKXGyexc4ymHJ5rS7qUKzIB3rssAX8OG2uzOXt1ixTWli1vOS5nOrYa1W8/34g34a3A2GTKaN7kaiMspQUCehefIFiMzkLUAGg8YExGRLUYDoTHVZNWUlZfnbTVdsUyKBTr+my7iMtJla1YTlC/ioKq1S2rpqpXs3LLsoY3aw+v9otXtOmwOSSNsWsNmzChePC82gtYSmETkgKro/2507lGoTyy/J6zS+gDEBMdlSFCA6I4TQx27afhkgdMsH8Qf91JTVUFqSXdczLVSUKg2HrDaZZq2lTQ2C701lcs1A3IRlsXvWXNKjrFLpc9K9S/O5rbrqMiILXcUQAbL0AiiryOs0Rt5zNhQFiAHokiPgroOmDYpNXgdyzsjWiBWTCbNOIlSr1GoQIGUlZdSU1VhPGw9mcc/tW+HUazAzoWn32rJaSkSJ5YSmkdq4rv69qSHo25dz9rnKTGSGsZmxognrTEW3ybTtUuh5OStHZyqMXOaDYh+33MSSbeZ9925wuKHlXE27e9weS92zlDK7+khtW0FG4IS26s8lthLqXfWWEprT4WnGZ8cNm0zVsjW6fM/dOwEJHbmH70KCP7NowjozUSfTvHME2rcqDrfeV/Iek9FLXqtlo0dlNPvMe43+DxWvy2spc85EaILpyLT2cNalF0JJaWxi04bH5bHUPRtRYToRm7DhdekUytu9WwnQ0KigpMLoe86GogAxgEZ3I6FoKP+GQ8svUTKis7BTJ0Pt42CkxuJ1K5NpVEYNu0Y2jEyPEJZh7ZPp1JBm/4eKx+2xVBhv1nkvpW5Y8g7o0v58edweS61A4vds4OpaN4tC93NZKSipKK5AznDUSStvTc1ZDc0bs3rBkzE8PUxERgy1mXrdXsIyzPC06W1ZgByyk+P+j62ar+FxeRgKDlkmsS6nSLu2rdD3hlJaQwNWW3WpArzBrX8SoYouQTGTfvAfykpBSYWRmffZYqoAEUJcI4R4SwhxTAjxxSSf/40Q4k0hxD4hxFNCiOUJn0WEEHtjPw/OP9ZM1C9Wl+5tbVsVE9Zs7l3RjMwBUbFaMmHWWlqW/g9Q7jkiI4tXaIJiJkUqSYUa8Lg9jMyMMBuZzWGE+lPIFUheJuksAjQy4Qv4sNvs1JTV5H2ufDFNgAghSoC7gGuBdcDNQoh183Z7HdgspTwHuB/43wmfBaWUm2I/N2Ah1BWILnbT9kshGsoq4Ws+Rmahq8STCaesYdLJejLN0v+ReG6rmLHUyTSrkh5L3qG0udW4ytVVOdIBf8CPw+aguqzasGs0uhsJhoNMhiZzP8mJ57JWUFKhBsSIHCv56omZK5ALgGNSyk4p5Szwa+DGxB2klM9IKVXV+0VgSYHHmBPqRK3LS7bsIhAleflBjKyDpaLes1Xs41nVR5oaAt/BrLVDq+VF+IN+Kh2VuB1u7QfZyxRnusbny2oJlGripJGTqbpyz+vZzkFBSYUv6DPUZJcNZgqQVqAn4d+9sW2puA34z4R/O4UQe4QQLwoh3pvqICHEHbH99vj9hXnRnXanfn0Eyiqh9by8/CDqBFfvqs9/PClQW9taRYD4A35qy2q1JU7m4P8A602mOef6tG+FgQOKIM2ALpOpjuTUMCxL4spRroqCGqCx/J26jMfokPxssJs9AC0IIT4ObAYSA6iXSylPCSE6gKeFEPullAvqn0sp7wbuBti8eXPBam97XV79lvltW+H5O2FmMqcMVl/QR52zDoctf+0nFXabUszOKtp4VlpaCv9HKBSit7eX6enkeThSSr677rtUTldy6NChfIecN++reh+iSmQci9PpZMmSJTgcseehLdb3pHsXrE+piwE6TKY64wv6WFmz0tBrqM9RzkIzRwUlFf6gnwubL9TlXPlipgA5BSxN+PeS2LY5CCGuBP4euExKOaNul1Keiv3uFELsAM4F9GugkScN7gb9bOPtW2H3t5UqnquuzPrwrJLL8sDr1lFo5slgYFC7lpbCvNDb20tlZSVtbW0pTSQlwyVUlFbQWpFu8VwYjowcwW13s6QytaVXSsnQ0BC9vb20t7crG1vPU/ITNAiQWmctdmG31Arkkpb86kplQn2Ocu7xk0OARiqC4SATsxOWiMACc01YrwCrhBDtQohS4CPAnGgqIcS5wA+AG6SUvoTttUKIstjfDcA7gTcLNnINeF3e/JpKJbL0IqUAWxYJX4kUqvBag6vBOuYcrVnoafwf09PT1NfXp7Wv2212/Up954GUknA0jN2WXicUQlBfXz93VVXiUASoBjOpTdgU5cgC33MgFGAyNGn4s13uKMdld+WuEHbvVvxM9vzr0KlzihVyQMBEASKlDAOfAR4DDgG/lVIeFEJ8VQihRlX9H6ACuG9euO5aYI8Q4g3gGeCbUkpLCZAGdwP+oF+fjnWlbqW8eI5+kEKVfva4PJZYgUSiEYaCQ9pesgzmhUzOWYfNYQkBEpERpJSazJRJ76n9Uhh8CyYyh2FbJRekUPkQQgjl2c5FIYwrKPr4P6zSC13FVB+IlPIR4JF5276c8HdSe42U8nngbGNHlx9e19sd62qcOsRrt22FXf8C02NKgqFGwtEwQ9NDBXngPG4PQ9NKYl2JrcTw66ViZGZEe+JknuYFu81OIJx7jo5eqEIs0wokJe0xAdq9C86+Ke2uHreHE+MncruOjhjZiXA+Da6G3Mx2J2P5NXr5PwqQ95INxUx0g8jb8Taf9q1KpzyNhe9UhqeHicpoQZa8HpeHqIyanlgXz8jWIjRV80KO4ZV2m51INGJYCZeSkhI2bdrEhg0buP766xkdHU26nypAoqEoH/7wh1m5ciUXXngh3d3d2i7UtBHKqjRVf/a4rFFEMqeWxTmScwmX7t1gdyml83Ugq2e7ABQFiEGoGoJuS/0lF0BJWdbl3QtZN8cqIZ6a7znH/I9EVJORUWYsl8vF3r17OXDgAHV1ddx1111J9wtFQwD8/Kc/p7a2lmPHjvG5z32OL3zhC9ouVGJXaq9pyAfxuD2Mz44zHc6/SnQ+FLKoYM5FJLt3K/0/dPB/gGKOLrWVUlVapcv58qUoQAxC98Q6h1N5ELN0pBciiVBF1wTKPNBsG9chvFI1GRXCD3LxxRdz6pQSqHj8+HGuueYazj//fLZu3RoP3X34oYe55ZZbALjpppt46qmntPvh2rbCcCeMn067m2W+54AfZ4mTSkel4dfyuD0EwgGmQlPaDwoMw8BB3cxX8HZwiBWy0GGR5IEsRnQ3YYGiKe/4plL4zlWr6ZBCa2lgfmKd5sTJLPwf//TQQd48Pb5ge1RGmQ4HKbOPUCKy8/usa6niK9ev17RvJBLhqaee4rbbbgPgjjvu4Pvf/z6rVq3ipZde4r9/9r/zowd+xOlTp1m6VImOt9vtVFdXMzQ0REODBj+BuhLr3g3nfCjlbomtbdOFDBtNISfTxPyX8uoM/eZVTjwPSF3qX6kUKiRfK8UViEG47C4qHZX6Rqu0qYXvtPtBfAEfNmGjzlmn3zhSEK9CbLIJS3Pi5Inn8g6vVCcvaZAPJBgMsmnTJpqamhgYGOCqq65icnKS559/ng9+8INs2rSJT37yk/T392MvyVMfbDobyqozmrGs0s63EFnoKjmZZ7t3K3XGWvXxf4B1eqGrFFcgBqKG8upG6/nKA9m9G9Zcp+kQf9BPvbM+9+icLHCUOKgtq9Uv/yVHNGlpgWGlfMf2f9B0zlQrBSklh4YPUe+sp7G8MduhZkT1gQQCAd71rndx1113ceutt1JTU8PevXvj+3WOdmITNlpbW+np6WHJkiWEw2HGxsaor9dYwsZWEvOD7E67m+7+vRzxB/2srVtbkGvllIF/QvV/lOk2Dn/Qz5ZW/VY0+VJcgRiI7vHyDqdSPTULP4jRvdDno2sGfo5o0tJ0Ki8hhMAujE8mdLvd3HnnnXzrW9/C7XbT3t7OfffdByhC7MC+AzhsDm644QZ+9rOfAXD//fezffv27Ew87TE/yNiCohBxqsuqcdgcpn7PUsqCPttZr64Dw9B/QFf/RyCk+GAKEbaslaIAMRDdVyCgPJD9B5QHVAOFLrymawZ+jmhq36tjeQm7zR6PgjKSc889l3POOYdf/epX3Hvvvdxzzz1s3LiR9evX8/gjj2O32bntttsYGhpi5cqVfPvb3+ab3/xmdhdJ9IOkQE2sM3MFMhWaIhgOFuzZriqtoqykTHvgwMkX0N3/YaFGUiqa7RpCCHdCafUiGlBXIFJK/Rx9bVsAqTyga96dcXd/0M85nnP0ubYGGlwNHB09WrDrzSccVboiZlyB6Fhewm6zMxs1psHS5OTcHhQPPfRQ/O9HH30UUO75reG3sNvsOJ3O+MokJxo3KImq3btg44dT7mZ2a9tCZ2QLIbIr1RP3f5yv2xislgMCGlYgQohLhBBvAodj/94ohPg3w0d2BtDgamA2Osv47MLonZxZsvltP0gGQtGQMpkW8IHzuD0MB4dN642uJk6m1dJU/4dO2qHD5iAcMa+ciWo+06Xasq0Elm/J6Ej3us0tZ2JGX/CsioV2744169LR/2GxLHTQZsL6DvAuYAhASvkGcKmRgzpTMKThkL0slg+SOeFrKKj0dyjkS+ZxeQjLMCPT2nps642miUXn8tp2m52INC4bPROq+Uy3QIm2LTDSDaM9KXcxOxu9kOHpKprLmQRHoH+/rv4PMOeeM6HJByKlnP8kRQwYyxmHYWGtGv0ghUwiVDE7G13TPevo/4DCJhMmI+86WPNRV2aqoE2Cx+1hMjRJIGSOVbuQZUxUNPt9Tqj+D30KKKr4Aj5cdhcVjux7AhmFFgHSI4S4BJBCCIcQ4n+gVM8tkoHEhCtdUf0gJ55Pu5sZy3yzGw5p0tJ0Li+hmo4K4UhPhu4rkMYN4KxJu8o1uze6L+DDbXdT7tCY1KcDqtAMhoPpdzzxnFJ2qHWzrtf3B/w0uBosk4UO2gTIp4BPo7SbPQVsiv27SAbiKxC9J9PEfJA0mFH6Wb2WmROLQKROnNTZ/wHWWIGU2EqwCZ2CKm025f8nTfsAs5NG1V7ohSRewiVTlGH3LkVBcTh1vb4/WLjESa1kfOKklINSyo9JKRullF4p5cellJmbJxfB7VA0JN1fsrgfJL0A8Qf8lIiSgmShq6gTi1n28cHgIPWuNImTOvs/wBoCRPdE0bYtMHoCRk8m/djsZEJ/QEOots7ES/Wky38JjkLfPt36nydihtDMhJYorJ8IIX48/6cQgzsTMCxevm2rokmn8YP4Aj4aXA36aaYaKCspo7qs2lQfSFotTefy2gAlogQhhCEmLC3l3MPRcNyM9u1vf5t169ZxzjnncMUVV3DiRI59O+L5IMn9IGaXMzGjpIcm/97JF9E7/wMKnzipFS0zy8PAn2I/TwFVwGTaIzQihLhGCPGWEOKYEOKLST4vE0L8Jvb5S0KItoTPvhTb/pYQ4l16jMcIDIuXj9fFSu0HMUtjMbMzYcZ77t4Ny/TJ/1ARQhjW2lZLOfdQNBRfgZx77rns2bOHffv2cdNNN/G3f/u3uV3Yu14p2Jlilasm1pmhKEgpTTVhpVUIu3cp/o8l79D12oVOnNSKFhPW7xJ+7gU+BOTtHRJClAB3AdcC64CbhRDr5u12GzAipVyJEk78z7Fj16H0UF8PXAP8W+x8lsOwFUjreYomncaMZZbNtMHVYJppI62WZoD/Q6UQvdFTlXP/6HUfpetIFwDbtm3D7XYDcNFFF9Hb25vbxWw2xQyTomyOmlhnhgAZnx1nJjJT8GdbLeGS9p67dyu5Wjr7P6zWylYlF8PpKkAPMXgBcExK2QkghPg1cCOQ2Nv8RuAfY3/fD/yrUEIQbgR+LaWcAbqEEMdi58uuXV8B8Lg88d7oukZPaPCD+AN+zvPqZ6rRitft5ZX+Vwp+XTVxMqWWlo//4z+/qMT2p6AlMq3kgdjd2s/ZdDZcq63USKpy7m0r2rj/ifv50t98iV075jq977nnHq699lrt45lP21Y4/DCMnIDa5Qs+NiuZMB5dWODJNGNv9Okx6N8Hl35e92ubEVGphYwCRAgxAUhAxH73AxrbnKWlFUjML+kFLky1j5QyLIQYA+pj21+cd2xrivHfAdwBsGzZMh2GnR0et4eZyAwToQn9u4i1bYVnvqZo1u65jvLZyCyjM6PmrUCMEJoZUBMn1V4sC+h+Tnf/h4oQQnvjpixQy7mfOnWKtWvXLijnHpVRZiOzyPDca//iF79gz549PPvss7lfPDEfJIkA8bg8HBk5kvv5cyQeqm3Gs52uWOjJF5W20wascK2YRAgaBIiU0vh2XwYipbwbuBtg8+bN+r/hGUi0m+ovQBJe8LXXz/nIzMJrHpeHcDTM6MwotU5tja/0IGOph3z8HxlWCuMBP76AjzV1ayix6WdNzVTOfWJ2gpPjJ2mvbo8f8+STT/L1r3+dZ599lrKyPEppeNeBq04J59300YUfu708dzp1sqFRmP1sd491J/+wexeUlOru/wBzEie1kNIHIoQ4L92PDtc+BSxN+PeS2Lak+wgh7EA1SkkVLcdaAkMzs1vPT+kHMWuZn3jNQtvH09qJDfR/QEJvdGmMHyRVOfdQNISUkjf3K5bf119/nU9+8pM8+OCDeL15TjY2m5JNncJM2uBqYCo0VfBsdDXyy4yy5qpJOindu5XkQYdL9+uakTiphXRO9G+l+fkXHa79CrBKCNEuhChFcYo/OG+fB4FbYn/fBDwtFTvBg8BHYlFa7Sh+mZd1GJPuGJqZbS9VNOokL3i8cqcJy3yzstHTamnx9qL61idSKUQuSLJy7lvfsZUbt9zInx76EwCf//znmZycjHcrvOGGG/K7aNtWGDup+EHmYVilhQz4A34qHZW4HVn4m3TC4/YwPjvOdHh67gfT49D3hmEKihVzQCCNCUtKuc3IC8d8Gp8BHgNKgB9LKQ8KIb4K7JFSPgjcA/w85iQfRhEyxPb7LYrDPQx8Wkppyfpchr9kbVvg6YV+ELOX+YljKBS+gI8SUUJtWRKzmQH5H4kYJUAylXM/PXma8dlx1tStARTzla4k9geZ5wdJzAVZXrXQR2IUmvq9GEQ8Gz04OLcfvIH+DzAncVILmqKwhBAbUEJt47FpUsr/yPfiUspHgEfmbftywt/TwAdTHPt14Ov5jsFo4tnoRmnjqkY9zw/iC/iw2+zUlNUYc900qE7sQueC+IN+6l31yX0QBuR/JGJWPazEJEJD8KwFd71i3z/3Y3M+Misb3cyEusRSPXMESPcusDkM8X+Acs9ne8425Nz5oCUT/SvA92I/24D/DeS5Lv6vhaGlr1ti+SDz6hapnQjNKLzmsruodFQWPEvZH0iR96L6P5Yb10vaJmwIIQpeziQxidAQ4vkgu2FelJmqKJhhwjIroS5ezmT+s33iOSX/o1R/s5qUksHgoOWSCEFbJvpNwBVAv5TyE8BGFGd2EY143V7jXrIUfhBf0NyyBx534bPRU5o24v4P4wSIkdno6TB8BQIxP0iPUhsrgUpHJc4SZ0FXIFJKU5/tpAEiMxNweq8h9a8AJkITTEemLWnC0iJApqWUUSAshKgCfMyNgCqSAY/b4OY7bVvBdxCm3q5xORgYNNXpZkbP7JSaqer/aDU2qdJhcxRUgEgpjSmkOJ/2mJl03ipXCKE82+mKC+rM6Mwo4WjYtIS6mrIa7MI+Vzk6+SLIyNv/Tzpj1RBeSB/Ge5cQYgvwshCiBvgh8CrwGhbM+LYyib3RDSHRDxLDF/SZEuao0uAubJmL2cgsIzMjybW0eP8P/dqLJsNusxfUB6J7I6lUeNbE/CALo/0KrSiYnVBnEzbqXfVzFcK4/+MCQ65pZkRlJtKtQI4A/wd4D/B3wEvAVcAtMVNWEY0Y0hs9kZZzlQ57sRc8GA4yMTthqsZiuNCch6oRLrjneP6HMdphIoU2YcUFiDBYgAihmP+S+EEKbaq0gja+oDe6Wv/KAP8HmBtRmYmUAkRK+f9LKS9G6X8+BPwYeBR4nxBiVYHGd0ZgSG/0ROylsPRtP4haq8dMjcVwoTmPlFpaAfwfKg6bg6iMEonqF1Gerpy7utpJ9IH89Kc/xePxsGnTJjZt2sSPfvQjfQbSthXGe5Ve6QkUuje6FbTxBlfD2/c8PW6o/wPMTZzMhJZqvCeklP8spTwXuBl4L3DY8JGdQcTj5Y20FbdtiflBBi1RuTPubCyQeSOlaaNA/g8wJhckXTl3Net9vgnrwx/+MHv37mXv3r3cfvvt+gxEXcHNa3PrdXsJhANMhab0uU4GzDZhwbx2BT0vKf4PAxWUweAgFY4KUxInM6EljNcuhLheCHEv8J/AW8D7DR/ZGURB4uXbL1V+n3guc02oAqCpe5uOpKxW2r0blr7DcP8HvG1KMsqMNb+c+03X38SHrvgQ2y/fzuHDBut0nrPA3bDAD1JoRcEX8FFdVk1ZifHfZyo8bg+jM6PMRmbf9n8sNcb/AebmvWQipfFUCHEVyorjOpQyIb8G7pBSFkbVOIMoSLx8gh/Et1xJODLzoVPNdoWyj/uDfuzCPrd4Y2AYBvbDtv+Z9/n/+eV/5vBw+kk6KqMEw0HKSso0ObbX1K3hCxdoK2ydrJz7P33rn/Au8zJ6dJS//Mu/5Omnnwbgd7/7HTt37mT16tV85zvfYelSHYIm5/tBYvlFiVUH2qrb8r9OBlLm+hSQxOoSrd3PKTXpSo2rUWWFe05FuhXIl4DngbVSyhuklL8sCo/ccNldVJYanFhX4oBlF0H3bvxBP2UlZfpX/82CQvdG9wV8NLjnte9Vo9IMCq+cj5q0KdEvcEAt597U1MTAwMCccu6f/PNP8r7L3scnP/lJ+vr6ALj++uvp7u5m3759XHXVVdxyyy0ZrpAFbVtg/BSMdMU3Fbq1rRVqQsWF5tgJOP264f41K9xzKtLVwtpeyIGc6ahRSYbStgWe+iq+8R4aXA2mZKGruB3ugmaj+wK+hSa7rl3KqkyH+ldaVgpSSg4PH6bWWUtTeVPe14T05dwf2vkQDpuDZVVv97mpr6+P/3377bfn3tI2GaqZtGsX1HUAhS9n4gv45pSuNwN1MvedfN5w/4dVe6GraEkkLKIDBUm4ijk6/aOdNLobjb2WBgrZsc4fSKKlde9WotMMqn81HzUb3YhckGTl3B/6/UPYbXaklLzxxhsA//E1QQAAIABJREFU8ZUIwIMPPsjatWv1G0TDaij3zPGDlDvKcdldBcn5icoog8FB05/tuAmr/3XD/R+jM6OEoiFLljGBogApGAWZTFvOBUc5/sCAJTSWQmYpLyhvMTWoRKUVIHw3ESNzQRLLuf/8Fz/n/p/fz1UXX8X69ev54x//CMCdd97J+vXr2bhxI3feeSc//elP9RtAknwQtc1rIRSF4elhIjJi+rNdU1aD3WbHN3LMcP+HuoJfdCasIvqiNqKJyuhcO72elDiQSy9kIHyMLRZwunndXl7uN75NS9LEybj/41LDr5+Iw+YgGA7qdr5U5dxnI7P84Lc/oKWiZU7gwDe+8Q2+8Y1v6Hb9BbRthYO/h+FOqF8BFE5RiE+mJmvjQgi8zgZ8452w5j2GXsvKSYRQXIEUDI/77TavRjK1/EKCAhrt5ncu87q9DAYGicqooddJmjjZtQsc5cqqrICoKxCjM/ALVsZkPknyQQri38MaWegq3hIn/hKb8Q50EzuLaqEoQAqE4dnoMXyN6wDwTA5l2NN4PC4PYRlmZHrE0OsMBAaU6yW+ZN27lKi0EoMr1c7DbrMTlVHDhaYqQAyvxDufhlVQ7p3jB/G4ldW10ULTCgmyKp5QCJ/dbqj/A6yReZ8OUwSIEKJOCPGEEOJo7PeCFnJCiE1CiBeEEAeFEPuEEB9O+OynQoguIcTe2M+mwt5B9hSqS5+vQulK6B1a2IK00MSjVQyOxIov81XTxqQf/Id1Cd/NdlKM90Y3uCaW6qjPZQWS10SfxA/icXkIhoOGZ6P7Aj4EgnpXfeadDcY7NYzP7jDU/wHKPdeU1VBaUphAkGwxawXyReApKeUq4KnYv+cTAP5cSrkeuAb4bqwqsMrnpZSbYj97jR9yfhQqY9c/o2j73r4Dhl5HC4XqmR23jZfHBIhqXsmzgKLT6WRoaCirCVed0I2uyhuOhhFCUCKSdF9Mg5SSoaEhnE5n5p1T0b4VJvpg6DhQoFI9KO9Ovau+8Kuu+cxM4B3rZ0pI44Vm0GcJk10qzHKi3whcHvv7Z8AOYE6gvZTySMLfp4UQPsADGOtEMIiUncx0Jr7k9R9RNPEK87PRDV+BBPw4S5xUOiqVDd27obQCmvNbmC5ZsoTe3l78fu0CMBwN4wv4mC6bNrR20ej0KDPRGYQv+1wfp9PJkiVLMu+YikQ/SMPKOebZjuqO3M+bAV/AZw1TzsmX8IQVBcHovBSr9kJXMUuANEop1YD1fiBtYLcQ4gKgFDiesPnrQogvE1vBSClnUhx7B3AHwLJly5LtUhBKS0qpKaspiDZeUeLCLSWc2A3r32fo9dJR76pHIIwXmrEQ3njiZPcuWHYxlOT3eDscDtrbs5scAqEAH/3lR/nseZ/ltrW35XX9dNz++O0Ew0Huve5ew66RkvqVUNGoCOrNnyiceTbg0y1BMy9O7MYbW5T6A37DBcjq2tWGnT9fDDNhCSGeFEIcSPJzY+J+UrEPpLQRCCGagZ8Dn4h1RgSlzMoa4B1AHfNWL/POf7eUcrOUcrPHY64kN7wzIbGyBxVNigaepAFQIXHYHNQ56wqy6oprphMDMHikYOVL5uN2uCl3lBteA8wf8JuXUBf3g+wCKQtnnk3VsrjQdO/GW68kaBpptotEIwxOD1rjnlNgmACRUl4ppdyQ5OePwEBMMKgCIum3EGuh+yfg76WULyacu08qzAA/AYwNhdCJQoQ7KmUPvPG6WGZjaD/4GHOy0OP+j8ImECZSiB4ZphfYa9sKkwMwdIxyRzluu9vQew5FQgxPD5vvD5iZhFOv4V2m9P8w8p6HpoeIyqjpeS/pMMuJ/iCgVnm7Bfjj/B2EEKXA74H/kFLeP+8zVfgIlP4k5nuMNVCIhKt4Tai2LUok0mRh+5LPx+hVl5RybrG57l1QVgVNGw27ZiaMFpqBUICJ0IS5mum8fBCj7znecdLsyfSEUv+qvGM7brvbUIXQ6jkgYJ4A+SZwlRDiKHBl7N8IITYLIdQWah9C6YZ4a5Jw3XuFEPuB/UAD8LXCDj83PC4PQ8EhXTvWJRKV0beX+fE+6eauQrxur6ECZDI0STAcTBAgu3Xxf+SD0UIzZfveQlK/Aiqa4qtcj9vYciZJc33MoHMHlJTBsosMf7bVc5td+ysdprxlUsoh4Iok2/cAt8f+/gXwixTHL8pKwV63l4iMMDIzYkh7ytGZUcLRsDKxNG9S/CBdu0x1pHtdXoanhwlFQjgMSOqb00hqvA+GjsH5t+p+nWxI7AdvREVkSySXCaH4mTqfVfwgLg/7B/cbdjl1dWP6ZNr1LCy7EBwuwwWIFbovZqKYiV5AjO6dMKfUQ4ld0cRN9oOo92yUU3mOZmoB/wcY3w/eMgX22rbAlA8Gj8YLKhqVjR4XmmZOppN+GDgA7ZcBxpvtfAEfNmGjzlln2DXypShACojRvRPik6mqmbZtgcG3YLIwFXGTEc8FMcj3M6fYXOcOcNWa6v+IjwUDFQWrFNhL8IN43B6mI9NMhCYMuZQv4MNus1NTVpN5Z6Po3qn87rgceNtUaaTQrHfWF77eWRYUBUgBMTpjVxVM8WV+/AU3bxVi9GQa10ydDYoAab8MbOY+1vGwVoO0U1/Ah8vuosJRYcj5NVPXAZXNSlir2sI4YMxKU406M6yStRY6n1UCNGIJql6Xl1A0ZFiB1AUtCixIUYAUELWGj1ErEFUwxf0rzRuhtNJUAWJ0Br4/4KfSUYl7/LTSbrXjckOukw1GrzTVydTMjpNALB9kK3TvxqO2MDZIObJESY+uZ5VVfSxAw/CVZrImaRajKEAKiJpYZ6RmWuese9tZXWKH5eb6QWqdtdhtduMmUzXqrHOHsqHjckOukw0NbmUyNex7tpJmGvODeKaVmlCGKUcBkwXISLfyE/N/QIEEiNlhyxkoCpACY2RnwqQai+oHmRgw5JqZsAmboYl1A2r3xc4dULMc6sztlw3gsruoLDWuH3zS/u9mEQtY8Ay8CRg7mZoaddb5rPK74/L4JiNNlbORWUZmRqyjKKSgKEAKjJGTadJic2pEkon5IEYmUPoDfrzOBiVcueNyQ66RC0a1eZVSWqvAXl0HVLbgPvESFY4KQ6LtAqEAk6FJc1cgXc8qeS+es+KbjDTPWiZQIgNFAVJgjAz9S7rMbzLfD9LobjRkMlUTJ71RCTNj1hIgBgnNidAE05Fp60wsaj5I927DEihNn0ylhK6dSnvkBL9TaUkptWW1xtxzYn6ThSkKkALjcSvZ6Hr3iwhFlVpBCzRT1Q/StSv5gQXAqFXXyPQI4WgYz0RMOCXYp83G6/IaEpHkm7JIDkgibVsgMIinxG2IcmR6DojvTZjyQ8fC58uoDHw1JN9S33MSigKkwHjdXiRS98llKDiERCZ/4NovhaGjMNar6zW14nF7mAxNEggFdD1vf6AfgKahbmg6B8rN71Snoq5A9M4RiN+zFcqaq6h+kHDYEEXB9MlU9X8kUVC8bq8hK83+KQt+z0koCpAC0+RWHgh1ItCL+APnTvLArYhVjTn+tK7X1Iqal6K3djowpUwsTQOHLGW+AmViCUfDuucIpP2ezaK2HaqW0Dg1zEBgQPd+8Kbfc+cOxddTs3TBR0aVMxkIDOCyu6gqrdL93HpSFCAFRtUo1JdCL9TzNZYnqRXkXQuVLXDsKV2vqRWjSrjE73lm2nICxCgH60BgAIGIhwpbAiFgxTaahk4QjoYZnh7W9fT9U/1UllYa2uExJeEZpUTOiuTl99QCqeFoWNfL9k/10+huND/XJwNFAVJgjBYgSZe8QigvQOcOMKgScDrUFYju9xzox4GNOhGr+2UhjArx7J/qx+PymN8XfD4rr6RpRskF0ft7HpgaMM+Uc/JFCAVg5ZVJP24sb1RM0jpHn5l6z1lQFCAFprK0knJHuSGTqdvufrsv+HxWbofpUTj1mq7X1YJRQnNgagBvVGJbeiGUmqCdpsGoFUj/VL81J5aOy2mKKP4eI55t08xXx54Em+PtskDzUMfVN9WX9PNc6Q/0m195WANFAWICTe4mQ1YgTeVNqZe8HdsAAccLb8Zy2V3UlNXof8/jJ2maCabUDs2k0d2IQOgvNAMDyc2UZuOqocl7NmDM6to0oXn8aaW7Z1nyumPN5c2AvvccjoYZDA5aU1GYhykCRAhRJ4R4QghxNPa7NsV+kYRmUg8mbG8XQrwkhDgmhPhNrHvhoqGpvEl3J3rGJa+7DlrPM80P0lzerLuWNjDeQ1MkAquu0vW8euAocdDgatB1YpFSxm3jVqRmxVWURaP0j3bpds5gOMjozKg5k+l4n1K+feWC1kVx1HHp+Wz7A36iMloUIGn4IvCUlHIV8FTs38kISik3xX5uSNj+z8B3pJQrgRHgNmOHqy9N5QasQAIatLSVV8KpPRAc0fXaWmgsb9RVaEZllIHQOE02F3jX6XZePdFbaI7PjhMMBy07sYhVV9IcjtDv16/DdDzSzox7VqMW06xwK0orqHRU6vo+q2HLVlUUEjFLgNwI/Cz2989Q+pprItYHfTug9knP6ngr0FjeyPD0MLORWV3OF4qEGAoOZbYTr7gCZPTtuPYC0lzeTP+kfi/Z8JSPMJLG+tVzsoOthN6KgjqxWFWA0LyJRinoGz+p2ynjeS9m+ECOPQkVjdC4Ie1uTRVNuioKiyUHBMwTII1SSvV/vB9IJWqdQog9QogXhRCqkKgHRqWUatxcL9Ca6kJCiDti59jj9xvXPSwb1JdB1a7yZSAwgERmfuBaz4eyalP8IE3lTUyEJpicndTlfP1dzyjnbb1Ql/MZgboC0SuZMB62bFXN1FaiCM3QBET1yQUxbTKNRqDzGUXpyqCgNLmbdHuXoShAABBCPCmEOJDk58bE/aTydqV6w5ZLKTcDHwW+K4RYke04pJR3Syk3Syk3ezzWqCsTj0rSyaSTNgckkRK7Uo7h2NNKfZ8Corezsf9ETIC0J4/PtwLNFc3MRGZ0SyZcDBNLU/1ZDNog3LdXl/OpE3PBAwdOv66YetP4P1T0NlX2B/opd5RTWZoiotJCGCZApJRXSik3JPn5IzAghGgGiP1OGuso/297Zx4dV3Em+t/XklqWJVnWLmuxJWNL8gpe2JewhnWABCeBmRCHIZOXzMmczCQzgbxM5uRNXk4gJ8m88OBNkgkJTMIEyAaG2AZj1mHxAniRbMuSbe1uydrV2qWu90fdliVrcav73l5M/c7p07fr1q2uqntvfVVfffWVUk3W93HgdWAd0A4sFBH/Po+FQJNT5XACu81a5+TeYtl10NMIp6ps+e9AsVtotnh0A5WbscyW9JzAbhPPlv4W4iQuqh3s5eVfhE+EU0dfsCU9T7+H9MR0EuMSbUkvYGpeAcSyXpydvOQ8uoa6GBgdsOWvW/paoneUeQaRUmFtATZbx5uB58+MICLpIpJoHWcBlwOHrBHLa8Cm2a6PZmwXIHNx9eCfEKx+2Zb/DhT/CMSWxrS3BU9fC4kSR3ritAZ8UUFeir0CxNPnISspizhXnC3pOUFeZikAnlp7nHdGzIS3Zqe2WgzAv5oT73M0jzInEikB8hBwg4hUA9dbvxGRjSLyCyvOCmCviOxHC4yHlFKHrHMPAF8TkRr0nMjjYc19iCTFJ5GWmGbrAxewq4e0QshdA0e32/LfgZKVlIVLXPaU+dhOPPFx5CZlRbWrB7vVdrGwOnnc11v7YRgIXXXn6fOEX33lPQWNe2BZYObhtnaOCNCiMkqIP3sU+1FKtQNTlItKqb3AF6zjd4A1M1x/HLjIyTw6Td58+9aCtPTPsWEpuwne+jH0d+j1IWEg3hVPzvwcexrT6h14EpPIW7A49LQcxK96Oem1T4VVllF29ogRZLw3HidaDbRm01mumJ2WvhY25m60I2uBU/0yoKDs5oCi+8tsx0S636LSqLAMs2KniWdLX8vczBxLbwY1Zul5w4ctK/DHRqBmJy3uJHKjySPtNIiINl+2oaMQ7YsI/aS4U0hJSMEzLyXkUW7fSB+9I73h740f3aadjy46P6Dofq8DdoxAWgdaA7OojBKMAIkQecn22Y7PWWeavw6Sc6Bqmy3/Hyi2WKvUvc3oUDetaiQmXrLc5Fxb7nPHYAeDY4Pkp+TbkCtnyUvO4+SCPN2THwt+47SIWJ2NDsGx16D0xoDXF9npdaDZ2wycVotFO0aARIi85Dx6h3tD3mSpf6SfzqHOuTUsLheUflxPFIbwgs+VvBRtLx/SfhFHtuJJnM8YPgpTC+3LnEPYtYDS37AUpMy45ClqyEvOw+NOhMFuqH836HSavNq4Mqxlrn0Lhr0Bq6/82GXKG5Eyh4ARIBHCLh86QT9wpTfrfcRDeMHnSt78PIZ9w8HvF6EUVG2juUjrxGPhJVuUvIhTA6cYCVFQN/Xp+xwLI5BFyYvwjPVDXCJUBa/G8j/bYS1z1TZImK938ZwDucm5to1ABDEjEMPsFKbo3rP/JQmWoHum510T8gs+V0K2SmqpgO56mvLKgdhpTBVq3A1JsDT1xk7PND8ln86hLvqLr4CqrUEvWm32NuN2uclKCtPmWUrp92HpNZCQNKdLFyUvwtPnCdnrQJO3iZz5OSTERdl+LzNgBEiE8KtfGntD26e80auvn3Nj6k7Wvayj28K2Kn1RihYgfqE3Z6q2AUJTqjYJjoU5ELvWCDR7m1mYuJDkhGQ7suUo48928cXQeSLoRatN3ibyU/JxSZiaqZYKvci27KY5X7ooeRGDY4N0DoXmqLTZ2xwTnQQ/RoBEiMx5mcyLmzcuAIKl2dtMUnwSmfPOvuBpCqU3QsdxaDsaUh4Cxf9iBD3qOvJnKLyQ5uFucufnRt+ufNPgF+yhjjSb+ppiYsQFp0fXjdmW56GjwRlrNHmbwtuYVm0HBErnLkD8QtM/UgyWsJc5RIwAiRAiQn5Kvi0PXH5yfnAL6spv1d+Ht8wezyZS3aksTFwY3KiruwlO7oOym8d7prFAfnI+gtjSUYiVhmW8o+Ab0KawR7YGlU7YG9PDW6DwQkjJmfOl40IzhPs84huhpb8lZp5tMAIkohSkFITeMw2lMV2QD0WXQGX4PMEUphQG95JVWY1Q2S0x1UtLiEsgLzkvJFWlUiqmBIhf1dbkbYLy26BxN/TMTW3pHfbSPdQdvsa04zh4DsDKO84edxoKUvW9CeU++y0UY+U+gxEgEaUwtZAmb1NIE28hN6Yr74CWg9B+LPg05kBhamFwL9mh5yGrjOGMElr7W2PqJStKLaKhtyHo69sH2xkaG4qZnqmI6M5RbxOstHZhODS3Ue64dWFqmO6zP38rb5893gwkxSeRlZQV0ggk1kx4wQiQiFKQUoB3RPe0gqFnuIfe4d7Q1kOs+Av9fSg8o5DC1EKavc2M+cYCv6i3BWr/G1Z9Ao+190msNKYQgtC0iMWGpSClQDem2aWQswoOPTen6/1l9quGHOfQ85C/HhYG7x6nMCW0++w3LomlZ9sIkAgSqimvf/4kpAduYREUbAyfAEkpZFSNzs2s9fAWQMGqO8d7eLHUmBalFtE+2B70otFYWkTox6+eVUrfN+rfnZMaK6yNaVc9NH8QtPrKjx0dBZe4wu88MgSMAIkg43rTIIe9tjUsK+/QE9SdtaGlEwBBmS9XPgfZ5ZCzIiYb01AnWP0djFhZXAb6Pg+MDuhFo0GosZq8TSTFJ4XHXX+I6is/hamFePo9QS8abfI2kTc/LyasC/0YARJBQjVrta037n9xwjAKGRcggTamvR6oextWfUJf19tIvGjPvrFCUWoREPwEa0NvAxnzMgJz1x8lTBKaQaixGr2NFKQUhMdd/6HnIW8tZCwNKZnClEJ8ykdzX3DrnBp7G8M352MTRoBEkFR3KmmJaSE1LKnuVBa4F4SWkfRi7WCx8k+hpRMAufNziZf4wMt8+AVAjfdi63vrKUwtJN4VkZ0IgsIvNIOdSK/rqaN4QbGNOXKe8c6R30x91Z1Q/17AaqzG3sbw+DrrqtdWYiGqryD0xcH1vfUsTo3uLQrOxAiQCFOQUhD0A+dvWGzppa3epPeBbqsOPa1ZiHfFsyhlUeBlrvijpb7S7ktqe2pZHOX7gJxJWmIaqe7U4BuWnvqYK/MU9ezKOwEV0Ch3zDdGfU99eITmgWf1d4j7lsCEUVcQ97lnuIeOwQ6WLFgScj7CSUQEiIhkiMgOEam2vqcoOkXkGhHZN+EzKCJ3WueeEJETE85dEP5S2MOS1CXU99YHdW1dT519D9yaTSAu2P+0PenNQsBrQTprof4dWPMpAHzKR0NPQ8y9ZKDL3OCd+wikf6SfUwOnYq7MSfFJZCdlU9dTpwOyS/WiwgCeL0+/h2HfsPNlVgoOPAOLL9Wj8BDJnp+N2+UOaq6rvke3AbF2nyM1AnkQ2KmUWg7stH5PQin1mlLqAqXUBcC1QD8wcSPvf/KfV0rtC0uuHaA4rZhmbzODo4Nzum5wdBBPn8e+nmlqnnYid+BZ8IXgbj0AClMLAxOa+58BBNZ+BoDW/lYGxwZZkhpbLxlYa36C8Drgb4BjTbUBUJJWQm1P7emA8+/Rxhqth2e9zl9mxxvTk/u0Gx/r+QoVl7goSC0ISlUZtjLbTKQEyB3Ak9bxk8CdZ4m/CdimlApt84wopHhBMQo154euobcBhbJ3mH/+3dBd77iL9+IFxXQPddM5OIvjOaVg/2+h5EptaszpXlqsqXNAC4BGbyOjvtE5XVfXG5sNC+j7XNtde3qh7OpN4IrX93UWwtaYHngW4tx6fsYm/GWeK/U99QgSE3vcTCRSAiRXKeXfCMMDnM3w+W7gzKfueyJyQET+TUQSZ7pQRL4oIntFZO+pU6dCyLIzFKcVA0zuqQWAIy9Z+a2QkAwHnFVjlaSVAHCi+8TMkRp2aU+u598zHuSvo1hsTEvSShj1jc5ZP+4Xmn5LrliiOK2YnuGe0x5qU7Jh2Q3WKHfmhaR1PXXjKjDHGBuFg7/XDkWT7DMVLkkroa63bs4dhdqeWhYlLyIxbsamLCpxTICIyCsiUjHNZ5K5g9Ldkxl9eYjIImAN8NKE4G8C5cCFQAbwwEzXK6V+rpTaqJTamJ3t4AMZJP4RxFx7LY40pu5kbdJb+TyMzE2lNhf8AuR49/GZI+3/rd7Yx79SHt2Yul3umHDjfiYBlXka6nrqyEnKiSkTXj/TPtsX3AO9J+H4azNe55/bc9SE99ir0Ndqm/rKz9K0pYz6Rudsmh+LhhLgoABRSl2vlFo9zed5oMUSDH4B0TpLUp8G/qSUGl+do5Q6qTRDwK+Ai5wqh9PMT5hPzvycOY9A6nvqyUrKsn9/iPPv0TsVOuihNz8ln8S4xJlHIMP9UPEnWHE7JKaOB9f11rF4weLw7Q9hIwGNuqahvqeeJWmxN+KCGUbXpTfBvIWwb2Y1lq3GITPx/hOQnA3Lb7Q12fGOQlfgHQWlFHW9YSizA0TqTdwCbLaONwOz2fbdwxnqqwnCR9DzJxUO5DFslCwomfMIxLGXrPhKyDgP9v7S/rQtXOKieEHxzI1p5R+1EFv32UnBtd21MTmZDHrNT05SzpxGIEopantqY7JhAe3K3u1yT3624xNh7ad1B6Wvbco1I2MjNHmbnL3PPc1wdLt+vuLdtiY93lHoCbyj0DHYQe9wb0ze50gJkIeAG0SkGrje+o2IbBSRX/gjiUgxUAS8ccb1T4nIQeAgkAX87zDk2TGK04o50XMiYK+8SimOdx93xk7e5YKN9+mJ9JZD9qdvUZJWMrMA2fM4ZJVB8RXjQUNjQzT0NrAsfZljeXKakrS5dRTaB9vpGupi2cLYLHOcK47FCxZPbUw33g9jw/Dhr6dcU9dTh0/5xhtiR/jg16DGYP3nbE861Z1KdlL2nEYgx7q0J+xYvM8RESBKqXal1HVKqeWWqqvDCt+rlPrChHi1SqkCpZTvjOuvVUqtsVRin1VKecNdBjspXlBM73Cv9hsUAG0DbXQNdbE8fbkzGTr/L/V+6Q6OQkrSSmjyNk01X27+UDu22/jXMEEHXttdy5gaY/lCh8ocBkrSSjjefTzgjkJ1p17UGYsNi59prZJyymHJFfr5OmMyvbpLl7k0vdSZDPnG4IP/1CbrIboumYmStJI5jUD8ZY7F+xx7yuRzkKUL9YPs74mcDf8D51hjmpypTRv3Pw1DzsjmkrQSFOr0QjM/ex7Xk+fn3z0pOJZfMj8laSV4R7y0DUxV3UyH/3k4b+F5TmbLUUrSSmjobWBobGjyiQvv125Eal6ZFFzdWU2cxDk3Aql+We97vvE+Z9Ln9Og60I5CTVcNaYlpZCVlOZYnpzACJAooSy8D4EjHkYDij/dMnVTnbLwfhnsdM+ldmqaF5qQ5gf4OqPgDrL4LkhZOin+s6xjxrviY1BP7Ge8odAfWUajpqiE9MT24/e6jhLKMMsbU2NTOUfltkJILe34xKbimq4YlC5bgjrN3bmKcdx+DBQVQdosz6aMFSO9wb8AdhZrOGpYtXBYex5E2YwRIFJCZlElWUhZVnVUBxa/pqiFzXiYZ8zKcy1TRRVCwAd55dFab/WApSSshXuInC809j8NIP1zy5SnxazprKF5QTEJc7Li6PhP/iLGqI7D7XN1VzbL02GxY/Pg7R1PKHO+GDffpEcGp0+eqO6udU80274Pat+DiL4GDz5Ff/RZIh1ApRU1XTcyOrI0AiRLK0ss42nk0oLiOvmR+RODyr+rFfIdfsD15d5yb8xaed/olGxmAXT/VC81yV02JX91VHbMvmZ/MpExy5ucE3LAc6zrGeWmxq74CvQAyKT5p+s7RRX8D8Unw9k8A7fer0dvo3H1+91Fwp8KGzWePGwLlGdrxZyD3uaW/Be+IN2afbSNAooTSjFKOdR0762Y0Y74xjncfD88DV36bnmh8+yfatYjdyWeUc6TjiNYV7/sv6G+DK/5+SjzvsJcmb1PMvmQJO9/OAAAQ1ElEQVQTWZGxIqCGpdHbSN9In/MdBYeJc8WxPH359KOu5CxtCXXgGehuHFdzOVLmrgbt2XnDZpiXZn/6E0h1p1KYUsjhjtl9fgHjncZYvc9GgEQJZelljPhGzrpOoLanloHRgfFejqO44uCyv9NWUSfOtKQOnRWZK+gY7KDV2wzvPKJVZksunxLvULs2J16VNXVkEmuUZ5RzvPs4A6MDs8arbK8Ezo0yl6WXUdVZNf2k8mVf0d/vPDp+nx15tt/6kfY2ffGX7E97GlZkBtZRqGirQBBWZKwIQ67sxwiQKMGvKz6bGutg20EA1mSvcTxPgDbpTc2Hnd+1fRTibyiq9v5Uu26/6p8mme76qWjX60RXZcZ+Y7oiYwU+5Rs3hJiJyrZKElwJlC50yJw1jJSll9E73MvJvpNTTy5cDGs+De8/wcGTu8iYl0F+ss37oHfW6jUnGzaPO+Z0mvKMchp6G+gd7p01XkVbBUvTlsakqxowAiRqKE4rJik+iQOnDswar6KtgpSElPDtUJcwD65+AJr2QtVWW5P2C81Dh/8AhRdpNxfTUNFWQUFKAenzwrA/tsOUZwamH69sr6Q8ozymjQb8rMxcCZzu/Ezh6gfAN0pF49uszlptv9HAGz/QXoCv/Ed7052FQOZBlFJUtlfG9CjTCJAoId4Vz9qstew/tX/WeAfbDrIqc1V4/UFd8FnIXAY7/9VWi6wUdwrnudPZJ8Nw3b9MO/oA3RtfnbXatv+NJPnJ+WTMy5j1PvuUj0Pth8Yb3linPLOceXHz2Nc6w7Y96cV4N2zm+Fgfq5MW2fvnLYe0Y86N98MCm9OehTVZWkMw230+2XeSjsGOmH62jQCJIi7IuYCqzir6RvqmPT84OsjRjqPhf+Di4uHaf4ZTR+D9X9mXbq+H9Z0e9s9PZmzJZdNGaRtoo7mvefyFjHVEhA25G3i/5f0Z4xzrOkbfSN85U+YEVwKrslbNLECAypU3okRYc+wd+1SlSsG2b+hJ86vCN/oASJ+XztK0pXzQ8sGMcfzahli+z0aARBHrctbhU74Z1Vj7Tu1jVI2yLmddmHOG3tO65GPwyr9Cb4s9ab78z6wfGMCLb8a5n90ndwOwMXejPf8ZBazPWU+TtwlPn2fa87s9uswX5l0Yzmw5yrqcdRzpODKj8cDe7mpcCGtPvGOfJ+jKP+l1H9d+G+Y7uGZqBtbnrufD1g8Zm2HUvtuzm+SE5PAYxDiEESBRxNrstbjENWPvdNfJXcRJHBtyN4Q5Z2j10q0/htEBeOmboadX8woc/B0b1twLwAet0/fUdnt2k5qQGtMv2Zn4799M93mPZw8FKQXkp9g8mRxB1uWsY1SNzqjS2XVyFyszV7IgZw1s/QYMdof2h31tsO0BvQ/7hs+HllaQrM9Zj3fEO+6G50z2ePawPmc98a74MOfMPowAiSJS3amszVrLW01vTXt+18ldrM5aTYo7Jcw5s8haBld9Q7sb2f9M8On0tcNzfwvZ5Sy65tsUphTyTvM700bd7dnNhrwNxLnigv+/KKM0vZRUdyrvNk/dOnjMN8belr3n1OgD9AgywZXAW41Tn+3+kX4OnjrIxYsugdsf0Rs9vfi14FVZSsELX4XBLrjz37U5egTw38Pp7nNrfyu1PbVclBezWxkBRoBEHR8r+hiH2g9xqn/y9rttA21Utldyaf6lEcqZxRX/AIsvgxf/AdpmN0WdFt8YPPdlGOiEu34BCUlcXXQ17zW/R//I5C3vj3Udo6G3gcvzp64NiWXiXHFcWXAlbza+OUW98UHrB3QPdXNFwRUzXB2bzE+Yz0V5F/Fm45tTzr3T/A6jalQ/2/nr4Jr/CRW/15s+BcPu/4AjL2rV1TReDcJFXnIe5RnlvNYwdffF1xteB+Dygth+to0AiTKuLLgSgNcbX58UvrNuJz7l4+NLPh6BXE0gLl43/PGJ8NSnwDvHfeZf/jZUvwQ3fR/y9OThNUXXMOwbntJT21G3A0G4bvF1duU+arh28bV0DnXyYeuHk8J31u8kMS5x/Dk4l7iq8Cpqe2qnLJZ9ufZl0hPTT6tmr/g6nHedngA//vrc/uTYq7D9QSi9GS79ij0ZD4Fri65lX+s+2gfaJ4XvqNtB8YLimPeuYARIlFGaXsrStKU8V/3cpPCtJ7ZSklYSHQ9cWgH85bPQ64Gn7gpMiCgFr34P3nsMLvofcOH4ti+sy11H5rxMnqs5XWaf8vHn439mXc46sudH3172oXJFwRUkxSex5djpCeORsRG2n9jO5fmXx+zCstm4YckNxEncpGfbO+zl9cbXuW7JdafnAlwu2PS4Nh1/+q+g/r3A/uDEmzp+djnc9R86nQhzw5IbUCheOHban5ynz8Mezx6uX3J9TDvKhAgJEBH5lIhUiohPRGY0rxGRm0SkSkRqROTBCeElIrLLCn9GRBzy/Rx+RIRNpZs40HaAija9AruyrZIPWj/gruV3Rc8DV3QhfObXcOooPH4DeGbZVXi4H7Z8Bd78Aay7V48+JpDgSuCu0rt4o/ENGnoaAK3WqO2pZVPpJidLETGSE5K5beltbD2xdXwjse2122kfbOdTZZ+KcO6cIXt+NlcXXc1zNc+Nqyv/UP0HBkYHuGv5XZMjJ6XDvX/SLt+fvF3voT7TnIhSepOo32yChUvgc89BYqrDpQmMZenLWJ+znqernmbUNwrA00eexqd8U8scg0RKRFcAnwSmKkQtRCQOeAy4GVgJ3CMi/pVVDwP/ppRaBnQC9zub3fBy57I7SU9M56HdD9E/0s/Dex4mLTEt+h645TfA5hdguA9+/jHY/k1on7Dvw5BXO0n890vhw6e0q5K/eGTaSc3PlH2GefHz+P7u79M30seP9v6I/OR8biy+MYwFCi+fXflZxnxj/HDPD+ka7OKRDx+hLL2My/KnXxNzLvD5VZ+nc6iTx/Y9RktfCz8/8HMuzrt4+rVNqXnwhVegcCM89yV4ahPUvn16MavPp0cdv74TtvwdLLkUPv9nSMkJb6HOwn2r76PJ28QTlU9wovsEvzn8G24svpHC1MJIZy1kJNBdsxz5c5HXgX9USu2d5tylwHeUUjdav/22ow8Bp4A8pdTomfFmY+PGjWrv3il/FZVsPb6VB956ALfLzbBvmO9f+X1uW3pbpLM1PX3tsOPbegdDNQbJ2ZCQBN1N+nfuaj3qKLlq1mSeOvwUD+1+CLfLzaga5dFrH+XKwnNvLmAij374KD878DPcLjcKxa9u+hXnZ58f6Ww5ynff/S7PHn0Wt8tNvCue39762/HNtqZlbBR2/wzeeFib97pTtCdfb6vePyYpHT72oHYPH4XWekopvv7G19lRtwO3y02KO4VnbnuGvOS8SGctYETkfaXUFG1RNAuQTcBN/j3SReRe4GLgO8B71ugDESkCtimlpl2eLSJfBL4IsHjx4g11dXXTRYtKdtbv5NX6V7mm6BquX3J9pLNzdroaoGobeA7A2DCkFcGy66DokoD10S8ef5H3mt/jlpJbuKzg3O2J+1FK8bujv+Ng20E+ufyTkVkkGmZGfaM8dfgpTnSf4O7yuwNf4zPcp5+vht3aii85S49OSm8Gd3TPGQ2PDfNE5RN4+jzcu/Je57bsdYiwCxAReQWYTsR+Syn1vBXndRwWIBOJpRGIwWAwRAszCRDHlkAqpULtMjcBE30vF1ph7cBCEYlXSo1OCDcYDAZDGIm8ndvM7AGWWxZXbuBuYIvSQ6bXAL95zmbg+Qjl0WAwGD6yRMqM9xMi0ghcCvxZRF6ywvNFZCuANbr4CvAScBh4VilVaSXxAPA1EakBMoHHw10Gg8Fg+KgT0Un0cGPmQAwGg2HuzDQHEs0qLIPBYDBEMUaAGAwGgyEojAAxGAwGQ1AYAWIwGAyGoPhITaKLyCkg2KXoWUCbjdk5VzH1FDimrgLD1FNgOFlPS5RSU9xif6QESCiIyN7prBAMkzH1FDimrgLD1FNgRKKejArLYDAYDEFhBIjBYDAYgsIIkMD5eaQzECOYegocU1eBYeopMMJeT2YOxGAwGAxBYUYgBoPBYAgKI0AMBoPBEBRGgASAiNwkIlUiUiMiD0Y6P+FGRH4pIq0iUjEhLENEdohItfWdboWLiDxi1dUBEVk/4ZrNVvxqEdkcibI4iYgUichrInJIRCpF5KtWuKmrCYjIPBHZLSL7rXr6X1Z4iYjssurjGWsbB0Qk0fpdY50vnpDWN63wKhE567bWsYiIxInIhyLyovU7eupJKWU+s3yAOOAYsBRwA/uBlZHOV5jr4CpgPVAxIewHwIPW8YPAw9bxLcA2QIBLgF1WeAZw3PpOt47TI102m+tpEbDeOk4FjgIrTV1NqScBUqzjBGCXVf5ngbut8J8CX7aO/xb4qXV8N/CMdbzSeh8TgRLrPY2LdPkcqK+vAf8FvGj9jpp6MiOQs3MRUKOUOq6UGgaeBu6IcJ7CilLqTaDjjOA7gCet4yeBOyeE/6fSvIfePXIRcCOwQynVoZTqBHYANzmf+/ChlDqplPrAOu5F72NTgKmrSVjl9Vo/E6yPAq4Ffm+Fn1lP/vr7PXCdiIgV/rRSakgpdQKoQb+v5wwiUgjcCvzC+i1EUT0ZAXJ2CoCGCb8brbCPOrlKqZPWsQfItY5nqq+PVD1a6oN16N61qaszsNQy+4BWtIA8BnQpvZEcTC7zeH1Y57vRG8md8/UE/B/gG4DP+p1JFNWTESCGkFF6nGzswS1EJAX4A/D3SqmeiedMXWmUUmNKqQuAQnRvuDzCWYo6ROQ2oFUp9X6k8zITRoCcnSagaMLvQivso06LpW7B+m61wmeqr49EPYpIAlp4PKWU+qMVbOpqBpRSXcBr6O2tF4pIvHVqYpnH68M6nwa0c+7X0+XA7SJSi1adXwv8hCiqJyNAzs4eYLll+eBGT05tiXCeooEtgN86aDPw/ITwz1kWRpcA3Zb65iXg4yKSblkhfdwKO2ew9M2PA4eVUj+ecMrU1QREJFtEFlrHScAN6Pmi14BNVrQz68lff5uAV62R3Bbgbsv6qARYDuwOTymcRyn1TaVUoVKqGN3uvKqU+iuiqZ4ibWEQCx+0tcxRtJ72W5HOTwTK/1vgJDCC1p/ej9at7gSqgVeADCuuAI9ZdXUQ2Dghnb9GT+DVAPdFulwO1NMVaPXUAWCf9bnF1NWUeloLfGjVUwXwL1b4UqthqwF+ByRa4fOs3zXW+aUT0vqWVX9VwM2RLpuDdXY1p62woqaejCsTg8FgMASFUWEZDAaDISiMADEYDAZDUBgBYjAYDIagMALEYDAYDEFhBIjBYDAYgsIIEIPBAUQkU0T2WR+PiDRZx14R+X+Rzp/BYAfGjNdgcBgR+Q7gVUr9MNJ5MRjsxIxADIYwIiJXT9jX4Tsi8qSIvCUidSLySRH5gYgcFJHtllsURGSDiLwhIu+LyEt+tygGQ6QxAsRgiCznoX0c3Q78BnhNKbUGGAButYTI/wU2KaU2AL8EvhepzBoME4k/exSDweAg25RSIyJyEL152XYr/CBQDJQBq4Ed2tUWcWi3MgZDxDECxGCILEMASimfiIyo05OSPvT7KUClUurSSGXQYJgJo8IyGKKbKiBbRC4F7S5eRFZFOE8GA2AEiMEQ1Si9jfIm4GER2Y/28HtZZHNlMGiMGa/BYDAYgsKMQAwGg8EQFEaAGAwGgyEojAAxGAwGQ1AYAWIwGAyGoDACxGAwGAxBYQSIwWAwGILCCBCDwWAwBMX/B/uTiBNF4AvkAAAAAElFTkSuQmCC\n"
           },
           "metadata": {
             "needs_background": "light"
@@ -483,14 +936,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 12,
       "id": "moral-worship",
       "metadata": {
         "id": "moral-worship",
-        "outputId": "164d96ee-bbdd-4fb9-c6d0-91e6cefb3ed3",
+        "outputId": "eef0a988-3e35-4e16-d019-e89f68342888",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 334
+          "height": 297
         }
       },
       "outputs": [
@@ -498,27 +951,19 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "<matplotlib.legend.Legend at 0x7f10ac836d50>"
+              "<matplotlib.legend.Legend at 0x7efe05ef4590>"
             ]
           },
           "metadata": {},
-          "execution_count": 22
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/google/colab/_event_manager.py:28: UserWarning: Data has no positive values, and therefore cannot be log-scaled.\n",
-            "  func(*args, **kwargs)\n"
-          ]
+          "execution_count": 12
         },
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEGCAYAAABLgMOSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAUOUlEQVR4nO3df5BdZX3H8c+nWWQpLBGSoGEX2WSCIQnWGBa0FRmoJoRMAwasBnVEkzFgoVOLWrHUX3U6lSodtKAYhaIUAcUfEBskWIIUKoQECJBITIA4bMQkhnbzQ5EkfvvHOUuuO/vj5smee+5x36+Zndw999xzvnn27P3sc865z+OIEAAA++uPyi4AAFBNBAgAIAkBAgBIQoAAAJIQIACAJC1lF3Agxo4dG52dnWWXAQCVsmrVql9FxLgD3U6lA6Szs1MrV64suwwAqBTbPx+O7XAKCwCQhAABACQhQAAASSp9DQQAyrB79251d3frhRdeKLuUQbW2tqqjo0MHHXRQIdsnQABgP3V3d6utrU2dnZ2yXXY5/YoIbdu2Td3d3ZowYUIh+2iaU1i2J9q+1vatZdcCAIN54YUXNGbMmKYND0myrTFjxhTaSyo0QGxfZ3uL7Sf6LJ9te53tDbYvlaSIeDoiFhZZDwAMl2YOj15F11h0D+R6SbNrF9geJelqSWdKmirpPNtTC64DADDMCg2QiLhX0vN9Fp8saUPe43hR0s2Szq53m7YX2V5pe+XWrVuHsVoAqJYf/vCHmjx5siZNmqTPfvazDd9/GddA2iU9W/N9t6R222NsXyPpdbY/NtCLI2JxRHRFRNe4cQf8SXwAqKS9e/fqoosu0h133KG1a9fqpptu0tq1axtaQ9PchRUR2yRdWHYdAFAFK1as0KRJkzRx4kRJ0vz583Xbbbdp6tTGXREoI0A2STqm5vuOfBkAVM6nl6zR2l9sH9ZtTj36cH1y7rRB19m0aZOOOWbfW2lHR4cefPDBYa1jKGWcwnpI0nG2J9h+maT5km4voQ4AwAEotAdi+yZJp0kaa7tb0icj4lrbF0u6U9IoSddFxJoi6wCAogzVUyhKe3u7nn123+Xk7u5utbe3N7SGQgMkIs4bYPlSSUuL3DcA/CE76aSTtH79ej3zzDNqb2/XzTffrG9+85sNraFpLqIDAOrX0tKiq666SmeccYb27t2rBQsWaNq0xvaGCBAAqKg5c+Zozpw5pe2/acbC2h+259pe3NPTU3YpADBiVTJAImJJRCwaPXp02aUAwIhVyQABAJSPAAEAJCFAAABJCBAAQBICBAAq6Nlnn9Xpp5+uqVOnatq0afrCF77Q8Br4HAgAVFBLS4uuuOIKzZgxQzt27NCJJ56omTNnNnQ0XnogAFBB48eP14wZMyRJbW1tmjJlijZtauzA5vRAAOBA3HGp9MvHh3ebr3yNdGb9Mwxu3LhRjzzyiF7/+tcPbx1DqGQPhE+iA0Bm586dOvfcc3XllVfq8MMPb+i+K9kDiYglkpZ0dXW9v+xaAIxw+9FTGG67d+/Wueeeq3e9610655xzGr7/SvZAAGCkiwgtXLhQU6ZM0SWXXFJKDQQIAFTQ/fffrxtuuEF33323pk+frunTp2vp0sZOs1TJU1gAMNKdcsopiohSa6AHAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACScBsvAFRUZ2en2traNGrUKLW0tGjlypUN3X8lA8T2XElzJ02aVHYpAFCq5cuXa+zYsaXsu5KnsCJiSUQsGj16dNmlAMCIVckeCAA0i8tXXK4nn39yWLd5/JHH66Mnf3TI9Wxr1qxZsq0LLrhAixYtGtY6hkKAAEBF3XfffWpvb9eWLVs0c+ZMHX/88Tr11FMbtn8CBAAOQD09haK0t7dLko466ijNmzdPK1asaGiAVPIaCACMdLt27dKOHTteerxs2TKdcMIJDa2BHggAVNDmzZs1b948SdKePXv0zne+U7Nnz25oDQQIAFTQxIkTtXr16lJr4BQWACAJAQIASEKAAECCsmcDrEfRNRIgALCfWltbtW3btqYOkYjQtm3b1NraWtg+uIgOAPupo6ND3d3d2rp1a9mlDKq1tVUdHR2Fbb+SAcJgigDKdNBBB2nChAlll1G6Sp7CYjBFAChfJQMEAFA+AgQAkIQAAQAkIUAAAEkIEABAEgIEAJCEAAEAJCFAAABJCBAAQBICBACQhAABACQhQAAASQgQAEASAgQAkKSSAWJ7ru3FPT09ZZcCACNWJQOE+UAAoHyVDBAAQPkIEABAEgIEAJCEAAEAJCFAAABJCBAAQBICBACQhAABACQhQAAASQgQAEASAgQAkIQAAQAkIUAAAEkIEABAEgIEAJCEAAEAJCFAAABJKhkgTGkLAOWrZIAwpS0AlK+SAQIAKB8BAgBIQoAAAJIQIACAJAQIACAJAQIASDJkgNgeZfvJRhQDAKiOIQMkIvZKWmf7VQ2oBwBQES11rneEpDW2V0ja1bswIs4qpCoAQNOrN0A+XmgVAIDKqStAIuLHto+VdFxE/Mj2H0saVWxpAIBmVtddWLbfL+lWSV/JF7VL+n5RRQEAml+9t/FeJOmNkrZLUkSsl3RUUUUBAJpfvQHy24h4sfcb2y2SopiSAABVUG+A/Nj230s6xPZMSd+WtKS4sgAAza7eALlU0lZJj0u6QNJSSf9QVFEAgOZX7228p0v6j4j4apHFAACqo94eyHskrbb9gO3P5VPKHlFkYQCA5lbv50DOlyTbR0t6m6SrJR1d7+sBAH946goA2++W9CZJr5H0K0lXSfrvAusCADS5ensQV0p6StI1kpZHxMbCKgIAVEJd10AiYqykBZJaJf2T7RW2byi0MgBAU6t3KJPDJb1K0rGSOiWNlvS74soCADS7ek9h3VfzdVVEdBdX0tBsz5U0d9KkSWWWAQAjmiPqH5HE9mGSFBE7C6toP3R1dcXKlSvLLgMAKsX2qojoOtDt1HsK6wTbj0haI2mt7VW2TzjQnQMAqqveDxIulnRJRBwbEa+S9KF8GQBghKo3QA6NiOW930TEPZIOLaQiAEAl1HsR/WnbH5fUe+vuuyU9XUxJAIAqqLcHskDSOEnflfQdSb2fCwEAjFCD9kBst0q6UNIkZUO5fygidjeiMABAcxuqB/J1SV3KwuNMSZ8rvCIAQCUMdQ1kakS8RpJsXytpRfElAQCqYKgeyEunqyJiT8G1AAAqZKgeyGttb88fW9mc6NvzxxERhxdaHQCgaQ0aIBExqlGFAACqpd7beAEA+D0ECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJJUMENtzbS/u6ekpuxQAGLEqGSARsSQiFo0ePbrsUgBgxKpkgAAAykeAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkBAgAIAkBAgBIQoAAAJIQIACAJAQIACAJAQIASEKAAACSECAAgCQECAAgCQECAEhCgAAAkhAgAIAkLWUX0Mv2oZK+JOlFSfdExI0llwQAGEShPRDb19neYvuJPstn215ne4PtS/PF50i6NSLeL+msIusCABy4ok9hXS9pdu0C26MkXS3pTElTJZ1ne6qkDknP5qvtLbguAMABKjRAIuJeSc/3WXyypA0R8XREvCjpZklnS+pWFiKD1mV7ke2Vtldu3bq1iLIBAHUo4yJ6u/b1NKQsONolfVfSuba/LGnJQC+OiMUR0RURXePGjSu2UgDAgJrmInpE7JL0vrLrAADUp4weyCZJx9R835EvAwBUSBkB8pCk42xPsP0ySfMl3V5CHQCAA1D0bbw3SfqJpMm2u20vjIg9ki6WdKekn0r6VkSsKbIOAMDwK/QaSEScN8DypZKWFrlvAECxGMoEAJCEAAEAJKlkgNiea3txT09P2aUAwIjliCi7hmS2d0haV3YddRgr6VdlF1EH6hw+VahRos7hVpU6J0dE24FupGk+SJhoXUR0lV3EUGyvpM7hU4U6q1CjRJ3DrUp1Dsd2KnkKCwBQPgIEAJCk6gGyuOwC6kSdw6sKdVahRok6h9uIqrPSF9EBAOWpeg8EAFASAgQAkKTpA8T2X9peY/t3trv6PPexfF71dbbPGOD1E2w/mK93Sz4CcNE132L70fxro+1HB1hvo+3H8/WG5ba6/azzU7Y31dQ6Z4D1+pvDvpF1fs72k7Yfs/092y8fYL2Gt+dQbWP74Px42JAfh52NqKtPDcfYXm57bf679Df9rHOa7Z6aY+ETja4zr2PQn6EzX8zb8zHbM0qocXJNOz1qe7vtD/ZZp5T2tH2d7S22n6hZdqTtu2yvz/89YoDXnp+vs972+XXtMCKa+kvSFEmTJd0jqatm+VRJqyUdLGmCpKckjern9d+SND9/fI2kDzS4/iskfWKA5zZKGlti235K0oeHWGdU3rYTJb0sb/OpDa5zlqSW/PHlki5vhvasp20k/ZWka/LH8yXdUsLPebykGfnjNkk/66fO0yT9oNG17e/PUNIcSXdIsqQ3SHqw5HpHSfqlpGOboT0lnSpphqQnapb9i6RL88eX9vf7I+lISU/n/x6RPz5iqP01fQ8kIn4aEf192vxsSTdHxG8j4hlJG5TNt/4S25b055JuzRd9XdJbi6y3n/2/XdJNjdpnAQaaw75hImJZZNMASNIDyiYhawb1tM3Zyo47KTsO35wfFw0TEc9FxMP54x3KplFob2QNw+hsSd+IzAOSXm57fIn1vFnSUxHx8xJreElE3Cvp+T6La4/Bgd4Dz5B0V0Q8HxH/K+kuSbOH2l/TB8ggBppbvdYYSf9X8+bT3zpFepOkzRGxfoDnQ9Iy26tsL2pgXbUuzk8FXDdA17aedm6kBcr+Au1Po9uznrZ5aZ38OOxRdlyWIj+F9jpJD/bz9J/aXm37DtvTGlrYPkP9DJvteJyvgf9AbIb2lKRXRMRz+eNfSnpFP+sktWtTDGVi+0eSXtnPU5dFxG2NrqceddZ8ngbvfZwSEZtsHyXpLttP5n9BNKROSV+W9Bllv7SfUXa6bcFw7r9e9bSn7csk7ZF04wCbKbw9q8z2YZK+I+mDEbG9z9MPKzsNszO/FvZ9Scc1ukZV6GeYX089S9LH+nm6Wdrz90RE2B62z240RYBExFsSXlbP3OrblHVxW/K//oZt/vWharbdIukcSScOso1N+b9bbH9P2SmRYf1lqbdtbX9V0g/6eaohc9jX0Z7vlfQXkt4c+UnbfrZReHv2UU/b9K7TnR8To5Udlw1l+yBl4XFjRHy37/O1gRIRS21/yfbYiGjowIB1/AwbcjzW6UxJD0fE5r5PNEt75jbbHh8Rz+Wn+7b0s84mZddtenUou+48qCqfwrpd0vz8LpcJytJ9Re0K+RvNcklvyxedL6lRPZq3SHoyIrr7e9L2obbbeh8ru1D8RH/rFqXPueN5A+y/9Dnsbc+W9HeSzoqIXw+wThntWU/b3K7suJOy4/DugQKwKPk1l2sl/TQi/nWAdV7Ze23G9snK3hsaGnR1/gxvl/Se/G6sN0jqqTk902gDnmFohvasUXsMDvQeeKekWbaPyE9lz8qXDa7Rdwkk3FUwT9n5uN9K2izpzprnLlN2F8w6SWfWLF8q6ej88URlwbJB0rclHdyguq+XdGGfZUdLWlpT1+r8a42yUzWNbtsbJD0u6bH8IBvft878+znK7tx5qqQ6Nyg7P/to/nVN3zrLas/+2kbSPyoLO0lqzY+7DflxOLGE9jtF2WnKx2racI6kC3uPUUkX5+22WtmNCn9WQp39/gz71GlJV+ft/bhq7sxscK2HKguE0TXLSm9PZYH2nKTd+fvmQmXX3P5L0npJP5J0ZL5ul6Sv1bx2QX6cbpD0vnr2x1AmAIAkVT6FBQAoEQECAEhCgAAAkhAgAIAkBAgAIElTfJAQaDTbe5XdBtrrrRGxsaRygEriNl6MSLZ3RsRhAzxnZb8bv2twWUClcAoLUDbIoLN5Pb6h7NPPx9j+iO2H8sEmP12z7mW2f2b7Pts32f5wvvwe53PW2B5re2P+eJSzOU16t3VBvvy0/DW3Opvv5MaaTy+fZPt/8sH4Vthus32v7ek1ddxn+7UNaySgD05hYaQ6xPsm+npG0t8qGw7n/Ih4wPas/PuTlX36+Xbbp0rapWzIkunKfn8elrRqiH0tVDbkxkm2D5Z0v+1l+XOvkzRN0i8k3S/pjbZXSLpF0jsi4iHbh0v6jbLhSN4r6YO2Xy2pNSJWH2hDAKkIEIxUv4mI2r/mOyX9PLI5JqRsLKBZkh7Jvz9MWaC0Sfpe5GNy2a5nXLBZkv7Edu+YbKPzbb0oaUXk46XlgdapbMj35yLiIWnfwHy2vy3p47Y/omzYiev39z8NDCcCBNhnV81jS/rniPhK7QruM3VpH3u077Rwa59t/XVE/N7gdLZPUzbGW6+9GuR3MiJ+bfsuZRMEvV2DjPQMNALXQID+3SlpQT6Hhmy353NU3CvprbYPyUeOnVvzmo3a96b+tj7b+kA+pLpsvzofbXYg6ySNt31Svn5bPhS8JH1N0hclPRTZzHFAaeiBAP2IiGW2p0j6SX5de6ekd0fEw7ZvUTbK6hZlQ7r3+rykbzmbSe8/a5Z/TdmpqYfzi+RbNcjUyhHxou13SPo324cou/7xFkk7I2KV7e2S/n2Y/qtAMm7jBQ6A7U8pe2P/fIP2d7SyiX6O5zZjlI1TWEBF2H6PsrnMLyM80AzogQAAktADAQAkIUAAAEkIEABAEgIEAJCEAAEAJPl/1VumISOaFmoAAAAASUVORK5CYII=\n",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
-            ]
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZUAAAEGCAYAAACtqQjWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3de3xdZZno8d+T+/1+aZu0TUrbNDug0JabAqJAWxDl5hkBR5iBY73POI5HmcPoeDlzwKPjIAPi8YKoHwfUERU9hRYRrQhY2gpC06ZJ25QmtEmbe9Lc854/3rWTnTRp0mTttfbl+X4++7P3XnvttZ7s7L2f/b7Pu94lxhiUUkopNyT4HYBSSqnYoUlFKaWUazSpKKWUco0mFaWUUq7RpKKUUso1SX4HEA5FRUWmoqLC7zCUUiqq7Nq164Qxpngh24jJpFJRUcHOnTv9DkMppaKKiBxe6Da0+0sppZRrNKkopZRyjSYVpZRSronJmopSSvlheHiYpqYmBgYG/A7ltNLS0igvLyc5Odn1bWtSUUoplzQ1NZGdnU1FRQUi4nc40zLG0NbWRlNTE5WVla5vX7u/lFLKJQMDAxQWFkZsQgEQEQoLC8PWmtKkopRSLorkhBIUzhg1qSjlkY6+Iba8etTvMKDuSehY8OEIvnv1+Ku8cvwVv8NQU2hSUcojm3+4k4/8aDetPT4WcYf74bH3wXP/7l8MLvnii1/k889/3u8wItJTTz1FVVUVK1eu5N577/V035pUlPJIU0c/ACOjPp4Y78R+MKPQWutfDC4YHB2koaOBg10HOTl80u9wIsro6Cgf/ehHefLJJ6mtreXRRx+ltta7/7cmFaXiSeveiesoPuvr/vb9jJgRxswY+zv2+x1ORNmxYwcrV65kxYoVpKSkcPPNN/PLX/7Ss/3rkGKl4kmwhTLYDd3NkFvubzzzVNs28ct7T9sezi0518dopveFX+2h9o1uV7cZWJLDv7yr5rTrNDc3s3Tp0vH75eXl/OlPf3I1jtPRlopS8aSlFhKSJm5Hqdr2WnJTcylMK5yUYJT/tKWiVDxp3Qsr3g4NT9tWy+oNfkc0L7VttQQKAiQlJEVsUpmtRREuZWVlHDlyZPx+U1MTZWVlnu1fWypKxYuBLuhuguVvgezFE/WVKBMs0gcKAwQKAxzsOkj/SL/fYUWM888/n/r6eg4dOsTQ0BCPPfYY7373uz3bv7ZUlIoXrfvsdWkNlASidgRYfUc9I2aEQKFtqYyZMera6yKyruKHpKQkHnjgATZu3Mjo6Ch33HEHNTXetZo0qSgVL1r32OuSanvZ8RyMjkBidH0NBLu7gkkluEyTyoRrrrmGa665xpd9a/eXUvGidS+kZEHuUttSGR2EjkN+R3XGattqyUnJoSyrjNKMUgrSCiK2rhKPNKkoFS9a99oWioi9hqjsAqttqyVQGEBEEBEChQFq26Pv74hVmlSUigfGQMse20IBKF4DSNQV64dGh6jvrCdQGBhfFigMcLDzIAMjkX0Ok3ihSUWpeNDbCv3tE0klJQMKKm2iiSL1HfWMjI2cklRGzSh1HXU+RqaCNKkoFQ+C3VzBbi9wRoBFV0tlT5tNgqFJpabQjmzSukpk0KSiVDwIJo+SiS9jSqqh/QAMR0+3UbBIX541Mb2MFusjiyYVpeJBay1kFkNW8cSykgCYMTtzcZSobaulurB60kmmRITqwmpNKo4jR47w9re/nUAgQE1NDV//+tc93b8mFaXiQWvt5K4vmGi1REkX2HRF+qBAQYADnQe0WI89+PHf/u3fqK2t5cUXX+TBBx/Uqe9DiUiCiPyriPyHiNzudzxKRZ2xMXs0fcmUL+PCsyAheeKgyAhX33lqkT6oprCGUTOq0+ADixcvZu3atQBkZ2dTXV1Nc3OzZ/v35VBaEXkYuBZoNcacHbJ8E/B1IBH4jjHmXuA6oBxoA5p8CFep6Nb1Ogz3ndpSSUyGotVR01IJdm/VFJw65Ugw0dS21fKm4jd5GteMnrwLjr3q7jYXnQNXz/1Mjo2Njfz5z3/mwgsvdDeO0/CrpfIIsCl0gYgkAg8CVwMB4BYRCQBVwPPGmE8CH/Y4TqWi33iRfpr5n0qjZwRYbVst2SnZlGefeg6YRZmLyE/N17pKiN7eXm666Sbuu+8+cnJyPNuvLy0VY8x2EamYsvgCoMEYcxBARB7DtlKOAEPOOqMzbVNENgObAZYtW+ZyxEpFseCxKMVVpz5WUg2v/hQGuiHNuy+e+dhzYg+BgsCkIn3Q+JH1kZRUzqBF4bbh4WFuuukm3ve+93HjjTd6uu9IqqmUYRNIUJOz7HFgo4j8B7B9picbY75ljFlvjFlfXFw802pKxZ/WvZC7bPqkESXF+vEifdGp9ZSgQKEt1g+ODnoYWeQxxnDnnXdSXV3NJz/5Sc/3H0lJZVrGmJPGmDuNMR83xjzodzxKLZTnZ4YPzvk1nSiZA+x0RfqgQGGAETPC/vb4Ltb/8Y9/5Ic//CG//e1vOffcczn33HPZsmWLZ/uPpDmvm4GlIffLnWVKqfkaHbbHocx0hsfcZXbm4ghvqZyuSB8UWqw/p/gcT+KKRJdccgnGeP7TZVwktVReAlaJSKWIpAA3A0/4HJNSrju1IhBGbQ0wNnzqcOKghAQ7uWSEt1ROV6QPWpy5mLzUPJ2x2Ge+JBUReRR4AagSkSYRudMYMwJ8DNgK7AV+YoyJjgH0SkWq6eb8mqqk2q7n46/b2QTPST9dkT4oIov1cciXpGKMucUYs9gYk2yMKTfGfNdZvsUYs9oYc5Yx5l/9iE2pcPP0q7t1L0iiPR5lJiUBONkGfce9i+sMDI8OU98x/ZH0UwUKAzR0NMR9sd5PkdT9pZRyW0stFK6EpNSZ1ykNjgCLzF/49Z31DI8NzzmpjJgR6jvqPYhMTUeTilIe87SmMt2cX1NF+LDi0HPSzya0WK/8oUlFqVg11AcdjTMX6YMyiyGjMGJP2FXbVkt2cjZLs5fOuu6SzCXkpuZqUvFRJA0pVioueFZTOV5n91Y6S1IRiegTdk033f1MRIRAgRbrKyoqyM7OJjExkaSkJHbu3OnZvrWlolSsGh/5NXu3ESUBOL7PzmgcQYZHh9nfsX9OXV9BgcIA9Z31DI0Ozb5yDHv22Wd5+eWXPU0ooElFKc95VlNp3QtJaZBfMfu6JdUw1AtdR2Zf10MNnQ1zLtIHBQoDjIxpsd4v2v2lVKxqrbWTSCYkzr5uScgIsPzl4Y3rDJxJkT4ouO6etj3UFM18BH64fXnHl9nXvs/Vba4pWMNnLvjMrOuJCBs2bEBE+OAHP8jmzZtdjeN0NKkoFata98KKt89t3ZI1znNqoerq8MV0hmrbaslKzppTkT6oLKuMnJScuK6rPPfcc5SVldHa2spVV13FmjVruOyyyzzZtyYVpWLRyXboOTr7cOKgtFzIXRpxxfpgkT5B5t5THylH1s+lRREuZWVlAJSUlHDDDTewY8cOz5KK1lSUikXjJ+aae7eRna4lcpLK8JhTpC84g7/BEc/F+r6+Pnp6esZvb9u2jbPPPnuWZ7lHWypKxaK5zPk1VUk1HHjWzmycmByeuM7Agc4DDI0NnVE9JWi8WN9ZT02hf3UVP7S0tHDDDTcAMDIywq233sqmTZtmeZZ7NKkoFYta99ourZwlc39OScDOaNx2YKLG4qP5FOmDQo+sj7eksmLFCl555RXf9q/dX0rFotZamyTmcMDguJLImgNsz4k9ZCVnsSznzE8PXp5VHvfFer9oUlEq1hgztzm/pipaDZIQMXWV+RTpg0SE6sJqTSo+0KSilMfCPk1Lz1EY6DqzIj1AchoUnBURLZWFFOmDAoUB6jvqGR4ddjGy2fl51sW5CmeMmlSUijVnMj3LVMETdvlsIUX6oEBhgOGxYeo7vTuyPi0tjba2tohOLMYY2traSEtLC8v2tVCvlMfCPk1LyzxGfgWV1sDeX8HQSUjJcDeuM7CQIn1Q8Hz2tW21C9rOmSgvL6epqYnjxyPzhGdBaWlplJfPfGrmhdCkolSsad0LWYsgo+DMn1tSDRg4UQdLznM9tLmqbaslMzlzXkX6oPLscrJTsj2tqyQnJ1NZWenZ/iKRdn8p5bGwd4zMp0gfFOwya/G3C6y2rZbqgvkV6YN0Gnx/aFJRKpaMjdrzqJTO89iM/EpITPW1rjI8Nkxde50rXVaBwgD7O/Z7XqyPZ5pUlPJYWGsqHY0w0j//lkpikp3Z2MdhxQc7Dy64SB8ULNY3dDa4EJmaC00qSsWS+UzPMpXPZ4F0o0gfpOes915UJBURyRSRnSJyrd+xKLVQYa2ptO4FBIoXMM1KSTX0vAH9Ha6FdSb2tO0hMzmT5TkLP6/L0uylZCd7W6yPd74kFRF5WERaReS1Kcs3iUidiDSIyF0hD30G+Im3USoVhVpr7ZkeUzLnv41gPcan1sretr2sKVizoCJ9kB5Z7z2/WiqPAJOmzRSRROBB4GogANwiIgERuQqoBVq9DlKpcAhrTaWldn4HPYYKdp35UKwfGRuhrsOdIn3QeLF+TIv1XvAlqRhjtgPtUxZfADQYYw4aY4aAx4DrgMuBi4BbgQ+ITP/zRUQ2O11kOyP9wCOlwmJkENoaFlZPAcgpg9QcX1oqBzoPMDg66HpSGRob4kDnAde2qWYWSTWVMuBIyP0moMwYc7cx5hPAfwLfNsaMTfdkY8y3jDHrjTHri4uLPQhXqfkJW03lRD2Y0YUnFRG7DR+OVXGzSB+kxXpvRVJSOS1jzCPGmF/7HYdSESvYspjvMSqhSgK2+8vjOaxq22rJSMqgIqfCtW0uzV5KVnKWJhWPRFJSaQaWhtwvd5YpFVPCVlNp3QMJyXam4YUqCcBAJ/QcW/i2zkBte61rRfqgBEnQYr2HIimpvASsEpFKEUkBbgae8DkmpVwXtt/+rXuhaBUkpSx8Wz4U60fGRtjfvj8skz8GCgLUtddpsd4Dfg0pfhR4AagSkSYRudMYMwJ8DNgK7AV+YozZ40d8SkWlVhdGfgX5cBbIg10HGRgdoKbI/dP/Bov1BzsPur5tNZkvsxQbY26ZYfkWYIvH4SgV/QZ7oPN1WHu7O9vLLISsUk9HgO05YX9DhqWlElKsryqocn37akIkdX8ppeardZ+9dqulAp6fsCscRfqgZTnLyEzOZE+bdn6EmyYVpTwWlrMCujHn11QlAZusxqYdxe+6cBTpgxIkgeqCava2+TenWbzQpKJULGjdC8mZkLfw+bLGlVTbGY87Drm3zRmEs0gfFCgMUNdRx8jYSNj2oTSpKBUbWvdAyRpIcPEjXeLdHGDBIn24k8rg6KAeWR9mmlSUigWte93t+gJ7XpXgtsMseAxJTaH7I7+C9Mh6b2hSUcpjrpdUeo9D33F3i/QAqVm2O82DYn1tWy3pSemuTHc/k+U5y8lMztSkEmaaVJSKdsedloTbSSW4TY9aKtUF1SQmJIZtHwmSwJqCNdS2a1IJJ00qSkW74MSP4UgqpQFoq4eRIfe37RgZG3HtnPSzCRQG2N++X4v1YaRJRalo11oL6QWQVeL+tksCMDZiE0uYHOo6FPYifVCgMMDA6AAHu/TI+nDRpKJUtGvda7/8JQxTVY7PARa+LrBwTHc/Ey3Wh58mFaWimTH2C780TF/IhasgISmsxfpgkT4cR9JPVZFTQUZShiaVMNKkolQ06zoCQz3uDycOSkqxiSWMJ+yqbbNH0oezSB80XqzXpBI2mlSUimatYRz5FRTGOcBGx0ZdPyf9bAKFdhp8LdaHhyYVpTzm6nEqwS/74jUubnSKkgB0HobBXtc3fajrEP0j/Z4nlYHRAQ51hX/6mXikSUWpaNa6F3LKIT0vfPsIdq0dr3N908FjRgIF3iWV4FH72gUWHppUlIpmLbXhq6cEBQcBtLo/bXywSF+ZW+n6tmeyPGc56UnpmlTCRJOKUh4zbp1QeHQETtSFP6nkVUBSeliGFXtZpA9KTEikukDPWR8umlSU8ojrR5G0H4TRofAW6cHOfFyyxvVi/ejYKPva93laTwkKToM/Ojbq+b5jnSYVpTzi+qm5gl/y4TpGJVQY5gBr7G70vEgfFCgM0D/Sr8X6MNCkolS0aq0FSYCi1eHfV0kAelugr821TQZP7etlkT5o/Mh6nVzSdZpUlPKYa0OKW2uhYAUkp7u0wdMYn67FvS9hP4r0QRU5FVqsDxNNKkp5xPWaSjhOzDWTYN3GxS6w2rZaqvKrPC3SByUmJOqR9WES8UlFRK4XkW+LyI9FZIPf8Sg1X67WVIb7baG+JHxnSpwkexGk5bnWUvGzSB8UKAywr32fFutd5ktSEZGHRaRVRF6bsnyTiNSJSIOI3AVgjPmFMeYDwIeA9/oRr1IR53gdmDHvWioiUFrjWlLxs0gfFCzWN3Y3+hZDLPKrpfIIsCl0gYgkAg8CVwMB4BYRCX3H/bPzuFJRzZUWixdzfk1VUm3360JR6MWjLwLeTHc/k+AAgV0tu3yLIRb5klSMMduB9imLLwAajDEHjTFDwGPAdWJ9GXjSGLPb61iVikittZCYagv1XimphsFu6G6e9ybe6H2Df/zdP3LvjntZmbfSlyJ9UGVuJcuyl/G/XvxffP75z9PW797ItngWSTWVMuBIyP0mZ9nHgSuB94jIh2Z6sohsFpGdIrLz+PHj4Y1UKb+17oXi1ZCY5N0+F1Cs7x/p56GXH+Ldv3g325u285FzP8Kj73yUpAQP458iMSGRx659jNsCt/HLhl/yrp+/ix/s+QHDo8O+xRQLIimpTMsYc78xZp0x5kPGmG+eZr1vGWPWG2PWFxcXexmiUt5rrfW26wsm6jctc58DzBjD1satXPeL6/jGK9/g7UvfzhPXP8GH3/xh0pLSwhTo3GWnZPOp8z/F49c9zptL3sxXdn6FG5+4keean/M7tKg1a1IRkUQR2edBLM3A0pD75c4ypWKKWWhNor/TdkF5VaQPSs+H7CVzbqnUtddxx9Y7+NTvP0VOSg7f2/g9vvK2r7A4a3GYAz1zlbmVPHTlQzx4hS3bfvg3H+ajz3yUw92HfY4s+sza9jTGjDojspYZY14PYywvAatEpBKbTG4Gbg3j/pSKTsed33heDScONYcTdnUOdPLAyw/w0/0/JSclh89e9FluWnWTL8ejnKnLyi/j4sUX85/7/pOHXnmI6395Pe+vfj+b37SZrJQsv8OLCnPt0MwH9ojIDqAvuNAY8+757FREHgUuB4pEpAn4F2PMd0XkY8BWIBF42Bjj/lzbSkW7YPeT1y2V4D53PAdjozAlSYyMjfDT/T/lgT8/QN9wHzdX3cxHzv0Iuam53se5AMmJydxeczvvXPFO7t99P4/seYQnDjzB36/9e65beR0JEvFVA1/NNal81s2dGmNumWH5FmCLm/tSKtIseEBu615IyYbccjfCOTOlNTA6aA+8LFo1vnjH0R3c+9K91HfUc+HiC/nM+Z9hVf6q02wo8hWlF/HFt36R91a9l3t23MPnnv8cP677MXddcBfnlpzrd3gRa04p1xjze6ARSHZuvwTo8F6lzoBr07QEp2cR1yd+md2UOcCae5v55O8+yZ3b7uTk8Enuu/w+vn3Vt6M+oYSqKarhh1f/kHsuvYfjJ4/z/iffzz/94Z9o6WvxO7SINKeWioh8ANgMFABnYYf6fhO4InyhKRVbXDno0Rj7hR6YV8/zwhVVAUL/sVd5eKiJ7732PRIkgY+f93Fur7md1MRUf+IKMxHh2hXX8o6l7+A7r36H7+/5Ps+8/gwfOOcD3FZzW8z+3fMx1+6vj2IPTvwTgDGmXkRKwhaVUmp6vS3Q3+79cGJHfV8zTy1exi+bHqflyDBXV17NJ9d9kkWZi3yJx2sZyRn83dq/44ZVN/C1nV/j/j/fz8/qf8YNK29gU+Umlucs9ztE3801qQwaY4bEaW6LSBJhOOeQUvFgQSOKgyOvPCzSH+o6xFONT7H10FYOdB0gIQ0uGB7hy9c+wrrSdZ7FEUmWZi/l39/+77x49EUeevkhHnj5AR54+QGqC6rZWLGRjRUbKc/2oeYVAeaaVH4vIv8TSBeRq4CPAL8KX1hKxR5XKiAezfl1pOcIWxu38tShp6jrqEMQ1pau5e41d3PlkT0UPf8AFPgwpDnCXLT4Ii5afBHH+o6xrXEbWxu3ct/u+7hv932cU3TOeIKJl5YczD2p3AXcCbwKfBA7Qus74QpKqVi04Kb98AAceBYySyCzyI2QJjnWd2w8kbzWZicQf1Pxm/j0+Z9mw/INlGaW2hVHHrczJB98Fqqudj2OaLQocxG31dzGbTW30dzbPP46fnXnV/nqzq9yXsl5bKzYyIblGyjOiO0ZP2QuR/eKyBXA88aY/vCHtHDr1683O3fu9DsMpSa5+J5nONo1wG8++TZWlpzBgXTGwL5fw9a7ofMwvPUTcNUXXInp+MnjbDu8jacOPcXLx18G7MzBmyo2sbFiI0uylpz6pN7j8H8vg5434M23wJWft+dbUac43H3YJpjGp6jvqEcQ1i9az8blG7ly+ZUUphf6HeIkIrLLGLN+QduYY1L5PnAxdmbhPwDbgeeMMR0L2Xm4aFJRkWgiqVzGypLsuT2pdS88+Rk49Hsoroar74UVly8ojrb+Np55/RmeanyKncd2YjCsyl/FpopNbKrYxLKcZbNvZLAHtn8VXvwGJKbAZZ+Ciz4CSToKaiYHOg+wtXErTx56ksbuRhIlkfMXnc+mik1csewK8tLy/A7Ru6QSssMlwHuATwFLjDH+TTF6GppUVCR6yz3P8MZck0p/Bzx7D7z0HUjNhrffDevvmNesxC19Lexq2TV+OdB1ALDnab+68mo2VWxiRd48p9BvOwDb/hnqtkB+JWz837ZLzI9jaKKEMYb9Hft5qvEpnjr0FE29TQjC6vzVrCtdx9rStawrXUdRuvtdnLPxsqXy18ClwDnACeA54A/GmBcWsvNw0aSiItGcWipjo7Dre/Dbf4WBTlj3tzahZM6tm8QYw5GeI5OSSFNvEwCZyZmcV3Ie60rXcWnZpazOX4249eXf8Bt46n/CiTo46x2w6V4ornJn2zHMGENtWy3bm7azq3UXr7S+wsDoAGCT/rrSdeOXabsiXeZGUpnrz577gAPYAx6fNcY0LmSnSqlpND5nu7paXoPll9iurkXnnPYpY2aMhs4GdrfsHk8ix/vt+YTyU/NZW7qWW6tvZV3pOqryq8I3qePKK+HDb4Md34bf3QsPvQUu2Axv+wyk+9+tE6lEhJqiGmqK7Ei64dFhattrx/+f2xq38bP6nwF2MEBokqnMqXTvR4GL5tz9JSI1wGXAJcAqoM4Y8/4wxjZv2lJRkSjYUnn6Hy5jVWlIS6XzCDz9Wdjzc8hdChu+BIHrp+1CGh4bpq69jl0tu9jZspPdLbvpHuoGoCSjhPWl61lXuo71peupzPXpS6fvBPz2S7Dr+5BRAO/4LKy97ZQJKNXsRsdGaehsmNTybBuwZ6gsSCtgbcna8SSzOn/1gn80eNZSEZEcYBmwHKgAcoGxhexYqXhzytf70El4/n547j57//J/grf8HaRkANA71EtdRx372vdR126vGzobGB6zZyZclr2MK5ZdMf6lUpZVFhm/XDOL4F1ftzWgJz8Dv/4E7HwYrv4yLH+L39FFlcSERKoKqqgqqOLW6lsxxnC4+zC7Wydapr95/TcApCWmsSp/FVUFVazJX0NVQRWr81eTkZzhacxzran8BVtHeQ7YboxpCndgC6EtFRWJxlsqn7iUVW3PwLbPQtcRTOB6Wi79e/aNdE9KIMFaCNiurDUFa1hTsIZAYYB1peui43gHY2DP47Dtc9DdBGffBFd90Z8ZlmPUsb5j7GzZSW1b7fh7J9h6FYTlOcttoilYQ1W+vS5KL5r2B4gfo7+yAIwxvQvZabhpUlGR6OJ7niGney9fWfE4h7v2si9vCXXFlezrP0bXYNf4estzlo9/+INfBsXpxZHRCpmvoZPwx/vgj18HBC75B3jr30Fyut+RxRxjDMf6jrGvfR/7OiZ+pDT3TpxItyCtYOL95bRqlucsJzkx2bPRX2cDP8TOUizAceB2Y8xrC9l5uGhSUX7rGeqhsauRQ92HaGzbR+MbO9hzvIHjySMMO8khNTGVVXmrxhPHmoI1rMpfRWZyps/Rh1HHYXj6c1D7C8haBOe8B2puhLK1Ogw5zHqGetjfsX/G7tTUxFR2vX+XZ0nleeBuY8yzzv3Lgf9tjInIDlJNKsoLI2MjvNH7Bo3djRzqOsShrkM0djfS2NU4XkwFSDSG8pERFg0nMDCwmHdccjtvW/VWlucsJykhIg/1Cr9Df4AXHoCGZ2BsGPKWQ80NcPaNsOhNmmA8Mjw2zKGuQ+NJ5tMXfNqzpPKKMebNsy2LFJpUlFtGx0ZpPdlKU28TTT1NHO4+PJ48Xu95nZGxkfF181JzqUzOpaK/j4q2w1QM9lORksfS1e8m+Zz/xsU/7OJo9yDb/uEyVpfO8Yj6WNffAfv+H7z2OBz8HZhRKFxpWy9n3+jPKZPjmJfHqRwUkc9iu8AA/ho4uJAdKxUJjDF0DHbQ3NNMc28zTb1N9rrHXh/tOzopcSQlJLEsexkVORVcvvRyKrLKqew+TsXhP5G3/zcw1AuZxRC40X4xLrsYEpwTrMozzj79+EsjVHo+nPfX9tLXBnufsIX9P3wVtv8fOzXN2c5rWbTS72jVHMw1qdwBfAF4HDvZ6h+cZUpFNGMM3UPdHOs7xhu9b9DcO5E8mnqaeKP3DU6OnJz0nIK0AsqyyqgprGHD8g2UZZdRllVGeVY5S7KWkGSM/VX92uOw799hsMt+OZ59ox3dtPySaadT0Q6dWWQWwvq/tZeeFptgXnscnv1Xe1l0zkQLJr/C72jVDE6bVEQkDfgQsBI77f0/GmOGvQhMqbnoGerhWN8xWk62cKzv2LS3+0cmT66dnpROeXY55dnlXLT4IsqybNIoy7aJY9px/cP98PqL8Luv2i+7/g5IzYE119ovuRWXQ2LyaWPVBsoZyC6FCz5gL13NtrD/2uPwzBfsZcla+7qveaedc0xrMBFjtpbK94FhbMvkajEqLo8AABbQSURBVKAa+ES4g1JqzIzROdjJ8ZPHOd5/nNaTrdMmjL7hvknPS5AEitKLWJSxiFX5q7i0/FJKM0pZlLmIJZlLKMsuIz81f/bhuQPdcGQHHP4jHH4e3tgNo0OQnGknTDz7RjjrCkhOC+OroADILYOLP2ovHYftzAN7HrcTWW77Z8heAssvtgdWLn8rFFVNdDkqz82WVALGmHMAROS7wI7wh6Ri2ejYKB2DHePJYur1if4TtJ5spa2/jREzMum5glCYXsiijEWsyF3BxUsuZlHGIhZlLqI0s5RFGYsoyigiOeH0LYZp9bXB68/D4RdsIjn2F3siKkmEJefBhR+0X1iVbxs/4n2+jLZZ5i9/OVzyCXtpO2BPFBb8n71m58givcAmmGVOoln0pnnN7qzmZ7ZXeryryxgz4sfBVyKSCXwDGAJ+Z4z5kedBqNMaM2N0D3bTNtBGW38b7QPtk2/3t9Ha38qJkydoG2hj1Iyeso281DyK0osoySihMreS4vRiijOKJ12XZpSSPEsX05x1NcPrL0y0RI7vs8uT0qBsPVz6KfuFVH4+pJ7BCbVOQztoXFZ4lr2c/9/t6IeORvu/PPy8/b/u+7VdLyULll7otGTeYrvOtIUZNrMllTeLSLdzW7DnqO92bhtjTM58dioiDwPXAq3GmLNDlm8Cvg4kAt8xxtwL3Aj8lzHmVyLyY0CTigcGRwfpGOigY6Bj2iTRNjBxu2Og45RWBUCiJJKflk9hWiFFGUVU5VdRlF5EcUYxJeklFGUUUZxeTFF6ESmJKeH7Y8ZGof2grYkEv3A6D9vHUrJh2YXwpr+yLZEl54XtRFPaPgkjESiotJfz3meXdR91Wp/O5bdfsssTU6F8/URrpmytHWihXHHapGKMCde0oo8ADwA/CC4QkUTgQeAqoAl4SUSeAMqxgwQATv2Jq2YVbEl0DNok0THYQedA58R9Z1nHQAedg510DHScMiIqKDUxlcK0wvFuqEBhYPx+QVoBhWnOdXohuam5JIjHfdtDJ6G11nZfHXsVjr0GLXsgWHsJdo1c+CHbD196jnaNxKqcxXY03tk32fsn253WqZNk/vA1e1wMQO4yO7os9JK3TAcAzIMvnyZjzHYRqZiy+AKgwRhzEEBEHgOuwyaYcuBlYMZvKBHZDGwGWLZsDqdDjVKDo4N0DnTSOdhJ91A3nYP2dtdgF12DXeP3uwcnHusc7GTMTD+pdHpSOvmp+eSn5ZOXlseK3BXkpeVRkFZAXmoe+an5FKYX2mSRXkBGUkbkzEHV2xqSPJxLW4OthYAdnbXoHFj7fig923ZlFa32vYirx6n4JKPAjhZb8057f7AHml6Co69MvH/qtjDepkzNdRLM2ROJpniNnjJ5FpH0E60MOBJyvwm4ELgfeEBE3gn8aqYnG2O+BXwL7BH1YYxzwcbMGH3DfXQPddM12EX3UDfdg92T7wdvD05OHMGzwk0nNTGV3NRc8lLzyEvN46y8s2xiSMsnP9UmjYLUgklJIy0pCvqWg91XUxNIb8vEOsFfmjU3RuwvzciJRAH2NM1nvcNegob6oHXv5PfZ7h/AsNNyT0iyiSW0RVN6tk1YCoispDItY0wf8Ld+xzHV8Ogw3UPd9Az12Mtwz8TtoZ5JiSJ4u2uoa/w5M7UcwB61nZOSM54gFmcuZk3BGpss0vLISckZTxy5qbnj60VFgjid/g440QBt9XCifuK6/aAdzgvOh7raDucd/2CfHRV94hH9S0dZKZm23lIeMlPJ2Ci0H5r8o+bAs/DKoxPrZBZD4Sp71H/hKihaZa/zK+KuezWS/tpmYGnI/XJnmevGzBi9w730DfXRM9xD71AvvcO99AxNvj1TwugZ6jltiwFskTqYGHJScshNy2VpztJJy3JScshJzTllWXpSeuR0MbltdMSO0pmUOBrgxH44eWJivYQke1Bb0SpYtWHi12FxlXY/KG8lJNpkUbTSHp8U1HscWpy6XfD9vG/LDO/j1acmnMxC7/8WD0RSUnkJWCUildhkcjNw63w21HKyhS+88AV6h3rHk0bfcJ9NGsO9pxwwN50kSSI7JXvSpSSjhJyUnFOWjy9LnlgW04lhNiND0HXEjrDqOAwdhyZaIO2H7Ky0QRlF9kNWdfXEh61otT0ewa3hwxFGayoxIqsYsqZ0n8GUFvd+58dTAzQ8PdHiBtu6Hk8yZ9lWTV6Ffe9nFEZU1+2Z8CWpiMijwOVAkYg0Af9ijPmuiHwM2IodUvywMWbPfLbf3t/Ob1//Ldkp2WQlZ5GVkkVRehFZyVl2WUqWXe48lp3sLAtZHtdJYTZjY9B7zCaM8cTROHG7542JYjlAYgoUrLDJYs07Qz5IK+OqL1rfTXEiPR+Wnm8voUZHoOt1m2RCW+kNv4GXpxwpkZxpk0vecnudXzFxO2+5a8dOhYNfo79umWH5FmDLQrdfXVjN79/7+4VuJn6NjdoieFezPQVs5+s2aQSTSOcRGB0MeYJA9mL7hq+4ZPKHIW855CyxXQhxThsocS4xyf64KlgBqzdOfmyw59TPWfD60PaJIfFBGYWTP2P5FZC3FHLK7ectbV6HELoikrq/lBfGxmyfb1cTdDdPJI6uZuh+wy7rOQpjUw5mTM+3b97SGqi6xnkzV0y8mbXOMWc6TYs6RWq2/WyV1pz6mDFwss1JMo2Tk87RV2Dvryd3KYMdTp9TZudNy1lik01umV0WXJ4SnjOMalKJJcMDtoXR2wI9x5zLG07CaLaJpOfo5H5dsEcY5yyB3HJ7VHnwzZfr/OrJWwZpuf78TTFEu7/UvIhAZpG9lK879fGxUfuDMPhDcfzHovOZP/oX6Gs99XlpeROf8WCicYEmlWgw1DeRJHqP2XNNTLp2LgOdpz43IdkeWZxTDksvOPVXS255VBcFlYp7CYm2tyBv6czrjAxO9ESEJqBgT0XzLtsacoEmFb8M9tpfD30n7JHhk24ft5feFps4hnpOfX5iCmSV2kvhSlvLyFpkz0ORtQiynUtGke9HkCtLO72Ub5JSJ+ZGm8lwP3xhYTNwgyYV94wO20x/ss0mh5MnZkgYzu3h6efWIi0XMkvswVSlZ8PKK23iyF7kXC+2t9PztXURpXRIsYpIyemubEaTynSMsaMxTp6wk9D1nXAShnPd13bq/cGu6bclCba1kFVi+0QLVkzcziyZfDuzGJLCOFuv8pX+BFDxIPaTysigTQz97fagpGlvd566fOpoiqDEFJskMgrtEbF5yybfzyicuJ9VYmfF1e4npVSciM2kcnwffK3GJomZupnAjnrKKLBf/On59oC84O1MJzGMJ4kCuywlS7ud1Lxor5eKB7GZVBJToPIyJ2Hk20to8gjeTk7XBKGUUi6KzaRSsAJueMjvKJSaRH++qHignf1KeUS7v1Q80KSilFLKNZpUlPKYHqeiYpkmFaU8ojUVFQ80qSjlEW2gqHigSUUppZRrNKko5TE9n4qKZZpUlPKI1lRUPNCkopRHtH2i4oEmFaU8pkOKVSzTpKKUR7T7S8UDTSpKKaVcExUTSorI9cA7gRzgu8aYbT6HpNQZ014vFQ/C3lIRkYdFpFVEXpuyfJOI1IlIg4jcdbptGGN+YYz5APAh4L3hjFepcNPkomKZFy2VR4AHgB8EF4hIIvAgcBXQBLwkIk8AicA9U55/hzGm1bn9z87zlIo6WlNR8SDsScUYs11EKqYsvgBoMMYcBBCRx4DrjDH3ANdO3YaICHAv8KQxZvd0+xGRzcBmgGXLlrkWv1JKqbnzq1BfBhwJud/kLJvJx4ErgfeIyIemW8EY8y1jzHpjzPri4mL3IlXKJdrtpeJBVBTqjTH3A/f7HYdSbjB6oIqKYX61VJqBpSH3y51lSsUsramoeOBXUnkJWCUilSKSAtwMPOFTLEoppVzixZDiR4EXgCoRaRKRO40xI8DHgK3AXuAnxpg94Y5FKT9pp5eKB16M/rplhuVbgC3h3r9SkUaTi4plOk2LUh7RmoqKB5pUlPKItlBUPNCkopTHdESximWaVJTyiHZ/qXigSUUppZRrNKko5RHt9VLxQJOKUp7T9KJilyYVpTyiNRUVDzSpKKWUco0mFaU8op1eKh5oUlHKY3qcioplmlSU8ojWVFQ80KSilFLKNZpUlPKI9nqpeKBJRSmPaXJRsUyTilIe0ZqKigeaVJRSSrlGk4pSHtFuLxUPNKko5TE9TkXFMk0qSnlEayoqHmhSUUop5RpNKkp5zGj/l4phmlSUUkq5JiqSiohkishOEbnW71iUUkrNLKxJRUQeFpFWEXltyvJNIlInIg0ictccNvUZ4CfhiVIppZRbksK8/UeAB4AfBBeISCLwIHAV0AS8JCJPAInAPVOefwfwZqAWSAtzrEp5QisqKpaFNakYY7aLSMWUxRcADcaYgwAi8hhwnTHmHuCU7i0RuRzIBAJAv4hsMcaMTbPeZmAzwLJly1z8K5RSSs1VuFsq0ykDjoTcbwIunGllY8zdACLyN8CJ6RKKs963gG8BrF+/Xn8MKqWUD/xIKvNijHnE7xiUWgj9paPigR+jv5qBpSH3y51lSsUFPUxFxTI/kspLwCoRqRSRFOBm4Akf4lDKUzpNi4oH4R5S/CjwAlAlIk0icqcxZgT4GLAV2Av8xBizJ5xxKKWU8ka4R3/dMsPyLcCWcO5bqUijvV4qHkTFEfVKxRKj6UXFME0qSnlEayoqHmhSUUop5RpNKkp5TXu/VAzTpKKUUso1mlSUUkq5RpOKUkop12hSUcpjWlJRsUyTilJKKddoUlFKKeUaTSpKKaVco0lFKY/p1PcqlmlSUUop5RpNKkoppVyjSUUppZRrNKko5TGd+l7FMk0qSimlXKNJRSmllGs0qSjlMR1SrGKZmBh8h4tID1DndxxzUASc8DuIOYiGOKMhRtA43aZxuqvKGJO9kA0kuRVJhKkzxqz3O4jZiMhOjdMd0RAjaJxu0zjdJSI7F7oN7f5SSinlGk0qSimlXBOrSeVbfgcwRxqne6IhRtA43aZxumvBccZkoV4ppZQ/YrWlopRSygeaVJRSSrkmapOKiPw3EdkjImMisn7KY/8kIg0iUiciG2d4fqWI/MlZ78cikuJBzD8WkZedS6OIvDzDeo0i8qqz3oKH+M0jzs+LSHNIrNfMsN4m5zVuEJG7PI7xKyKyT0T+IiI/F5G8Gdbz5bWc7bURkVTn/dDgvA8rvIotJIalIvKsiNQ6n6W/n2ady0WkK+S98Dmv43TiOO3/Uaz7ndfzLyKy1ocYq0Jep5dFpFtEPjFlHV9eTxF5WERaReS1kGUFIvK0iNQ71/kzPPd2Z516Ebl91p0ZY6LyAlQDVcDvgPUhywPAK0AqUAkcABKnef5PgJud298EPuxx/P8GfG6GxxqBIh9f288Dn5plnUTntV0BpDivecDDGDcASc7tLwNfjpTXci6vDfAR4JvO7ZuBH/vwf14MrHVuZwP7p4nzcuDXXsd2pv9H4BrgSUCAi4A/+RxvInAMWB4JrydwGbAWeC1k2f8B7nJu3zXdZwgoAA461/nO7fzT7StqWyrGmL3GmOmOmr8OeMwYM2iMOQQ0ABeEriAiArwD+C9n0feB68MZ7zT7/yvgUa/2GQYXAA3GmIPGmCHgMexr7wljzDZjzIhz90Wg3Kt9z8FcXpvrsO87sO/DK5z3hWeMMUeNMbud2z3AXqDMyxhcdB3wA2O9COSJyGIf47kCOGCMOexjDOOMMduB9imLQ9+DM30HbgSeNsa0G2M6gKeBTafbV9QmldMoA46E3G/i1A9KIdAZ8qU03TrhdCnQYoypn+FxA2wTkV0istnDuEJ9zOlGeHiGZvFcXmev3IH9lTodP17Lubw24+s478Mu7PvSF07323nAn6Z5+GIReUVEnhSRGk8DmzDb/zGS3o9gW58z/WiMhNcToNQYc9S5fQwonWadM35dI3qaFhH5DbBomofuNsb80ut45mKOMd/C6VsplxhjmkWkBHhaRPY5vzQ8iRN4CPgS9oP8JWxX3R1u7n8u5vJaisjdwAjwoxk2E/bXMtqJSBbwM+ATxpjuKQ/vxnbh9Dq1tV8Aq7yOkSj6Pzr12XcD/zTNw5Hyek5ijDEi4srxJRGdVIwxV87jac3A0pD75c6yUG3Y5nGS8ytxunXmZbaYRSQJuBFYd5ptNDvXrSLyc2x3iqsfoLm+tiLybeDX0zw0l9d5QebwWv4NcC1whXE6gKfZRthfy2nM5bUJrtPkvCdyse9LT4lIMjah/MgY8/jUx0OTjDFmi4h8Q0SKjDGeTo44h/9j2N+PZ+BqYLcxpmXqA5HyejpaRGSxMeao01XYOs06zdg6UFA5to49o1js/noCuNkZXVOJ/RWwI3QF5wvoWeA9zqLbAa9aPlcC+4wxTdM9KCKZIpIdvI0tSL823brhMqUv+oYZ9v8SsErsKLoUbHP/CS/iAzu6Cvg08G5jzMkZ1vHrtZzLa/ME9n0H9n3425kSY7g4NZzvAnuNMV+bYZ1FwVqPiFyA/c7wNPnN8f/4BHCbMwrsIqArpGvHazP2RETC6xki9D0403fgVmCDiOQ73eAbnGUz83oUglsX7JddEzAItABbQx67Gzv6pg64OmT5FmCJc3sFNtk0AD8FUj2K+xHgQ1OWLQG2hMT1inPZg+3q8fq1/SHwKvAX5423eGqczv1rsCOGDngdp/N/OwK87Fy+OTVGP1/L6V4b4IvYJAiQ5rzvGpz34Qof/s+XYLs4/xLyOl4DfCj4HgU+5rx2r2AHRLzFhzin/T9OiVOAB53X+1VCRoR6HGsmNknkhizz/fXEJrmjwLDzvXkntob3DFAP/AYocNZdD3wn5Ll3OO/TBuBvZ9uXTtOilFLKNbHY/aWUUsonmlSUUkq5RpOKUkop12hSUUop5RpNKkoppVwT0Qc/KuUlERnFDkcNut4Y0+hTOEpFJR1SrJRDRHqNMVkzPCbYz8uYx2EpFVW0+0upGYhIhdhzovwAewT3UhH5HyLykjPZ5hdC1r1bRPaLyHMi8qiIfMpZ/jtxzvcjIkUi0ujcThR7Tpjgtj7oLL/cec5/iT1fzI9CjsA+X0SedyYj3CEi2SKyXUTODYnjORF5s2cvklJTaPeXUhPSZeLEaYeAf8BO83O7MeZFEdng3L8AewT3EyJyGdCHnYrlXOxnajewa5Z93YmdSuR8EUkF/igi25zHzgNqgDeAPwJvFZEdwI+B9xpjXhKRHKAfO83K3wCfEJHVQJox5pWFvhBKzZcmFaUm9BtjQn/1VwCHjT0/B9h5jzYAf3buZ2GTTDbwc+PMQSYic5kDbQPwJhEJzj+X62xrCNhhnLnhnCRXgZ0a/6gx5iWYmJhQRH4KfFZE/gd2Oo1HzvSPVspNmlSUOr2+kNsC3GOM+b+hK8iUU8ZOMcJEN3PalG193BgzaXI+EbkcO59d0Cin+ZwaY06KyNPYEy79FaeZ/VopL2hNRam52wrc4Zx/BBEpc87vsR24XkTSndl03xXynEYmvujfM2VbH3amnkdEVjsz8M6kDlgsIuc762c7U+YDfAe4H3jJ2LPzKeUbbakoNUfGmG0iUg284NTOe4G/NsbsFpEfY2eebcVOfR/0VeAnYs9W+P9Cln8H26212ynEH+c0p7Q2xgyJyHuB/xCRdGw95Uqg1xizS0S6ge+59KcqNW86pFgpl4nI57Ff9l/1aH9LsCdOWqNDnpXftPtLqSgmIrdhzyt/tyYUFQm0paKUUso12lJRSinlGk0qSimlXKNJRSmllGs0qSillHKNJhWllFKu+f+iaqRtOBkYAAAAAABJRU5ErkJggg==\n"
           },
           "metadata": {
             "needs_background": "light"


### PR DESCRIPTION
[This draft PR replaces issue #4]
Now that we found a good path to using Bifrost on Google colab (ledatelescope/bifrost#158), Jayce suggested (March 2022) updating the tutorials to work well on Colab. I'd like to take that on. There are some [instructions here](https://colab.research.google.com/github/googlecolab/colabtools/blob/main/notebooks/colab-github-demo.ipynb#scrollTo=8QAWNjizy_3O) about interfacing colab with github, and there's even an "open in colab" badge that would be great to put at the top of the README:

![](https://colab.research.google.com/assets/colab-badge.svg)
